### PR TITLE
Add SingNER dataset-driven pytest coverage and refresh existing tests

### DIFF
--- a/src/tests/data/download_singner_sample.py
+++ b/src/tests/data/download_singner_sample.py
@@ -1,0 +1,33 @@
+"""Download a deterministic 5,000-row sample from NHLOCAL/SingNER."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from datasets import load_dataset
+
+
+OUTPUT_PATH = Path(__file__).with_name("singner_sample_5000.jsonl")
+SAMPLE_SIZE = 5000
+
+
+def main() -> None:
+    dataset = load_dataset("NHLOCAL/SingNER", split="train")
+    sample = dataset.select(range(SAMPLE_SIZE))
+
+    with OUTPUT_PATH.open("w", encoding="utf-8") as output_file:
+        for row in sample:
+            output_file.write(
+                json.dumps(
+                    {"text": row["text"], "entities": row["entities"]},
+                    ensure_ascii=False,
+                )
+                + "\n"
+            )
+
+    print(f"Saved {len(sample)} rows to {OUTPUT_PATH}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/tests/data/singner_sample_5000.jsonl
+++ b/src/tests/data/singner_sample_5000.jsonl
@@ -1,0 +1,5000 @@
+{"text": "מרום שטיינברג אילי מנצל רון קירשנבוים - עברתי בחושך (קולולחן)", "entities": [{"start": 24, "end": 37, "label": "SINGER"}, {"start": 0, "end": 13, "label": "SINGER"}, {"start": 14, "end": 23, "label": "SINGER"}]}
+{"text": "אורה וולדפוגל משחרר את - אבא מתוך אלבום שישי - אמר אביי", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "דני לוי תקציר אלבום שישי - אמר אביי", "entities": [{"start": 0, "end": 7, "label": "SINGER"}]}
+{"text": "יועד קצנלבוגן חוזר - ישראל ואורייתא", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "אריאל קבלרצ'יק עם תזמורת נשמע במחרוזת סעודה", "entities": [{"start": 0, "end": 14, "label": "SINGER"}]}
+{"text": "הדף היומי מסכת בבא בתרא דף י''ד תמוז תשפ''ד - שיעור בעברית מאת הרב יהודה ברנדויין הי''ו מקול חי", "entities": [{"start": 67, "end": 81, "label": "SINGER"}]}
+{"text": "אהרן דויטש מפתיע עם סינגל חדש - אור חדש", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "דוד יצחק אמיר בסינגל חדש ונוגע - פשוט לחיות", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "אליאל אפרתי מגיש את סינגל הבכורה שלו - רק תרקוד", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "מקהלת הרצל פרידנזון בביצוע נדיר לשירו של צורי שטמלר - הרים סביב לה", "entities": [{"start": 41, "end": 51, "label": "SINGER"}, {"start": 6, "end": 19, "label": "SINGER"}]}
+{"text": "הדף היומי מסכת בבא מציעא דף י''ג תמוז תשפ''ד - שיעור בעברית מאת הרב משה ליכטמן הי''ו מקול חי", "entities": [{"start": 68, "end": 78, "label": "SINGER"}]}
+{"text": "צדוק קוגן הרטיט את האולם עם - שמע ישראל", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "איתן ג'ורנו חוזר בסינגל חדש וקצבי - נחמו עמי", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "לישי אדלסבורג ניל נוי ואושרי אואזנה ושמואל פריעדמאן - בית צדיקים", "entities": [{"start": 14, "end": 21, "label": "SINGER"}, {"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "הדף היומי מסכת בבא מציעא דףי''ב תמוז תשפ''ד - שיעור בעברית מאת הרב חיים דוד ברסון הי''ו מקול חי", "entities": [{"start": 67, "end": 81, "label": "SINGER"}]}
+{"text": "הראל רוטנברג מארח את מקהלת נעימות בסינגל חדש - הכל עובר", "entities": [{"start": 21, "end": 33, "label": "SINGER"}, {"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "אמציה אשכנזי חנן שלום מארחים את גיא טולמסוב - ושמרו", "entities": [{"start": 0, "end": 12, "label": "SINGER"}, {"start": 13, "end": 21, "label": "SINGER"}, {"start": 32, "end": 43, "label": "SINGER"}]}
+{"text": "הוד ריבלין ואליאב זוהר לזכרו של צביקה לביא הי''ד - כזה היית", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "אוריאל וקנין וילדי החינוך המיוחד - יוסף מוקיר שבת", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "דורון סודרי בסינגל מרגש - לא לבד", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "הדף היומי מסכת בבא מציעא דף י' - י''א סיון-תמוז תשפ''ד - שיעור בעברית מאת הרב בני גל הי''ו מקול חי", "entities": [{"start": 78, "end": 84, "label": "SINGER"}]}
+{"text": "הדף היומי מסכת בבא מציעא דף ט' סיון תשפ''ד - שיעור בעברית מאת הרב מנשה דורון הי''ו מקול חי", "entities": [{"start": 66, "end": 76, "label": "SINGER"}]}
+{"text": "שלומיק יובל בביצוע לייב מתוך האלבום החדש - אל השם", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "דיג'יי פארברנג מארח את לאון קורקוס - לא נעצור ולא נפסיק - Can't Stop Won't Stop", "entities": [{"start": 23, "end": 34, "label": "SINGER"}]}
+{"text": "עדינה רוזן ומתתיהו אימבר שרים עינינו אל ה אלוקינו", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "הדף היומי מסכת בבא מציעא דף ח' סיון תשפ''ד - שיעור בעברית מאת הרב זכריה צפריר הי''ו מקול חי", "entities": [{"start": 66, "end": 77, "label": "SINGER"}]}
+{"text": "מיכאל שניצלער בסינגל חדש - חוזר הביתה", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "ליאל אבבה J חוזר עם להיט קיצי חדש - אחד", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "פרחי שיר ושבח ארז לבנת חגאי הרבסט ואלעזר שטרן - מחרוזת פריד עברית", "entities": [{"start": 14, "end": 22, "label": "SINGER"}, {"start": 0, "end": 13, "label": "SINGER"}, {"start": 23, "end": 33, "label": "SINGER"}]}
+{"text": "הדף היומי מסכת בבא מציעא דף ז' סיון תשפ''ד - שיעור בעברית מאת הרב ראביב גורטנשטיין הי''ו מקול חי", "entities": [{"start": 66, "end": 82, "label": "SINGER"}]}
+{"text": "מוישי ורמי פורטיס עם סער ביבי ודניאל שטרן - אין כאלוקינו", "entities": [{"start": 21, "end": 29, "label": "SINGER"}]}
+{"text": "צוריאל ארליכמן בסינגל חדש - זיך אליין", "entities": [{"start": 0, "end": 14, "label": "SINGER"}]}
+{"text": "שימי ליפשיץ וחזקיה חג'בי בדואט מחזק - שומר ישראל", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "מרדכי רז בסינגל חדש - הכל לטובה", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "דני מאמו באלבום קומזיץ חדש – שירים שכתבתי תקציר", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "אילן אסולין בסינגל בכורה - שאל ממני", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "יונתן אברמוביץ העולמית וישי ביטון בסינגל חדש - אשר ברא", "entities": [{"start": 0, "end": 14, "label": "SINGER"}]}
+{"text": "הדף היומי מסכת בבא מציעא דף ה' סיון תשפ''ד - שיעור בעברית מאת הרב ארנון פינטו הי''ו מקול חי", "entities": [{"start": 66, "end": 77, "label": "SINGER"}]}
+{"text": "הדף היומי מסכת בבא מציעא דף ו' סיון תשפ''ד - שיעור בעברית מאת הרב אלרועי חסון הי''ו מקול חי", "entities": [{"start": 66, "end": 77, "label": "SINGER"}]}
+{"text": "הרב לי-ים פולדי שליט''א פרשת שלח - מתוקה שנת העובד (עברית)", "entities": [{"start": 4, "end": 15, "label": "SINGER"}]}
+{"text": "הדף היומי ''התחלת'' מסכת בבא בתרא דף ג' - ד' סיון תשפ''ד - שיעור בעברית מאת הרב צור סיום הי''ו מקול חי", "entities": [{"start": 80, "end": 88, "label": "SINGER"}]}
+{"text": "טוביה סולקיס ריגש בדינר עם הלהיט - קנא לשמך", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "הדף היומי ''התחלת'' מסכת בבא בתרא דף ב' סיון תשפ''ד - שיעור בעברית מאת הרב מידן קרישבסקי הי''ו מקול חי", "entities": [{"start": 75, "end": 88, "label": "SINGER"}]}
+{"text": "שלום לוי במחרוזת שבת חדשה ומרגשת - חיים של שבת", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "גיל ויין חושף את אלבומו החדש - ריפליי תקציר", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "אלדן תמרי בסינגל חדש אל תסתר", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "יונה מתוקי בסינגל חדש ללימוד הדף היומי - היומי", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "הדף היומי ''סיום'' מסכת בבא מציעא דף קי''ט סיון תשפ''ד - שיעור בעברית מאת הרב ישכר ברדפיס הי''ו מקול חי", "entities": [{"start": 78, "end": 89, "label": "SINGER"}]}
+{"text": "הרב יהב אמר מגיש - יעלה תחנוננו לר׳ הלל קמפינסקי", "entities": [{"start": 36, "end": 48, "label": "SINGER"}, {"start": 4, "end": 11, "label": "SINGER"}]}
+{"text": "לירן אלקובי משיק את אלבום הבכורה - תירוצים תקציר", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "יוסי אוברמייסטר והמעגל בסינגל חדש - קול שמחה", "entities": [{"start": 0, "end": 15, "label": "SINGER"}]}
+{"text": "נחמן דרייר מקפיץ עם - השמחה תחייך", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "אלי מנדלבאום משחרר את - ונתתי מתוך אלבומו הבכורה - תירוצים", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "בועז איילין בסינגל חדש וקצבי - עם הנצח", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "דני בכור משחרר סינגל - לטב מאלבומו הבכורה - שירו לו", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "אורין פאר (כוכב הזמר מצרפת) משיק אלבום בכורה - שירו לו תקציר", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "אמרי מכלוביץ בסינגל חדש - אתה אחד", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "מוטי זינגלבוים שוורץ ודניאל מזרחי בסינגל חדש - השם יעזור", "entities": [{"start": 0, "end": 14, "label": "SINGER"}]}
+{"text": "עמרם בורנשטיין שר את הלהיט שלו - פייער", "entities": [{"start": 0, "end": 14, "label": "SINGER"}]}
+{"text": "הדף היומי מסכת בבא מציעא דף קי''ח סיון תשפ''ד - שיעור בעברית מאת הרב ליאו סלע הי''ו מקול חי", "entities": [{"start": 69, "end": 77, "label": "SINGER"}]}
+{"text": "עופר טללה במחרוזת חופה מרגש ואותנטי - זמן חופה", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "אורן יפרח בסינגל חדש - בנים למקום", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "מיכאל שניצלר משחרר סינגל חדש - רחמים, מתוך אלבומו הראשון", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "צור פרידמן בסינגל חדש - כבד", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "הדף היומי מסכת בבא מציעא דף קי''ז סיון תשפ''ד - שיעור בעברית מאת הרב אבי זוהר הי''ו מקול חי", "entities": [{"start": 69, "end": 77, "label": "SINGER"}]}
+{"text": "רותם יטיב מארח את אמוץ מגידש, שמוליק פלדמן ותיאו לביא - בלילות", "entities": [{"start": 18, "end": 28, "label": "SINGER"}, {"start": 30, "end": 42, "label": "SINGER"}, {"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "דורון שוורץ מפרסם שיר ראשון - רצונות טובים", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "שימי אילוזיני מבצע - וארשתיך לקראת שמחת הכנסת ספר התורה לישיבת 'תפארת ישראל", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "גל בלס בסינגל חדש לבקשת הרב ארוש - תמיד אוהב אותי", "entities": [{"start": 0, "end": 6, "label": "SINGER"}]}
+{"text": "הדף היומי מסכת בבא מציעא דף קט''ז סיון תשפ''ד - שיעור בעברית מאת הרב נחמן שפיר הי''ו מקול חי", "entities": [{"start": 69, "end": 78, "label": "SINGER"}]}
+{"text": "הרב ר' דוד צוברי מלאך שליטא שיעור באידיש על פרשת נשא -שבועות השית געבט די תורה פאר מיין וועלט", "entities": [{"start": 7, "end": 16, "label": "SINGER"}]}
+{"text": "הרב ויקטור קליסקי שליט''א פרשת בהעלתך - תהא השעה הזאת שעת רחמים ועת רצון מלפניך (עברית)", "entities": [{"start": 4, "end": 17, "label": "SINGER"}]}
+{"text": "ויל הרציג בסינגל חדש לכבוד בר המצווה של בנו - והערב נא", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "יהושע ישראלי בסינגל חדש לכבוד תכלית הבריאה - שבת", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "פז יהודה מחדש את שירו של ר' צור סבג ז''ל - ריבונו של עולם", "entities": [{"start": 28, "end": 35, "label": "SINGER"}, {"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "אורי קריס בסינגל חדש - ליבי", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "אריה אריאב מארח את בנימין דקל ואבישי בורנשטיין - והערב נא", "entities": [{"start": 0, "end": 10, "label": "SINGER"}, {"start": 19, "end": 29, "label": "SINGER"}]}
+{"text": "שלמה רגה בסינגל - אייר אייר", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "תודה לך השם ולהקת אבשלום אלקובי בשיר שממתין למשיח - טוט אלץ", "entities": [{"start": 18, "end": 31, "label": "SINGER"}]}
+{"text": "עקיבא חזנוב בסינגל חדש - טוב להודות", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "הרשי קליין ז''ל - ברכת כהנים (מידד טאסה)", "entities": [{"start": 0, "end": 10, "label": "SINGER"}, {"start": 30, "end": 39, "label": "SINGER"}]}
+{"text": "הדף היומי מסכת בבא מציעא דף קיג סיון תשפ''ד - שיעור בעברית מאת הרב אסף תיבון הי''ו מקול חי", "entities": [{"start": 67, "end": 76, "label": "SINGER"}]}
+{"text": "הדף היומי מסכת בבא מציעא דף קיד - קט''ו סיון תשפ''ד - שיעור בעברית מאת הרב אהוד קריאף הי''ו מקול חי", "entities": [{"start": 75, "end": 85, "label": "SINGER"}]}
+{"text": "עובדיה יעיש ואמנון דהן מרגשים בשיר החופה - חופה ליד", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "יצחק ריס משיק סינגל חדש - גאולתנו", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "אדיב ירוחם מציג - די שמעלצער חתונה- החתונה של שמעלצר", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "המזמרים מחדש שיר של קרליבך- ועינינו תראינה", "entities": [{"start": 0, "end": 7, "label": "SINGER"}]}
+{"text": "לישי מנדלסון ודיוויד טויב בסינגל - תורתי", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "חי חורש ונתי אלבר - אבינו אב הרחמן", "entities": [{"start": 0, "end": 7, "label": "SINGER"}]}
+{"text": "מרדכי סמין בסינגל חדש - בן פורת יוסף", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "ראובן פוירשטיין בסינגל חדש - אם אשכחך", "entities": [{"start": 0, "end": 15, "label": "SINGER"}]}
+{"text": "אהרל_ה וינטרוב בסינגל בכורה - זה היום", "entities": [{"start": 0, "end": 14, "label": "SINGER"}]}
+{"text": "עופרי ארליך בסינגל מדליק - בא לי", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "הדף היומי מסכת בבא מציעא דף קי''ב סיון תשפ''ד - שיעור בעברית מאת הרב ליאב הופמן הי''ו מקול חי", "entities": [{"start": 69, "end": 79, "label": "SINGER"}]}
+{"text": "יאן פריס והילל זלצמן מארחים את אוריאל זלמה - בואי בשלום", "entities": [{"start": 31, "end": 42, "label": "SINGER"}, {"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "אורי קוטלר ואהובה רוזנבלום מגישים ניגון 'לכה דודי' של ברסלב", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "'מבד' ושגיב גוטמן בסינגל חדש - אם אני כאן", "entities": [{"start": 1, "end": 4, "label": "SINGER"}]}
+{"text": "יוסי מעוז מארח את בניה אלקובי בסינגל חדש - תורה ותפילה", "entities": [{"start": 18, "end": 29, "label": "SINGER"}, {"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "ולרי נברו בסינגל חדש - באה השמחה", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "פרחי ניו יורק בסינגל חדש לשבועות - איינס אחד", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "טוביה צפיר משחרר האלבום ה-14 אלבום חב''ד", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "הדף היומי מסכת בבא מציעא דף קי''א סיון תשפ''ד - שיעור בעברית מאת הרב מאור אדרי הי''ו מקול חי", "entities": [{"start": 69, "end": 78, "label": "SINGER"}]}
+{"text": "אורן קורנבלום וחברים בהפקה שבתית עוצמתית - קבלת שבת קרליבך", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "סיון עדני משחרר גרסת רמיקס לשירו - התורה הקדושה", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "בארי סורוקין מגיש בהופעה חיה - מחרוזת גמרא", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "יותם בלק משחרר 'כי הם חיינו' מתוך האלבום קומזיץ חדש 'שירים שכתבתי'", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "מאיר רובנשטיין בסינגל געגועים לגאולה - וכסא דוד", "entities": [{"start": 0, "end": 14, "label": "SINGER"}]}
+{"text": "יגאל צאלק בשיר שבתי חדש וואוילגיין פאר שבת", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "אלישיב היינה בסינגל - הנה זה בא", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "מיכה שקד פותח עונה בלהיט מקפיץ - גמזו לטובה", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "דוד הלר מרענן עם סינגל חדש - יזכו לרוב שמחה", "entities": [{"start": 0, "end": 7, "label": "SINGER"}]}
+{"text": "אליעד קוסטין בסינגל חתונות חדש - שמחת כלה", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "הדף היומי מסכת בבא מציעא דף ק''י סיון תשפ''ד - שיעור בעברית מאת הרב לירון שבנוב הי''ו מקול חי", "entities": [{"start": 68, "end": 79, "label": "SINGER"}]}
+{"text": "הדף היומי מסכת בבא מציעא דף ק''ט סיון תשפ''ד - שיעור בעברית מאת הרב רומי טאוב הי''ו מקול חי", "entities": [{"start": 68, "end": 77, "label": "SINGER"}]}
+{"text": "גדעון שיק במחרוזת ריקודים חסידית סוחפת", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "מרדכי הס פותח את עונת הקיץ עם סינגל חדש אתה 10", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "רחמים גניש בסינגל חדש - יגיע טוב היום", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "עירן ברוידא בסינגל מקפיץ - יש חתונה הלילה", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "מוישי פריינד בסינגל קצבי וצבעוני - הכל ממך", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "ישי לב-ארי בסינגל בכורה - שושנה בין החוחים", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "רעי שריון מוציא סינגל ראשון הנקרא - בלילות", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "אמיר שמש בשיר חדש לכבוד חג השבועות - תורה", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "אחיה פרישברג שגב שוורץ משה שטקל וצור חיות - ותערב", "entities": [{"start": 0, "end": 12, "label": "SINGER"}, {"start": 13, "end": 22, "label": "SINGER"}]}
+{"text": "עמיקם נחושתן אליאל בטיש צוריאל קורייש ומונה - זאת התורה", "entities": [{"start": 24, "end": 37, "label": "SINGER"}, {"start": 0, "end": 12, "label": "SINGER"}, {"start": 13, "end": 23, "label": "SINGER"}]}
+{"text": "הדף היומי מסכת בבא מציעא דף ק''ו - סיון תשפ''ד - שיעור בעברית מאת הרב ילדי המלאכים הי''ו מקול חי", "entities": [{"start": 70, "end": 82, "label": "SINGER"}]}
+{"text": "הדף היומי מסכת בבא מציעא דף ק''ה - סיון תשפ''ד - שיעור בעברית מאת הרב מישל גמליאל הי''ו מקול חי", "entities": [{"start": 70, "end": 81, "label": "SINGER"}]}
+{"text": "ברי וועבר מגיש - והאר עינינו", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "אלחי אזרד ואסף גורן ביצוע לייב - מתיקות התורה", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "צוריאל אסרף ומוישי כהנא עם מחרוזת מיטב שירי תורה", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "נעם אונז בסינגל מושקע ומסקרן - סולם", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "יהב אלקובי מארח את אושר טיבי בסינגל חדש - תנו רבנן", "entities": [{"start": 0, "end": 10, "label": "SINGER"}, {"start": 19, "end": 28, "label": "SINGER"}]}
+{"text": "פלא פרילינג סוחף עם השיר העתיק - אתה בחרתנו", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "דין אורן בסינגל חדש בלחנו של מקהלת קול הנשמה - להתוודע", "entities": [{"start": 0, "end": 8, "label": "SINGER"}, {"start": 29, "end": 44, "label": "SINGER"}]}
+{"text": "עמוס כוכב במחרוזת חדשה - אהבת תורה", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "דוד לוי משחרר סינגל חדש וקצבי - יש אלוקים", "entities": [{"start": 0, "end": 7, "label": "SINGER"}]}
+{"text": "ניב פולמן בסינגל חדש לקראת שבועות - משלי התורה", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "הדף היומי מסכת בבא מציעא דף ק' - ק''א סיון תשפ''ד - שיעור בעברית מאת הרב בנימין פוירברגר הי''ו מקול חי", "entities": [{"start": 73, "end": 88, "label": "SINGER"}]}
+{"text": "הדף היומי מסכת בבא מציעא דף צ''ט אייר תשפ''ד - שיעור בעברית מאת הרב יוסי הכט הי''ו מקול חי", "entities": [{"start": 68, "end": 76, "label": "SINGER"}]}
+{"text": "הרלי פידלר מרגש תפילת השל'ה ווקאלי", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "אבוא אליך שיר מרגש של המלחין הרב אלרוי עמר (עם מוזיקה)", "entities": [{"start": 33, "end": 42, "label": "SINGER"}]}
+{"text": "הדף היומי מסכת בבא מציעא דף צ''ג - צ''ד אייר תשפ''ד - שיעור בעברית מאת הרב אביגדור סויסה הי''ו מקול חי", "entities": [{"start": 75, "end": 88, "label": "SINGER"}]}
+{"text": "הדף היומי מסכת בבא מציעא דף צ''ב אייר תשפ''ד - שיעור בעברית מאת הרב שרוליק לפקוביץ הי''ו מקול חי", "entities": [{"start": 68, "end": 82, "label": "SINGER"}]}
+{"text": "הדף היומי מסכת בבא מציעא דף פ''ח אייר תשפ''ד - שיעור בעברית מאת הרב אריה שגיא הי''ו מקול חי", "entities": [{"start": 68, "end": 77, "label": "SINGER"}]}
+{"text": "ק. קגן בשיר מלא השתוקקות לרבי שמעון - 'געגועים'", "entities": [{"start": 0, "end": 6, "label": "SINGER"}]}
+{"text": "לידור שפיגלמן בלהיט חדש - בזכות", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "זלמן שניאורסון מחדש את הפיוט - בר יוחאי", "entities": [{"start": 0, "end": 14, "label": "SINGER"}]}
+{"text": "משפחת בוסקילה מארחים את ליאם בלישה - מחרוזת בר יוחאי", "entities": [{"start": 24, "end": 34, "label": "SINGER"}]}
+{"text": "משה שטקל האחים קוטלר וסהר שכאני בלחן ויז'ניצאי - לכבוד התנא", "entities": [{"start": 9, "end": 20, "label": "SINGER"}]}
+{"text": "אחיה ויינברגר במחרוזת סוחפת - ואהבת", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "עמרם סבהט אוראל אורלנציק היצירה הוויזניצאית 'בר יוחאי' - די ויזניצע בר יוחאי", "entities": [{"start": 10, "end": 24, "label": "SINGER"}, {"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "חננאל זולדן שוואקי בסינגל סוחף - בזכות הצדיק", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "דוד אשר וחיים ישראל בסינגל ללג בעומר - א ריקוד ביי ר’ שמעון", "entities": [{"start": 0, "end": 7, "label": "SINGER"}]}
+{"text": "אפק רובינוב מגיש מחרוזת לג בעומר מלאה אנרגיה", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "יגל זילברשטיין נעם אינז חוני עוז איתמר בורשטין וירחמיאל שהינו - פייער אין מירון", "entities": [{"start": 0, "end": 14, "label": "SINGER"}, {"start": 33, "end": 46, "label": "SINGER"}, {"start": 24, "end": 32, "label": "SINGER"}, {"start": 15, "end": 23, "label": "SINGER"}]}
+{"text": "ישראל בנעט ואלתר נתיב במחרוזת לג בעומר מקפיצה", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "אורי אדלר בסינגל קצבי לכבוד הילולת הרשבי - בר יוחאי", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "הדף היומי מסכת בבא מציעא דף פ''ו - פ''ז אייר תשפ''ד - שיעור בעברית מאת הרב ששי אנקרי הי''ו מקול חי", "entities": [{"start": 75, "end": 84, "label": "SINGER"}]}
+{"text": "הדף היומי מסכת בבא מציעא דף פ''ה אייר תשפ''ד - שיעור בעברית מאת הרב גונן רפאל הי''ו מקול חי", "entities": [{"start": 68, "end": 77, "label": "SINGER"}]}
+{"text": "הרב אבי שני שליט''א פרשת בהר-תורתו מגן לנו היא מאירת עינינו ימליץ טוב בעדנו (עברית)", "entities": [{"start": 4, "end": 11, "label": "SINGER"}]}
+{"text": "שלמה שווארץ בגרסה ווקאלית לשירו 'אהבת ישראל'", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "הדף היומי מסכת בבא מציעא דף פ''ד אייר תשפ''ד - שיעור בעברית מאת הרב עומר גדי הי''ו מקול חי", "entities": [{"start": 68, "end": 76, "label": "SINGER"}]}
+{"text": "הדף היומי מסכת בבא מציעא דף פ''ג אייר תשפ''ד - שיעור בעברית מאת הרב ינון לרמן הי''ו מקול חי", "entities": [{"start": 68, "end": 77, "label": "SINGER"}]}
+{"text": "שלומי גאנץ בביצוע ווקאלי לשיר 'נקודות' של מירון סנדר", "entities": [{"start": 0, "end": 10, "label": "SINGER"}, {"start": 42, "end": 52, "label": "SINGER"}]}
+{"text": "דודי רוט ואביו דודו בגרסה הווקאלית לשיר - אבא ובן", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "עילאי דסה וילד הפלא יוסי סגל - מודה אני", "entities": [{"start": 0, "end": 9, "label": "SINGER"}, {"start": 20, "end": 28, "label": "SINGER"}]}
+{"text": "דילן פלד מגיש סט ווקאלי (42 דקות)", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "זיון שטיינשניידר ואהוד סורקיס בקאבר ללהיט 'אתה זוכר'", "entities": [{"start": 0, "end": 16, "label": "SINGER"}]}
+{"text": "אוהד פישר ומקסים אדרי בשיר ווקאלי - מזמור לדוד", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "מקהלת בית יהודה ורנה רימוק - אלוקי נשמה ווקאלי", "entities": [{"start": 0, "end": 15, "label": "SINGER"}]}
+{"text": "הדף היומי מסכת בבא מציעא דף פ''א אייר תשפ''ד - שיעור בעברית מאת הרב עמי בן-שבת הי''ו מקול חי", "entities": [{"start": 68, "end": 78, "label": "SINGER"}]}
+{"text": "הדף היומי מסכת בבא מציעא דף פ''ב אייר תשפ''ד - שיעור בעברית מאת הרב זיו צפניה הי''ו מקול חי", "entities": [{"start": 68, "end": 77, "label": "SINGER"}]}
+{"text": "הדף היומי מסכת בבא מציעא דף ע''ט - ס' אייר תשפ''ד - שיעור בעברית מאת הרב ששון הורן הי''ו מקול חי", "entities": [{"start": 73, "end": 82, "label": "SINGER"}]}
+{"text": "הרב קינדרלעך שליטא פרשת אמור - ונקדשתי בתוך בני ישראל (עברית)", "entities": [{"start": 4, "end": 12, "label": "SINGER"}]}
+{"text": "עידו קנטורוביץ בסינגל ווקאלי חדש - אין זו הסתרה", "entities": [{"start": 0, "end": 14, "label": "SINGER"}]}
+{"text": "עמיקם סלוק מחדש את השיר 'נחמה' בווקאלי", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "אופיר שוב לירי מגל העולמית וילד הפלא אלי וקסלר עם הגרסה הווקאלית - אתה זוכר", "entities": [{"start": 0, "end": 9, "label": "SINGER"}, {"start": 10, "end": 18, "label": "SINGER"}]}
+{"text": "יחיאל ויצמן חוזר בביצוע ווקאלי לשירו '2000'", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "חיים נחום מרמלשטיין בגרסה ווקאלית - משה", "entities": [{"start": 0, "end": 19, "label": "SINGER"}]}
+{"text": "גיל ישראלוב בשיר ווקאלי - אשריכם תלמידי חכמים", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "אחיקם אלישייב בסינגל חדש - התנערי", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "הדף היומי מסכת בבא מציעא דף ע''א ניסן תשפ''ד - שיעור בעברית מאת הרב מרים פרידמן הי''ו מקול חי", "entities": [{"start": 68, "end": 79, "label": "SINGER"}]}
+{"text": "הדף היומי מסכת בבא מציעא דף ע' ניסן תשפ''ד - שיעור בעברית מאת הרב חוליו קסטנבאום הי''ו מקול חי", "entities": [{"start": 66, "end": 80, "label": "SINGER"}]}
+{"text": "הדף היומי מסכת בבא מציעא דף ע''ב - ע''ג אייר תשפ''ד - שיעור בעברית מאת הרב הראל שרביט הי''ו מקול חי", "entities": [{"start": 75, "end": 85, "label": "SINGER"}]}
+{"text": "הרב ציון דוד היו - סיפור חיים מרתק - ישיג בין הזמנים ניסן תשפד (עברית)", "entities": [{"start": 4, "end": 12, "label": "SINGER"}]}
+{"text": "הרב שון בריף שליטא פרשת קדושים - כשהאדם אומר טוב על חבירו גורם שמחה עצומה להשית (עברית)", "entities": [{"start": 4, "end": 12, "label": "SINGER"}]}
+{"text": "אושרי סלומוביץ ישראל גולדווסר מלאכי הלוי מרדכי צין עמירם ברמן- אני בוכיה ווקאלי", "entities": [{"start": 0, "end": 14, "label": "SINGER"}, {"start": 30, "end": 40, "label": "SINGER"}, {"start": 51, "end": 61, "label": "SINGER"}]}
+{"text": "יורם הוכהויזר מגיש הלהיט שלו 'לחיות' בווקאלית", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "פלג פרידמן ושמואל רובין באלבום ווקאלי מרגש - הארץ און געפיהל", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "בנימין כהן מגיש אלבום ווקאלי שלישי בשם 'קרן אורה'", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "חנניה אלמליח ושחף מיטרני - 'תפילה של ילדים' הגרסה הווקאלית", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "חן דרעי בביצוע ווקאלי ללהיטו - מודים", "entities": [{"start": 0, "end": 7, "label": "SINGER"}]}
+{"text": "הדף היומי מסכת בבא מציעא דף ס''ה - ס''ו ניסן תשפ''ד - שיעור בעברית מאת הרב עילאי אבידני הי''ו מקול חי", "entities": [{"start": 75, "end": 87, "label": "SINGER"}]}
+{"text": "אדיר שכטר בגרסה ווקאלית - הכל זמני בעולם", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "מעוז ביאלוסטוצקי הפתיע את צבי ברקוביץ עם ביצוע ווקאלי לשיר - השם ישמור", "entities": [{"start": 26, "end": 37, "label": "SINGER"}, {"start": 0, "end": 16, "label": "SINGER"}]}
+{"text": "שבתאי גמליאל משחרר גרסה ווקאלית לשירו - פרספקטיבה", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "יהושע מנדלוביץ בגרסה ווקאלית - עלה קטן", "entities": [{"start": 0, "end": 14, "label": "SINGER"}]}
+{"text": "אמיתי ממן ואליעזר פלג בגרסה ווקאלית - אשוב אליך", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "הרב בועז חכמו ב''שאבעס טיש'' בקול פליי ערב שביעי של פסח תשפ''ד (עברית)", "entities": [{"start": 4, "end": 13, "label": "SINGER"}]}
+{"text": "מ.ד. שוורץ בסינגל חדש - מצה זו", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "הדף היומי מסכת בבא מציעא דף נ''ח - נ''ט ניסן תשפ''ד - שיעור בעברית מאת הרב ניצן מנדל הי''ו מקול חי", "entities": [{"start": 75, "end": 84, "label": "SINGER"}]}
+{"text": "הדף היומי מסכת בבא מציעא דף ס' - ס''א ניסן תשפ''ד - שיעור בעברית מאת הרב יונתן שטנצל הי''ו מקול חי", "entities": [{"start": 73, "end": 84, "label": "SINGER"}]}
+{"text": "נוב אסטריכר בסינגל חדש - מה טובו", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "שמואל פלוס מרגש בלהיט חדש - שבת וינפש", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "סאני שפע בגראמען מרגש לר' מרק יעקב זל", "entities": [{"start": 26, "end": 34, "label": "SINGER"}, {"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "סלע שייביץ ותבל זלמנוביץ בשיר מרגש לזכרו של נחום דבח ז''ל", "entities": [{"start": 0, "end": 10, "label": "SINGER"}, {"start": 44, "end": 52, "label": "SINGER"}]}
+{"text": "יהושע בערקא מחדש את קרליבך - וגאלנו גאולה", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "ענבל לביא שר - חד גדיא", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "רן לירון בסינגל פסחי היישר מהאולפן - למעשה", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "עמירם קצבורג שר את לחנו של ר' עודד הפנר זצל - יום שכולו טוב", "entities": [{"start": 0, "end": 12, "label": "SINGER"}, {"start": 30, "end": 39, "label": "SINGER"}]}
+{"text": "שולם במלואו בסינגל חדש עם מסר חשוב - תחיו בעידן הגאולה משיח נאו", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "הרב חן קרן עם שירי חבד ניגון שמחה – קנז", "entities": [{"start": 4, "end": 10, "label": "SINGER"}]}
+{"text": "טלאור שוויץ בסינגל חדש - שקט סוער", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "ארי קונדה בסינגל געגועים מיוחד - שובה אלינו", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "לירז גולדמברג מארח הניגון שהולחן בטרמינל - פסח'ס סדר", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "אילור קצנשטיין מחדש את הסיפור של קרליבך ומגיש - ליל הסדר האחרון בגטו ורשה", "entities": [{"start": 0, "end": 14, "label": "SINGER"}]}
+{"text": "לני מידן ופניה פנלון בביצוע לייב - הלילה הזה", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "ישראל מאיר ששון אלבז ומנדי גולדברג בסינגל חדש - א גוט יום טוב", "entities": [{"start": 11, "end": 20, "label": "SINGER"}, {"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "מקס קורן שמח להפיץ רגע לפני החג סינגל חדש משמח ואופטימי - לחיות", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "חיים מישייב ומנחם וולפין בסינגל חגיגי לחג הפסח - הלילה הזה", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "נריה גרבי עפר כהנא ושיר ושבח משיק את - שבת קודש", "entities": [{"start": 10, "end": 18, "label": "SINGER"}, {"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "דוד בן ארזה הלחין ושר - גלה", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "קורן עמר אדיר פריצקר ואלי וקסלר במחרוזת שירי ליל שבת", "entities": [{"start": 0, "end": 8, "label": "SINGER"}, {"start": 9, "end": 20, "label": "SINGER"}]}
+{"text": "גדליה ליברמן מארח את מתנאל שינברג בסינגל חדש - נכספתי", "entities": [{"start": 21, "end": 33, "label": "SINGER"}, {"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "ישכר אליאב ומנחם אירנשטיין ריגשו בדינר של סלבודקה", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "אימרי בדש מגיש להיט פסח - בנה ביתך", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "ניתאי מרסיאנו וליאו קופר בסדר פסח - בבהילו יצאנו ממצרים", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "עמית רטיג בלחן משיר השירים - כתפוח", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "יפתח קלוש וצרויה להב מיכאל קוטלר - מחרוזת ליל הסדר", "entities": [{"start": 0, "end": 9, "label": "SINGER"}, {"start": 21, "end": 32, "label": "SINGER"}]}
+{"text": "דניאל מלמד מגיש סינגל ראשון ‘בצאת ישראל’ של מודז’יץ", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "דב שפיר בסינגל שני - א חבר ווי א ברודער", "entities": [{"start": 0, "end": 7, "label": "SINGER"}]}
+{"text": "שמעיה סילברמן בסינגל חדש לחג - קל בנה", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "אפי בונדי בסינגל אישי ומרגש - אתגעגע לכאן", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "ארז עמר כהן בסינגל חדש - הוא יצא", "entities": [{"start": 0, "end": 7, "label": "SINGER"}]}
+{"text": "שראל פרנקל עם שיר חדש לקראת פסח בביצוע של בנו לוזי - ימים באים", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "אליסף פיניש עם להיט חדש - העם הזה", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "יחיאל מרסיאנו נחמן ביטון ותבור וובה - סדר נאכט", "entities": [{"start": 0, "end": 13, "label": "SINGER"}, {"start": 14, "end": 24, "label": "SINGER"}]}
+{"text": "הדף היומי מסכת בבא מציעא דף נ''א - נ''ב ניסן תשפ''ד - שיעור בעברית מאת הרב ברוך דוד הי''ו מקול חי", "entities": [{"start": 75, "end": 83, "label": "SINGER"}]}
+{"text": "אחיה רובין אור כספי שרים בלייב והיא שעמדה ויז'ניץ", "entities": [{"start": 0, "end": 10, "label": "SINGER"}, {"start": 11, "end": 19, "label": "SINGER"}]}
+{"text": "שמעון רז בשיר חדש לזכרו של יוסי הרשקוביץ היד - גם כי אלך", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "רעיה בן ארי ואביעד גיל בקאבר לפסח - קרב יום", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "יעקב קובי הררי מגיש סינגל חדש בשם - נגילה", "entities": [{"start": 0, "end": 14, "label": "SINGER"}]}
+{"text": "ארי נקש בסינגל חדש - תבוא לעזור לי", "entities": [{"start": 0, "end": 7, "label": "SINGER"}]}
+{"text": "יעיש אשרף בסינגל מרגש לפסח - די פיפטע קשיא", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "אוריאן זיידמן במחרוזת שירי פסח מדהימה", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "דביר דעוס טל קריגר וגלעד בראונשטיין במחרוזת שירים לפסח - שלמה בלסם", "entities": [{"start": 57, "end": 66, "label": "SINGER"}, {"start": 0, "end": 9, "label": "SINGER"}, {"start": 10, "end": 18, "label": "SINGER"}]}
+{"text": "נבו טולדנו מגיש מחרוזת שירים שמתאימים לתקופה", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "מוטי בעק ועיליי רז לקראת חג הפסח - הראינו בבניינו", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "עמיחי אסוס ומוישי כהנא במחרוזת פסח", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "הרב ידידיה פינחסוב היו ריתק את הקהל בסיפור אישי בכינוס הכללי רצוננו לעשות רצונך של חסידות צאנז", "entities": [{"start": 4, "end": 18, "label": "SINGER"}]}
+{"text": "צדף רוטמן ודב קזס בביצוע אקוסטי - תן לגשם", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "יורם גרסט מארח את ישעיה בלאס בדואט מקפיץ - רצית השם", "entities": [{"start": 0, "end": 9, "label": "SINGER"}, {"start": 18, "end": 28, "label": "SINGER"}]}
+{"text": "אלרואי עוז בשיר קומזיץ חדש - מצפים לישועה", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "חיים גנץ בשיר חדש ומחזק - כח", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "זושא ולנזבאום בסינגל בכורה עם המסר הכל לטובה", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "אמנון פרמן בביצוע מפתיע - קידוש ליל פסח", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "מאיר אמסילי מחדש את הלחן העתיק - חסל סידור פסח", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "ר' אלירן עמוס מגיש לחן חדש - רם ונשא", "entities": [{"start": 3, "end": 13, "label": "SINGER"}]}
+{"text": "רז עיני בסינגל בכורה סוחף - שומר עלינו", "entities": [{"start": 0, "end": 7, "label": "SINGER"}]}
+{"text": "אביב גפני ודגן הורביץ בדואט לייב ללהיט - רבות מחשבות", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "נהוראי אמסטר בסינגל חדש לקראת פסח - מוציא אסירים", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "אוריה באום וישיבת אורייתא נוקדים בקומזיץ שירי גאולה והלל", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "מתי אזולאי והיוצר יעקב יוסף עבאדי גרסה מחודשת לשיר - קרב יום", "entities": [{"start": 23, "end": 33, "label": "SINGER"}, {"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "להקת '613' מארח את מורי עבדוש - הלילה הזה", "entities": [{"start": 19, "end": 29, "label": "SINGER"}]}
+{"text": "גיא אסולין וסיון שפירא מרגשים - קול דודי דופק", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "לוי לוריא שר - כי אלוקים מתוך פרויקט צמאה​", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "מבשר טרבלסי בסינגל חדש ומרגש בצל המלחמה - זעקת הלב", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "דוד החקין מארח את ינון פרנקו - גם בעולם הזה", "entities": [{"start": 0, "end": 9, "label": "SINGER"}, {"start": 18, "end": 28, "label": "SINGER"}]}
+{"text": "הדף היומי מסכת בבא מציעא דף מ''ד - מ''ה ניסן תשפ''ד - שיעור בעברית מאת הרב טום ספיבק הי''ו מקול חי", "entities": [{"start": 75, "end": 84, "label": "SINGER"}]}
+{"text": "צורי איוונוב ויצחק דאבוש שניאור אסרף - עונג שבת!", "entities": [{"start": 25, "end": 36, "label": "SINGER"}, {"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "שימי יונייב באלבום הבכורה - שישי (תקציר)", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "אהרון רולניצקי במחרוזת חדשה - מחרוזת ברית מילה", "entities": [{"start": 0, "end": 14, "label": "SINGER"}]}
+{"text": "תומר סויסה בסינגל בכורה נוגע ומיוחד - זמן להתקרב", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "יקיר גרוסר מלווה אותנו במסע היסטורי עם סינגל - נחמה", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "אריאל אסרף עם סינגל חדש מנסה - להישאר קרוב", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "זבולון אלתר בסינגל חדש ומפתיע - טיפה יותר", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "שילו הרבסט מוציא לאור - קומי אורי", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "חיים רוגוזינסקי משיק את אלבום הבכורה שלו - מודים לך", "entities": [{"start": 0, "end": 15, "label": "SINGER"}]}
+{"text": "בני אלבז ושילה עזרא במחרוזת שירי פסח - 'פסח אינדערהיים'", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "ברק גרוסברד' בסינגל חדש - עבדו", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "רזיאל סלינגר, מנדי ויינרב ושיר אוחיון בסינגל חדש - טוב להודות", "entities": [{"start": 14, "end": 25, "label": "SINGER"}, {"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "דוד יהושע מגיש סינגל חדש - יום של אור", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "יוחאי שחם והחברים במחרוזת שירים למוצאי שבת - מלווה מלכה", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "סער הנדלר ואיילון מלין בסינגל חדש לכבוד התורה - נותן התורה", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "הדף היומי מסכת בבא מציעא דף ל''ט אדר ב' תשפ''ד - שיעור בעברית מאת הרב דיין גוזלנד הי''ו מקול חי", "entities": [{"start": 70, "end": 81, "label": "SINGER"}]}
+{"text": "דב טולדנו בסינגל חדש - נעם מיך ארום", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "איליי פייבל בסינגל חדש - תשמור על הילדים", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "טיראן לב ממשיך עם סינגל חדש ומפתיע בשם - תן לי", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "יחיאל אקשטיין ז''ל בביצוע הסוחף לניגון טשאבא", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "סיון חיים וירון בן עמי מבקשים - בנה ביתך", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "יעקב יצחק וויינגארטן ועומרי אסרף מארחים את נחמן עתיה - ואנפהא נהירין", "entities": [{"start": 43, "end": 52, "label": "SINGER"}, {"start": 0, "end": 20, "label": "SINGER"}]}
+{"text": "משה כץ סוחף בסינגל חדש - ס'קומט שבת", "entities": [{"start": 0, "end": 6, "label": "SINGER"}]}
+{"text": "מוטי קורנפלד בסינגל חדש ומרגש - תחזור אלי", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "מאיר בלוך בסינגל חדש - שוש אשיש", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "אוהד גרוס מגיש וביום השבת פינציק פינת פיטסבורג", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "חיים אלון בסינגל חדש - אחד מי יודע", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "הדף היומי מסכת בבא מציעא דף ל''ז - ל''ח אדר ב' תשפ''ד - שיעור בעברית מאת הרב גון ינאי הי''ו מקול חי", "entities": [{"start": 77, "end": 85, "label": "SINGER"}]}
+{"text": "ענבר מנחם ואיתן שלום בלחן חדש למילים מתוך ההגדה - מה נשתנה", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "עדן אמון הלחין - דקל אלעזר שר - חיוך של יהודי", "entities": [{"start": 17, "end": 26, "label": "SINGER"}, {"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "תומר אפרת וחברים - אספקלריה", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "דניאל מור משחרר השיר - רצית מאלבומו החמישי מנגן חבד", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "דב לשם בסינגל חופה בכורה - אם אשכחך", "entities": [{"start": 0, "end": 6, "label": "SINGER"}]}
+{"text": "אליאב סקסיק במחרוזת כניסה לחופה מלווה ברביעיית מיתרים", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "מיכאל דבורקין בסינגל חדש לכבוד הילולת הבבא חאקי זיעא - מלכי אל חי אהודך", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "ישראל דרור אהר'לע סאמעט גבי רחמים עדיאל ברוכיאל וחסידימלעך - מעשה", "entities": [{"start": 34, "end": 47, "label": "SINGER"}, {"start": 24, "end": 33, "label": "SINGER"}, {"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "הרב בנימין פינקל בביצוע מעניין", "entities": [{"start": 0, "end": 16, "label": "SINGER"}]}
+{"text": "קאי ויסמן ואדי שילינגר בדואט מקפיץ עם להיט שבתי תוסס של ישיבת אורייתא - שלום עליכם", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "יוחאי שלמייב מארח את טובי השמות ל - יידישע ביט", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "ארבעת אילעאי גיל בסינגל חדש - אמא אמא", "entities": [{"start": 6, "end": 16, "label": "SINGER"}]}
+{"text": "אמציה חן בסינגל בכורה - דרך ארוכה", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "ברק כץ ואליאב קדמי בסינגל מסר וצוואה כובש - חיים בער'ס מודים", "entities": [{"start": 0, "end": 6, "label": "SINGER"}]}
+{"text": "בניה קרוגר באלבום חמישי מהסדרה היוקרתית - מנגן חבד", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "אלעד פרץ יקותיאל הילזנרט - קודש קודשין - א ניגון פון א צדיק!", "entities": [{"start": 0, "end": 8, "label": "SINGER"}, {"start": 9, "end": 24, "label": "SINGER"}]}
+{"text": "אילי סגל בסינגל בכורה - משה", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "עילאי לוי בסינגל שני - הכל זמני בעולם", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "משי קלינשטיין משחרר סינגל חדש בשם - רגע לנשמה", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "דניאל כץ מתניה בוחבוט ודני רוזנבלום במחרוזת שירי שבת", "entities": [{"start": 9, "end": 21, "label": "SINGER"}, {"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "אריק גראד עם סינגל ביכורים - מחשבות", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "עדי רגב משחרר סינגל הודיה - אשיר ואזמר", "entities": [{"start": 0, "end": 7, "label": "SINGER"}]}
+{"text": "ידידיה קלצקו מוציא לאור שיר שמבטא את התקווה והאמונה של כולנו - לא היה סתם", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "דוד עבאדי והחברים בסינגל חדש - פארברענגען", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "ר' דודו אהרוני בסינגל חדש לכ' יומא דהילולא - ותשפיע", "entities": [{"start": 3, "end": 14, "label": "SINGER"}]}
+{"text": "יוסי צוקר בשיר של חסידי בוסטון - שושנת יעקב", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "בן יעקב מזרחי בסט פורים חסידי - רקידה הקדושה", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "איילת גרינברג בלסופסקי מחדש את - בנים, שיר של מרום גואטה", "entities": [{"start": 0, "end": 13, "label": "SINGER"}, {"start": 46, "end": 56, "label": "SINGER"}]}
+{"text": "שימעון בליאכר בסינגל חדש מלא תקווה - אין עוד מלבדו", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "דב ברזלי בסינגל חדש וקצבי - וקיבצתי אתכם", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "לביא קונסטנטין משחרר סינגל מרגש ואקטואלי בשם - מציאות אחרת", "entities": [{"start": 0, "end": 14, "label": "SINGER"}]}
+{"text": "קאי שטיינשניידר בזעקה - אב הרחמן העם שבו בחרת מחכה לגאולה", "entities": [{"start": 0, "end": 15, "label": "SINGER"}]}
+{"text": "סעדה צובירי בסינגל בכורה - ההבטחה", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "נבות גידניאן ומעכל מנדל בסינגל פורימי - בכל מכל כל", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "חיים אדלר ושלום וינטרויב מגישים פורים טראק לייב", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "סער סרדיוק, רפי סיון, אדיר מסלטי - א אידישע טאנץ", "entities": [{"start": 12, "end": 20, "label": "SINGER"}, {"start": 0, "end": 10, "label": "SINGER"}, {"start": 22, "end": 32, "label": "SINGER"}]}
+{"text": "עודד דהן מגיש - מחרוזת שירי פורים", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "אברהם זינגר מארחת את גריגורי ביינה אליאב ברגר ואהוד טויטו", "entities": [{"start": 35, "end": 45, "label": "SINGER"}, {"start": 21, "end": 34, "label": "SINGER"}, {"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "אילעי אשר בסינגל עם ראיון מרגש שרולי'ס חידוש", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "דר הרטמן ותזמורתו מארחים את גיורא קרני אלחי בנדק דוד אבייב - למחרוזת פורים סוחפת", "entities": [{"start": 39, "end": 48, "label": "SINGER"}, {"start": 28, "end": 38, "label": "SINGER"}, {"start": 49, "end": 58, "label": "SINGER"}, {"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "דן שטערן מארח את כוכבי הזמר של ארהב למחרוזת 'מוזיקאלער'", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "רון ג'ינו סוחף במחרוזת ריקודים אלקטרונית - טרעק 2", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "אברהם שטרקמן והילאי יפרח בשיר חדש ונוגע - מ'דארף דא ישועות", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "מקהלת ה'אהרן רזאל' בשיר פורימי - עד דלא ידע", "entities": [{"start": 8, "end": 17, "label": "SINGER"}]}
+{"text": "רפי אלקיים עם עוד סינגל מתוך האלבום החדש 'גוף ונשמה' - ה' הוא האלקים", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "הדף היומי מסכת בבא מציעא דף כ''ג - כ''ד אדר ב' תשפ''ד - שיעור בעברית מאת הרב יניב אקשטיין הי''ו מקול חי", "entities": [{"start": 77, "end": 89, "label": "SINGER"}]}
+{"text": "זיו למקין ויהלי רזיאל - לשם יחוד", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "דיג'יי פאברנג שם סלאב ואפיקו-מן בשמחה אמיתית אפ-מיקס פורים תוסס במיוחד", "entities": [{"start": 14, "end": 21, "label": "SINGER"}]}
+{"text": "יאיר גולן ודי גי ידי.פ - פריש ענד טשילד", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "אביחי זייפרט בסינגל שהפיק הכל בעצמו - שמחה ליהודים", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "חגי צפתי מארח את שלמה גרוניך ונרי ניסנוב - טאטע למה", "entities": [{"start": 17, "end": 28, "label": "SINGER"}, {"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "אליקים בוטה מכניס אתכם לאווירה עם מחרוזת פורים אנרגטית!", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "רחמים הראל רותי רוזנבלט בקאבר לעומרי אלקיכן וליאל מתנה שבורי לב & אתה זוכר", "entities": [{"start": 11, "end": 23, "label": "SINGER"}, {"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "ליאם ויינבלט מחרוזת פורים תשפ''ד", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "עילאי סמאי מגיש סט פורים מקפיץ תשפד", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "רובין בונפלד מוציא לקראת פורים 'דיין שמייכל'", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "כפיר זילברשטין בבייב במחרוזת פורים תשפד", "entities": [{"start": 0, "end": 14, "label": "SINGER"}]}
+{"text": "שרית חדד בשיר חדש לפורים - 'אשרי העם'", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "האחים למר וגבריאל טומבק ''שתי דקות של פורים''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "חן שרמן רון אליוף ואלכסנדר שכטר - א גוטן פורים", "entities": [{"start": 0, "end": 7, "label": "SINGER"}, {"start": 8, "end": 17, "label": "SINGER"}]}
+{"text": "נס שטיינהרט ו'מורן צ׳מסי' מגישים מחרוזת פורים תשפ''ד עם חביב גלילי וגדולי הזמר החסידי", "entities": [{"start": 14, "end": 24, "label": "SINGER"}, {"start": 0, "end": 11, "label": "SINGER"}, {"start": 56, "end": 66, "label": "SINGER"}]}
+{"text": "יהוידע פון וילה מגיש לחנו של דוד שמחה ''לחיים טובים''", "entities": [{"start": 0, "end": 15, "label": "SINGER"}, {"start": 29, "end": 37, "label": "SINGER"}]}
+{"text": "סול נהרי בשיר מקורי להיט של פורים ''אורה ושמחה''", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "נפתלי בלומנטל שוורץ מחדש את השיר האהוב על הרבי זצ''ל ''תשועת עולמים''", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "שמוליק אינדיג בסינגל חדש ''כנוס את כל היהודים''", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "אהרון לוגסי וגרשון גרינברג ממקסמים לכם את הפורים עם ''מיקסאמעט''!", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "שוכי גולדשטיין ומקהלת הילדים 'שיר ושבח' בסינגל חדש ''לפני המלך''", "entities": [{"start": 0, "end": 14, "label": "SINGER"}]}
+{"text": "חביב אסא אלפסי בסינגל ''גלגלים'' מתוך האלבום החדש 'גוף ונשמה'", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "ישראל ביטון עוזיה צדוק ולאו סובלמן במחרוזת ''גאולה אנרג'י''", "entities": [{"start": 0, "end": 11, "label": "SINGER"}, {"start": 12, "end": 22, "label": "SINGER"}]}
+{"text": "דב ברורמן בסינגל חדש ומלהיב ''כל מיני שמחה''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "לירוי ששון ואייל זכאי בשיר ומי יודע (לני מלחי)", "entities": [{"start": 0, "end": 10, "label": "SINGER"}, {"start": 37, "end": 45, "label": "SINGER"}]}
+{"text": "עוז פורת בליווי אלברט אסא העולמית במחרוזת פורים תוססת ''א ביסל’ע משקה''", "entities": [{"start": 16, "end": 25, "label": "SINGER"}, {"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "ליאון דינר במחרוזת 'כל הלהיטים' (13 שירים ברצף)", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "עמנואל ג'אנו במיקס אנרגטי שיקפיץ את שמחת פורים", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "עדה בנבנישתי בסינגל חדש ''געוואלד''", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "גבריאל נוני בסינגל חדש וסוחף ''אתה תמיד כאן''", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "מרדכי בלוי בסינגל חדש לפורים ''שושנת יעקב''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "דני זכריה מגיש ''יואליס'ט''! הלהיטים הגדולים מכל הזמנים עם אמיר צור ועמיחי רחמים", "entities": [{"start": 59, "end": 67, "label": "SINGER"}, {"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "לוי פלקובי'ץ פוגש את מיכה חנוני ונחמן כהן בשמחה יהודית ושיר חדש נולד ''בני חיי ומזוני''", "entities": [{"start": 21, "end": 31, "label": "SINGER"}]}
+{"text": "יריב פחימה במחרוזת פורים תשפ''ד ''חגיגה בשושן''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "בערי משחרר את ''מחרוזת דאנס 2'' עם אבי אבורומי ז''ל מתוך אלבומו החדש", "entities": [{"start": 35, "end": 46, "label": "SINGER"}]}
+{"text": "הדף היומי מסכת בבא מציעא דף ט''ז - י''ז אדר ב' תשפ''ד - שיעור בעברית מאת הרב יונתן כרמון הי''ו מקול חי", "entities": [{"start": 77, "end": 88, "label": "SINGER"}]}
+{"text": "בערי ובער ושירה חנקין בשיר משלוח מנות ''מרדכי ואסתר''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "להקת קרוהמה בלהיט פורימי חדש ''דורש טוב''", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "תמיר אביטן שוואקי מתארח אצל טומי ליברמן ולירוי בוחבוט ''וזכנו''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}, {"start": 28, "end": 39, "label": "SINGER"}]}
+{"text": "ישראל גליס בסינגל חדש ומיוחד ''שיר נשמה''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "צביקה עוליאל משחרר מחרוזת א''היים פון שול'' מתוך אלבומו החדש 'מטעמים'", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "אור זרקא בסינגל פורימי חדש - פורים תשפ''ד", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "רן בליצר בסינגל בכורה ''אתה פה איתי''", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "לירן מלקה בסינגל חדש ומקפיץ ''דרך אמונה''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "הרשי רוטנברג משיק אלבום חדש וסוחף ''בערי אנרג'י'' (10#)", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "ינון ישראל משחרר מחרוזת ''שירי פורים'' מטיש ברחמסטריווקא", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "יפעת טל סורקין דניאל אלישע וערן סוברנו ב''מחרוזת סעודה''", "entities": [{"start": 0, "end": 7, "label": "SINGER"}, {"start": 15, "end": 26, "label": "SINGER"}]}
+{"text": "סהר מגד מגיש סינגל רשמי ראשון ''הדיויד אבטהיל''", "entities": [{"start": 0, "end": 7, "label": "SINGER"}]}
+{"text": "יוחנן גרימברג מגיש יצירה חדשה ''אחינו''", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "הדי שפירה משיק אלבום שבתי חדש ''מטעמים''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "אברהם רובינשטיין בסינגל מלחמה חדש ''פורחים לשובם''", "entities": [{"start": 0, "end": 16, "label": "SINGER"}]}
+{"text": "אלרועי שמואלביץ ב''מחרוזת פורים חסידית'' שכמותה לא שמעתם", "entities": [{"start": 0, "end": 15, "label": "SINGER"}]}
+{"text": "רני יהב פותח את חודש אדר ב' עם סינגל חדש ''שיר התתי''ם''", "entities": [{"start": 0, "end": 7, "label": "SINGER"}]}
+{"text": "אמרי חמלניצקי בסינגל חדש ''ותוסף אסתר''", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "אבי קלצקו נס אלקרס וצדוק נחמיה ''ליפא'ס ערשטע טאנץ''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}, {"start": 10, "end": 18, "label": "SINGER"}]}
+{"text": "שלום שבזי מארח את מנחם ארשטיין ודוד פרלמן ''שושנת יעקב'' (מודז'יץ)", "entities": [{"start": 18, "end": 30, "label": "SINGER"}, {"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "מני אפשטיין ואהר'לה סאמט מרבים בשמחה עם מחרוזת שירי פורים", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "נוי לפין במחרוזת שירי פורים ''אינסטרומנטלי''", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "אפיק ברלין במחרוזת אנרגטית מקפיצה ''מוכנים לרקוד'' - ''גרייט צו טאנצן''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "אביתר גוטמן משחרר מחרוזת דאנס סוחפת ''שמחה טאנץ''", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "ישורון צימרמן משה ועמיאל גורי ''מחרוזת פורים סוערת''", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "אברימי רוט ויהשוע לימוני בביצוע סוחף ''עם ישראל חי''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "הדף היומי מסכת בבא מציעא דף ט' - י' אדר א' תשפ''ד - שיעור בעברית מאת הרב מקהלת חסידי ויז'ניץ הי''ו מקול חי", "entities": [{"start": 73, "end": 92, "label": "SINGER"}]}
+{"text": "תימור בוני מכניס אתכם לאווירת השבת עם ''מחרוזת שירי שבת''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "דני אזולאי ונדב בייטון במחרוזת ''פרייליך טאנץ''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "רועי שי בלהיט מקפיץ ואנרגטי ''בכל דור ודור''", "entities": [{"start": 0, "end": 7, "label": "SINGER"}]}
+{"text": "הרצל בקר ודוד בן-גוריון בדואט ''יעטוף באהבה''", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "מעוז קורן ואדוארד מינס מארחים את הזמר נועם סולומון ''ויכולו''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}, {"start": 38, "end": 50, "label": "SINGER"}]}
+{"text": "אליקים סנדרס בסינגל חדש ''שירה כים''", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "עברי לניאדו עם יצירה חסידית ''ישמח משה''", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "יעקב-שוואקי חוזר לשורשים עם סינגל חדש ''קח את האור''", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "ישי גולדנשטיין הראל חדד ותם ריטר מחדשים ''נפשנו''", "entities": [{"start": 0, "end": 14, "label": "SINGER"}, {"start": 15, "end": 23, "label": "SINGER"}]}
+{"text": "אלימלך בידרמן ואלישיב ברעוודה שרים ומתחננים ''בעד עמך''", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "עמוס אלי בשיר מלאכותית ''משנכנס אדר''", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "יואל פרידמן קרייג טאובמן שראל טופז ובצלאל ברנבוים במחרוזת ''עלייה לתורה''", "entities": [{"start": 12, "end": 24, "label": "SINGER"}, {"start": 0, "end": 11, "label": "SINGER"}, {"start": 25, "end": 34, "label": "SINGER"}]}
+{"text": "עמיר אדרי בלהיט חדש ''שירים וחלומות''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "מאיר צימרמן מתכונן לגאולה עם סינגל חדש ''ועד שהוא יבוא''", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "אדיר פינטו מרגש בסינגל חדש ברוח תקופת המלחמה ''קול דמי בניך''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "שניר וקנין ז''ל ואופק בנג'י ועזרא אמיניאן בלחן מרגש ''פוקח עורים''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "אילון פתאל מארח את עומרי שטרן ''שיר הרחמים''", "entities": [{"start": 19, "end": 29, "label": "SINGER"}, {"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "רם ליפץ ושלום שמש מתכוננים לפורים ''שושנת יעקב''", "entities": [{"start": 0, "end": 7, "label": "SINGER"}]}
+{"text": "דובי ישראל בסינגל חדש ''משתה נגינתם''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "חיים לקס ו'ידידיה פריימן' בדואט מרגש ''תפילה של ילדים''", "entities": [{"start": 0, "end": 8, "label": "SINGER"}, {"start": 11, "end": 24, "label": "SINGER"}]}
+{"text": "ניראל דיכטר בסינגל חדש לכבוד הילולת ה’נועם אלימלך’ ''אדרבה''", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "עומר גלעדי מגיש סינגל חדש בשם ''לשיר לך''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "בן סמה מגיש לרגל כא אדר אוסף שירי רבי אלימלך מליז'ענסק זיע''א", "entities": [{"start": 0, "end": 6, "label": "SINGER"}]}
+{"text": "ר' כרמל אורטס עם 15 דק' של ''חופה צייט''", "entities": [{"start": 3, "end": 13, "label": "SINGER"}]}
+{"text": "קול חי מיוזיק חוגג 50 שנות יצירה למלחין מירון יאסו בוחרים גרין! המשדר המלא ותוצאות האמת", "entities": [{"start": 40, "end": 50, "label": "SINGER"}]}
+{"text": "הדף היומי ''התחלת'' מסכת בבא מציעא דף ב' - ג' אדר א' תשפ''ד - שיעור בעברית מאת הרב שניר פינטו הי''ו מקול חי", "entities": [{"start": 83, "end": 93, "label": "SINGER"}]}
+{"text": "חביב דניאל ביקש סליחה מחבר וחיבר איתו שיר חדש ''באתי לדבר''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "דני אלון ואלעזר סויסה מארחים את דין גמרסני ''ימין ושמאל''", "entities": [{"start": 32, "end": 42, "label": "SINGER"}, {"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "תודה לך השם מגיש מחרוזת ''שירי ''לב ונשמה בביצוע של בועז אביטל", "entities": [{"start": 52, "end": 62, "label": "SINGER"}]}
+{"text": "מקס מנצור מוציא סינגל מתוך פרויקט חדש בשם ''גוף ונשמה''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "מיילך פישר בסינגל חדש בדרך לאלבום ''אני נצחי''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "שמעון יואל זינגר במחרוזת ''קומזיץ אלייב''", "entities": [{"start": 0, "end": 16, "label": "SINGER"}]}
+{"text": "ליאו אסולין בסינגל חדש ''שר לאלוקים''", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "ארנון עברון בסינגל נוסף ''גאולה פרטית''", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "שלמה כרמל מנגן ''משנכנס אדר'' בחמישה רבעים", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "רפאל סויסה בסינגל היפ-הופ אלקטרוני ''אנחנו טובים''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "נריה חזוט באלבום חדש עם 12 שירים מרגשים מקפיצים ''שלום עליכם''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "דניאל ברונשטיין בסינגל חדש ''להתקרב''", "entities": [{"start": 0, "end": 15, "label": "SINGER"}]}
+{"text": "אליה בראונר בדרך להתחבר לצדיק ''ליזענסק'ע תנועה''", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "שלום בער סורצקין משיק שיר חופה מרגש ומקורי ''לפני החופה''", "entities": [{"start": 0, "end": 16, "label": "SINGER"}]}
+{"text": "ארד מושל בלהיט חתונות אנרגטי וסוחף ''לחיים''", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "גור ארז והלהקה מגישים ''מחרוזת פורים''", "entities": [{"start": 0, "end": 7, "label": "SINGER"}]}
+{"text": "יאר ברוש וזיו סלומון בסינגל חדש ''איז געווען איז געשען''", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "משה דוד וויסמנדל משחרר השיר ''המלך'' מתוך אלבומו הבכורה ''חלום''", "entities": [{"start": 0, "end": 16, "label": "SINGER"}]}
+{"text": "לוי חזן משיק אלבום בכורה חלום", "entities": [{"start": 0, "end": 7, "label": "SINGER"}]}
+{"text": "בנצי וברמן משחרר בביצוע קאבר לשיר ''זכות אבות''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "יוחאי המשך שר במופע היצירה הדרך שלי (My Way)", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "מעוז גולדשטיין מפתיע בסינגל חסידי ''ואסיים בתפילה''", "entities": [{"start": 0, "end": 14, "label": "SINGER"}]}
+{"text": "רן עוזר מפתיע בסינגל חדש ''לבוש שחורים''", "entities": [{"start": 0, "end": 7, "label": "SINGER"}]}
+{"text": "מעוז לפיד - הסיעה החסידית ביתר עילית", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "מפלגת 'בני תורה' תשפד אלי מילר ומלכות", "entities": [{"start": 22, "end": 30, "label": "SINGER"}]}
+{"text": "יהדות התורה אגודת ישראל ושלומי אמונים דגל התורה וש''ס ירושלים זוהר זיסאפל ויותם וויס", "entities": [{"start": 62, "end": 73, "label": "SINGER"}]}
+{"text": "יהודה בוטבול ותנועת ש''ס - אלעד - אביגדור כהן ודן אביחי ג'ינגל תשפד", "entities": [{"start": 34, "end": 45, "label": "SINGER"}]}
+{"text": "יצחק גמבריאן מישאל ונונו עוזיה כץ - 'כח' בית שמש", "entities": [{"start": 13, "end": 24, "label": "SINGER"}, {"start": 0, "end": 12, "label": "SINGER"}, {"start": 25, "end": 33, "label": "SINGER"}]}
+{"text": "הרב מרק פרנסז שליט''א פרשת תצוה - הוכח לחכם ויאהבך (עברית)", "entities": [{"start": 4, "end": 13, "label": "SINGER"}]}
+{"text": "רום גולדנברג בסינגל מצמרר ברקע המלחמה ''הביטה''", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "אורן בקי אבישי מליק ומקהלת ויז’ניץ ''א חסידישע שמחה''", "entities": [{"start": 0, "end": 8, "label": "SINGER"}, {"start": 9, "end": 19, "label": "SINGER"}]}
+{"text": "אדם פרלמן מפתיע בסינגל ייחודי ''דראפנען''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "אליעזר סרוסי יוני נפטלייב ורון טהלר בקאבר לשיר של אביעד ויטל ''ידיד נפש''", "entities": [{"start": 13, "end": 25, "label": "SINGER"}, {"start": 0, "end": 12, "label": "SINGER"}, {"start": 50, "end": 60, "label": "SINGER"}]}
+{"text": "זאב עמרני רוצה להרגיש ''קרוב מתמיד''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "שלום טייב שמח ונרגש לשחרר את היצירה החדשה לפורים תשפ''ד", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "דביר דוידוב וישיבה לצעירים ‘תורת החיים’ ''ותן בנו''", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "סמואל בילינסון ומקהלת ‘נשמה’ במחרוזת שירים מכל הזמנים", "entities": [{"start": 0, "end": 14, "label": "SINGER"}]}
+{"text": "סהר דרבי ויאיר לוי בהופעה מקפיצה ''משנכנס אדר''", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "שרון אפנזר ויהודה ג'אנה בביצוע לייב ''ותיהב לי''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "ים פישבין בסינגל חדש ''תמיד איתי''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "נחום רוף וחברים בביצוע לייב לשירו ''ער''", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "ליאו נעים בסינגל נחמה למשפחות השכולות ''אין מילה בלשוני''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "אורן גבאי וחברים במחרוזת ממיטב הניגונים ''קרליבך טיש''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "רנן אייזן ויקטור דויד וטלי ליבוביץ מקפיצים ''שמחה דאנס 2''", "entities": [{"start": 10, "end": 21, "label": "SINGER"}, {"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "נפתלי רוזנפלד חוזר עם סינגל חדש ''נר ניצחון''", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "''תובל בדש אפיק הללי וגדולי הזמר בסדרת חופה מרהיבה ''ברוכה הבאה", "entities": [{"start": 11, "end": 20, "label": "SINGER"}, {"start": 2, "end": 10, "label": "SINGER"}]}
+{"text": "שמחה אברמצ'יק מוציא שיר חדש העוסק בקשר האישי עם הבורא ''אפ'חד''", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "ידידיה גת ונוה מלכה ''ועל חסדך'' מתוך מיזם ה'מעוררים' 3.2 של טים רוט", "entities": [{"start": 61, "end": 68, "label": "SINGER"}, {"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "שמעון מושקוביץ במחרוזת להיטי ישראל אבגי", "entities": [{"start": 0, "end": 14, "label": "SINGER"}, {"start": 29, "end": 39, "label": "SINGER"}]}
+{"text": "יעקב אליהו בשיר חדש ''בשבילי נברא העולם''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "אלון יריב חוזר בסינגל ''הוא ייטיב''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "ערן ברבר החזן מגיש ''מחרוזת שירי שבת''", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "יוסי סלומיוק בסינגל חדש ומקפיץ ''מתבטלים כל הצרות''", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "עידן רייכל משיק סינגל חדש ''הגיע הזמן''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "הדף היומי מסכת בבא קמא דף ק''ו - ק''ז אדר א' תשפ''ד - שיעור בעברית מאת הרב דוד מסילתי הי''ו מקול חי", "entities": [{"start": 75, "end": 85, "label": "SINGER"}]}
+{"text": "יולי גרוסמן משחרר סינגל נוסף ''אפיסת כוחות''", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "יוחאי ליברמן מרגש בסינגל חופה חדש ''תפילת הקהל''", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "אופרי לייטנר בשירו ''חמול'' בביצוע בהופעה חיה בניו יורק", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "עשהאל דסטה וטום איטח ומנדל רוזנטל בסינגל חדש ''לראות בנים''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "הראל זריהן ויודי יגאלי בשיר מקפיץ למילים של הרבי מויז'ניץ שליט''א", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "שמואל נעמן משחרר לקראת אלבום בכורה סינגל חדש ''תשחרר''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "יהושע לימוני בשירו ''יש עניין'' שיצא באלבומו ''ליבי''", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "אליעזר אייזיקוביץ מחדש את שירו של  הרבי הראשון מסקולען זיע''א ''האירה''", "entities": [{"start": 0, "end": 17, "label": "SINGER"}]}
+{"text": "ירון בוכריס שיר צ'רקסקי ואברומי סמט ''שומר ישראל''", "entities": [{"start": 0, "end": 11, "label": "SINGER"}, {"start": 12, "end": 23, "label": "SINGER"}]}
+{"text": "חיים סוזנה כתב הלחין ושר ''הקשיבה''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "מנשה ויצמן ומקהלת ויז'ניץ במחרוזת קסומה עם מיטב שירי ר''ח", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "כפיר ברגר משיק סינגל חדש מעומק הלב ''נחלי דמעות''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "מרדכי קאהן & מיכאל טברסקי - ראש חודש", "entities": [{"start": 13, "end": 25, "label": "SINGER"}]}
+{"text": "דביר צרור ובראל וינברג מארחים את רזיאל זק ''התנערי''", "entities": [{"start": 33, "end": 41, "label": "SINGER"}, {"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "אתי משרקי בקאבר לאיציק אנצבאכר ''באתי לגני''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "עילאי ברזילי בסינגל חדש ''כ׳האדיך ליבּ''", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "הדף היומי מסכת בבא קמא דף צ''ט - ק' שבט אדר תשפ''ד - שיעור בעברית מאת הרב משה לוי הי''ו מקול חי.crdownload", "entities": [{"start": 74, "end": 81, "label": "SINGER"}]}
+{"text": "דרור דדוש כתב הלחין ושר ''שירו איתי'' (Sing With Me)", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "נמרוד רפפורט ויוסי לקס מגישים קאבר ''משיח''", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "אמרי בצרי משחרר סינגל חדש וקיצבי עם מסר גדול ''זרוק ת'דאגות''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "אליהו אליהו בסינגל חדש ומיוחד למצב ''שומר ישראל''", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "ברוך שמחה ואביו פינקי בסינגל חדש ''געבליבן מיט דיר''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "רועי ברק עם מחרוזת שירי אמונה וניצחון ''פרויקט אמונה וניצחון 2''", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "אסי מעודה בסינגל חדש ''כבד את אביך''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "עדן רונן ותזמורתו של לייבלה השל במחרוזת ''שירי שלמה''", "entities": [{"start": 0, "end": 8, "label": "SINGER"}, {"start": 21, "end": 31, "label": "SINGER"}]}
+{"text": "אליעזר גורן לא נח לרגע ומגיש מחרוזת חופה מרגשת עם מיטב הלהיטים", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "שניאור זילבר בסינגל בכורה חדש ''אני פה להישאר''", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "יניב אליוף ניסן פרידמן וחנוך אבנרי וחסידימלעך במחרוזת ''פרוק ית ענך''", "entities": [{"start": 11, "end": 22, "label": "SINGER"}, {"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "אליאור לב והחברים בשירה שכולו ערגה וכיסופין ''שלשידעס''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "יונתן דורן בסינגל בכורה ''מי שענה''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "אליק קפלן במחרוזת משובחת בשם ''השפעות מוצאי שבת''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "הדף היומי מסכת בבא קמא דף צ''ב - צ''ג שבט תשפ''ד - שיעור בעברית מאת הרב דקל אונגר הי''ו מקול חי", "entities": [{"start": 72, "end": 81, "label": "SINGER"}]}
+{"text": "מיכה סובול בסינגל חדש ''איך וויל אהיים גיין''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "ישראל גרינברג ולירן קליין מבצעים ''ניגון מניקולייב''", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "לירם גולדנברג ולהקת ענבי הגפן מארחים את אלי לעווין ''שבת שלום''", "entities": [{"start": 0, "end": 13, "label": "SINGER"}, {"start": 40, "end": 50, "label": "SINGER"}]}
+{"text": "בר שגב בסינגל נוסף מהאלבום ''שבת''", "entities": [{"start": 0, "end": 6, "label": "SINGER"}]}
+{"text": "יקיר חרזי בשיר - לְנַצֵּחַ", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "שמעון בר יוחאי חוזר עם סינגל חדש ומרגש ''הוציאה''", "entities": [{"start": 0, "end": 14, "label": "SINGER"}]}
+{"text": "חיים שלמה מאיעס וירדן שיינפלד ביצוע מיוחד ''מודים''", "entities": [{"start": 0, "end": 15, "label": "SINGER"}]}
+{"text": "ארד רביבו בסינגל חדש מהאלבום שבדרך ''וקיימא''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "אשר קובלסקי באלבום בכורה ''שירי דוד'' דוגמה", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "יורם ערן בדואט מפתיע והיסטורי עם חיים אלעזר ''שמעה תפילתי''", "entities": [{"start": 0, "end": 8, "label": "SINGER"}, {"start": 33, "end": 43, "label": "SINGER"}]}
+{"text": "ירין אינגר במחרוזת תוססת ''ריקוד - מהדורת שוואקי''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "עילי גזולי במחרוזת שירי כפיר דכטיאר", "entities": [{"start": 0, "end": 10, "label": "SINGER"}, {"start": 24, "end": 35, "label": "SINGER"}]}
+{"text": "שלם אזולאי בשיר ''עלינו'' מתוך באלבום בכורה ''שירי דוד''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "הרב לירן זילברמן מגיש ניגון נוסף ''ניגון המשפיע'' (מתוך פרוייקט געגועים 8)", "entities": [{"start": 4, "end": 16, "label": "SINGER"}]}
+{"text": "שימי מרקוביץ ולהקתו מארחים את אמיר אבו & מוריס קרביץ ''בענטשן''", "entities": [{"start": 30, "end": 38, "label": "SINGER"}, {"start": 41, "end": 52, "label": "SINGER"}]}
+{"text": "ננסי פליישר בלהיט חתונות חדש באווירת המלחמה ''לכתך אחרי''", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "'אלעד אלדד' והחברים בקומזיץ 'הבדלה' מושקע", "entities": [{"start": 1, "end": 10, "label": "SINGER"}]}
+{"text": "רינת סילמן בשיר ''אשריכם תלמידי חכמים''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "אופיר קרבצ'נקו הלחין ושר ''אשת חיל''", "entities": [{"start": 0, "end": 14, "label": "SINGER"}]}
+{"text": "ירדן פנחס בסינגל חדש ''אתה פה איתי''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "שביט גוטליב ומלאכי כספי מרגשים עם מחרוזת 'אילן'", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "אשר פנקס בסינגל חדש ''עם הנצח''", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "רענן חן והפקות TK תקווה קאשי בשיר מיוחד ''שיר המעלות''", "entities": [{"start": 0, "end": 7, "label": "SINGER"}]}
+{"text": "הדף היומי מסכת בבא קמא דף פ''ה - פ''ו שבט תשפ''ד - שיעור בעברית מאת הרב ניל תורגמן הי''ו מקול חי", "entities": [{"start": 72, "end": 82, "label": "SINGER"}]}
+{"text": "עזרא גיא מארח את מעיין שורצר במחרוזת ''אילן''", "entities": [{"start": 17, "end": 28, "label": "SINGER"}, {"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "שלום זילבר עושה סדר עם סינגל חדש ומסקרן ''חפר''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "אמיתי שוקר שר עם יהודה מימרן הי''ד ''ארץ הקדושה''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}, {"start": 17, "end": 28, "label": "SINGER"}]}
+{"text": "בועז שטרן בסינגל חדש לט''ו בשבט ''אברכך''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "טל אלבז מפתיע ומשחרר סינגל חדש בסטייל השמור רק לו ''מודים''", "entities": [{"start": 0, "end": 7, "label": "SINGER"}]}
+{"text": "אהרן טויסיג בשיר תפילה לאורי דנינו החטוף בעזה ''תן לי כח''", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "לידור בן ישי בסינגל עוצמתי ומחבר ''אל תוותר''", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "ארגון סיון זרחיה משיקים לקראת הילולת רבי יצחק אבוחצירא זצ''ל מחרוזת פיוטים לכבוד הצדיק", "entities": [{"start": 6, "end": 16, "label": "SINGER"}]}
+{"text": "להקת כוונה מגיש סינגל חדש ''ניגון תו אחד'' 'One Note Niggun'", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "אבידן פרוז עם סינגל חדש ואופטימי ''להמשיך''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "האחים כליף מגיש שיר סינגל-תפילה חדש להארה לכל היהודים באשר הם ''המנורה''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "אוראל אריאלי בסינגל בכורה ''עמדי''", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "זאנוויל וויינברגר במחרוזת י''ב הפסוקים", "entities": [{"start": 0, "end": 17, "label": "SINGER"}]}
+{"text": "יואלי יוסט ואיתן דהן ''נאר ער קען''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "עתי עוזרי בסינגל חדש השנה השחורה", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "שמואל מדאלסי ואביטל אביסדריס בסינגל חדש ''בואי לגני''", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "הדף היומי מסכת בבא קמא דף ע''ח - ע''ט שבט תשפ''ד - שיעור בעברית מאת הרב אבירן דיאמנט הי''ו מקול חי", "entities": [{"start": 72, "end": 84, "label": "SINGER"}]}
+{"text": "מוסא ברלין בסינגל חדש ומושקע עם בנו ''אליך נשאתי''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "אהוד בלוקה שר ''ושלמו'' של הרב שוע קסין בלייב", "entities": [{"start": 0, "end": 10, "label": "SINGER"}, {"start": 31, "end": 39, "label": "SINGER"}]}
+{"text": "לירן דוד מכניס אתכם לקצב ''טיק טאק''", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "שחרי שניידר עם שיר חדש ''אל אדון''", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "מקהלת 'פרחי שמים' בסינגל חדש באווירת המלחמה ''אהובי''", "entities": [{"start": 7, "end": 16, "label": "SINGER"}]}
+{"text": "יצחק כרמלי בסינגל חדש לרגל ט''ו בשבט ''אילן''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "ליאון שאול חוזר בסינגל חדש בשם ''באור שלך''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "אברהם דוד ורצברגר בביצוע מרגש ''אבינו מלכנו'' מתוך מופע 'צמאה'", "entities": [{"start": 0, "end": 17, "label": "SINGER"}]}
+{"text": "שרית בק בסינגל חדש לאור הצלת בנו ''ברכו''", "entities": [{"start": 0, "end": 7, "label": "SINGER"}]}
+{"text": "גבריאל טרטקובסקי מנגן ושר ''תן לי תפילה''", "entities": [{"start": 0, "end": 16, "label": "SINGER"}]}
+{"text": "צבי וויס בביצוע חדש ''אחינו''", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "רגב עובדיה בביצוע לייב לשיר ''טועמיה''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "גיל מנדלזיס בטוויסט אנרגטי ללהיט הישראלי ''מתחיל בצעד''", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "בארי גריינימן, חיים אלטר ורן נוסן במחרוזת ''קידושא רבא''", "entities": [{"start": 0, "end": 13, "label": "SINGER"}, {"start": 15, "end": 24, "label": "SINGER"}]}
+{"text": "יונה הלר מפתיע בסינגל מלחמה חדש ''קרב יום''", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "כרמל אוסישקין בשיר מחזק לימים אלו ''להחזיק חזק''", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "חנניה סמוליאנסקי בסינגל חדש ''בידך''", "entities": [{"start": 0, "end": 16, "label": "SINGER"}]}
+{"text": "הדף היומי מסכת בבא קמא דף ע''א - ע''ב שבט תשפ''ד - שיעור בעברית מאת הרב אליהו מושקוביץ הי''ו מקול חי", "entities": [{"start": 72, "end": 86, "label": "SINGER"}]}
+{"text": "יוני גמרמן בסינגל הבכורה  ''לך אבא''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "פנואל כצבאך בשירו 'היי זה הזמן' בלייב", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "זיו קרבצוב בקאבר אלקטרוני מקפיץ לשיר ''זכרני נא''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "ארי רויטמן בסינגל חדש ''יהא רעווא''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "אהרן פרידמן בסינגל חדש ''ניגון מוישי''", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "דוד גדסי בביצוע נוסטלגי ''הרחמן הוא ינחילנו''", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "מנור רוזנבאום בסינגל חדש מעומק הלב ''רק עוד ניגון''", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "אליסף סמואל הרעיד את מוצ''ש חי בראיון מרתק", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "בצלאל ברגמן שמחה הלפגוט וארלה סאמט וזינגערליך בביצוע מרשים ''כה אמר''", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "אבישי מארח את ארי צוקר ''אלוקי נשמה''", "entities": [{"start": 14, "end": 22, "label": "SINGER"}]}
+{"text": "שלמה גורפינקל בביצוע לייב לשיר ''ידי''", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "אלימלך ורנר משחרר ''נאר מיט אמונה''", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "עופר האואר משחרר סינגל חדש ''בסוף זה יבוא''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "הדף היומי מסכת בבא קמא דף ס''ד - ס''ה טבת תשפ''ד - שיעור בעברית מאת הרב שנהב פינסקי הי''ו מקול חי", "entities": [{"start": 72, "end": 83, "label": "SINGER"}]}
+{"text": "יהב חנינה מגיש שוב סט שירי שבת מובחרים 4 מחרוזת חסידית משובחת (שעתיים)", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "יואל קרמר, דן עדיקא, אלישי שפיצר ב'קוֹלַעוֹילֶם' ''שכוייח''", "entities": [{"start": 21, "end": 32, "label": "SINGER"}, {"start": 0, "end": 9, "label": "SINGER"}, {"start": 11, "end": 19, "label": "SINGER"}]}
+{"text": "בן-ציון שנקר וישיבת 'אורות שאול' ''ממקומך'' (שנקר)", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "דן גזולי בסינגל חדש ''שיהא זרעי''", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "אליסף מימון בסינגל חדש ''מחכה לשקט''", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "בן זוהר ומקהלת הילדים שבח ''להתוודע''", "entities": [{"start": 0, "end": 7, "label": "SINGER"}]}
+{"text": "דניאל פלצמן (קלרינט) ושמוליק הופמן (קלידים) ב''מחרוזת נעימות'' חלק א'", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "אמרי רוזנטל וחניאל בראונשטיין בקאבר נוסטלגי ''שאו מרום''", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "דוד חסקלסון ילדי קעמפ אגודה זעקו בקולולם ''אני רוצה להיות ירא שמים''", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "האחים ברונר בסינגל חדש באידיש ''אכן''", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "ר' יצחק גולדקנופף נטע מרקו ומקהלת הילדים במחרוזת גאולה בשמחת בית גור", "entities": [{"start": 18, "end": 26, "label": "SINGER"}]}
+{"text": "אליאור גמליאל ויששכר ברוכשווילי בדואט ייחודי Unstoppable (בלתי ניתן לעצירה)", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "קדוש סלומוביץ, אלאור דאר, אהר'לע סאמעט - יאאא די די", "entities": [{"start": 0, "end": 13, "label": "SINGER"}, {"start": 15, "end": 24, "label": "SINGER"}]}
+{"text": "צור צוקר שר לרגל יום השנה הראשון של הרב בעדני זצוק''ל ''שור נא אבי''", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "יהושע פריד פורץ עם סינגל בכורה ''בשעה טובה''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "אפק גולדשטיין משיק אלבום חדש בראיון ומופע אולפן מיוחד צפו - רדיו", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "מנשה פטמן ויתיר הרשקו בדואט Silent Cries (בכי חרישי)", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "חיים גולד בסינגל חדש פרי לחנו ''יראו עינינו''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "הדף היומי מסכת בבא קמא דף נ''ז - נ''ח טבת תשפ''ד - שיעור בעברית מאת הרב שלמה כץ הי''ו מקול חי", "entities": [{"start": 72, "end": 79, "label": "SINGER"}]}
+{"text": "אליהו פסטרנק בקאבר ללהיט של אביב ספיבק ''שבורי לב''", "entities": [{"start": 28, "end": 38, "label": "SINGER"}, {"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "מרדכי רזייב בשיר מלחמה חדש ''לא לפחד''", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "עידן עמדי בסינגל חדש ''התנערי''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "אלישיב וההופעה ויחזקאל מנחם בקאבר נוסטלגי ''התמונות שבאלבום''", "entities": [{"start": 0, "end": 14, "label": "SINGER"}]}
+{"text": "עיליי אבן בסינגל חדש שיר ''הקדיש''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "נבות קליינברג בסינגל חדש מצפים", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "הרב אלרן מלאכי מגיש לכבוד החתונה בגור ''ובשירי דוד''", "entities": [{"start": 4, "end": 14, "label": "SINGER"}]}
+{"text": "תבל גוטליב בשירו ''אנשים כמלאכים'' מתוך אלבומו השגות", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "נחמיה לויה ברוח הימים במחרוזת ''רפאנו''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "שון אפרת בדרך לאלבום הבכורה מגיש סינגל חדש ''אחים'' (בכל מצב)", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "שוהם אלקלעי ורום זוזל ביצירה מצמררת על השואה ''גולדי'ס געשיכטע''", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "אורי דווידי ואוריאל דויטש בדואט מרגש ''שמור נא עלינו''", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "ליאב הייטנר מרגש בשיר ''קה אכסוף''", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "מקהלת רננים בסינגל חדש ''מעורר את הלב''", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "אלחנן לוינגר אביעד ביטון ודותן דובדבני בסינגל מקפיץ ''הממליך מלכים''", "entities": [{"start": 13, "end": 24, "label": "SINGER"}, {"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "שמואל גרינברג מאיר צורטקוב ויובל ואזנה במחרוזת מחווה לאלרן אמזלג", "entities": [{"start": 14, "end": 26, "label": "SINGER"}, {"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "ג'ואי יקיר רחמים סוחף בסינגל חדש ''ר' שעיה בן ר' משה''", "entities": [{"start": 6, "end": 16, "label": "SINGER"}]}
+{"text": "יונה סעדון בסינגל חדש ''רבי, הכל ממך''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "יצחק קופרמן מבצע מחרוזת עם מיטב הקלאסיקות של נועם כהן", "entities": [{"start": 0, "end": 11, "label": "SINGER"}, {"start": 45, "end": 53, "label": "SINGER"}]}
+{"text": "שוהם עמר בסינגל נוסף ''תן לגשם''", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "חברי אהרון טויסיג נפגשו לביצוע עם ''א גלעזל ויין''", "entities": [{"start": 5, "end": 17, "label": "SINGER"}]}
+{"text": "תומר רוזנצויג במופע תפילה ונחמה במוצ''ש חי", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "עתי אליהו השיק להיט ענק לכבוד הילולת מוהרנת מברסלב ''הבער אותה''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "הדף היומי מסכת בבא קמא דף נ' - נ''א טבת תשפ''ד - שיעור בעברית מאת הרב איתן אחרק הי''ו מקול חי", "entities": [{"start": 70, "end": 79, "label": "SINGER"}]}
+{"text": "יחזקאל רוטנברג מתחנן לגאולה בסינגל חדש ''הגלה נא''", "entities": [{"start": 0, "end": 14, "label": "SINGER"}]}
+{"text": "נרייה ציובוטרו בביצוע לייב ''כשמשיח יגיע''", "entities": [{"start": 0, "end": 14, "label": "SINGER"}]}
+{"text": "ישראל ברגמן בחידוש לשיר ''אני מאמין''", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "ישראל גוריון משחרר מתוך אלבומו הבכורה שיר הנושא ''מזמור לדוד''", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "חיים ברוין במחרוזת מקבצת את טובי שירי ''ירושלים והגאולה''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "יעקב בן-יהודה בסינגל חדש ''התעוררי''", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "זוהר קליינר מחדש את שירו של פריד You’re Never Alone (לעולם אינך לבדך)", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "הרב עופרי טוביאנה בשיר חיזוק בעקבות המלחמה ''חוסה ה' עלינו''", "entities": [{"start": 4, "end": 17, "label": "SINGER"}]}
+{"text": "בנימין אטיאס בסינגל חדש בצל המלחמה ''אנא השם''", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "פנחס שינפלד ואליקים ביננשטוק שרים יחד עם אלפי המשתתפים את הניגון החבד''י ''הגלה נא''", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "אושיק ברוקמן בלהיט חדש ''רוצים גאולה''", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "פינקי וובר באלבום בכורה חסידי מושקע ''מזמור לדוד'' - דוגמה", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "שלמה סווינקין וישיבת אש התלמוד ב'שירושיר' השנתי המסורתי ''שנשתוקק''", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "מורן טרנובסקי עופר ז'ורנו וגיורא אליהו ביצירה חדשה ומיוחדת ''תפילת הדרך''", "entities": [{"start": 14, "end": 25, "label": "SINGER"}, {"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "שמולי הורוויץ דניאל לוי ושמילי לאנדא בסינגל טריו קצבי ''שלא עשני גוי''", "entities": [{"start": 0, "end": 13, "label": "SINGER"}, {"start": 14, "end": 23, "label": "SINGER"}]}
+{"text": "שעיה היטמן בסינגל ראשון מהאלבום שבדרך ''מודה אני''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "הרב מאיר טוביה פולק בסינגל בכורה ברוח התקופה ''מספד של ילד''", "entities": [{"start": 0, "end": 19, "label": "SINGER"}]}
+{"text": "שניר בלסקי כהן מארח את בן עמוס בסינגל חדש ''למקדשך''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}, {"start": 23, "end": 30, "label": "SINGER"}]}
+{"text": "אורי חיזקיה ואור שפייר שרים 'חשוף'", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "ריין ספיבק בסינגל מיוחד לחנוכה ''באור''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "אושרי קשתי מחדש את הלחן של קרליבך ''מי כמוך''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "לישי מיכאלי בלהיט אופטימי ''שבוע טוב יותר''", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "אלדד פלד וישכר גולדין עם מיטב הלהיטים שלהם במחרוזת ענק", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "רפאל נחשון משחרר ''וגר זאב עם כבש'' מתוך אלבומו החדש 'מזבח אדמה'", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "ארד רוקח וידידיה בלומנפלד ומונה בביצוע לייב לקל אדון של באבוב", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "ראובן יזדיאן בביצוע מדהים ''יוונים'' עם הגיטרה לכבוד חנוכה", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "גבי פרנקיל בסינגל ''ברענט לעכטעלע ברענט''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "יוחנן שמואל מגיש סינגל חדש לחנוכה ''על הניסים''", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "אפרים חן ואבי אלבאז לקראת חיתום החג ''ראחמיסטריווקא חנוכה ניגון''", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "איזי פלודבינסקי במחרוזת הלל ייחודית", "entities": [{"start": 0, "end": 15, "label": "SINGER"}]}
+{"text": "מלאכי סויסה וגד צבר במחרוזת הלל", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "גוריון נוביק בסינגל - מנורה", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "אופיר שריד - חנוכה ניגון (קאבר)", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "יעקב יאנג עם חידוש לניגון העתיק ''מעוז צור''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "דורי ישראל בני פלוט ואוהד הרוש במחרוזת ייחודית", "entities": [{"start": 11, "end": 19, "label": "SINGER"}, {"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "אוריאל בוקובזה ושמואל ויס במחרוזת בית המקדש", "entities": [{"start": 0, "end": 14, "label": "SINGER"}]}
+{"text": "יריב אשתר בסינגל חדש ''אפשר לתקן''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "יאיר דולגין מוציא מחרוזת חנוכה מגוונת", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "אופק ברכץ ואלקנה מבצעים ''לראות את האור''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "יששכר שמואל בוקשפן ודוד פינק מגישים ''לא אמות כי אחיה''", "entities": [{"start": 0, "end": 18, "label": "SINGER"}]}
+{"text": "מלאכי אגאי בסינגל על המצב ''שדה עקרב''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "טוהר חסון מגיש אוסף שירים חסידים לחג החנוכה (שעה ועשרים)", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "יהודה אזולאי ביצירה לכבוד חנוכה ''באלייכט אלע וועלטן''", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "רזיאל גניאל בסינגל חדש ''מנורה'לע''", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "גלי ווקנין בסינגל חנוכה חדש ''פייערל''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "זוהר דרומי מגיש מחרוזת חנוכה מושקעת תשפ''ד", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "חנוך אלטמן בסינגל חדש ומרגש ''חשוף''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "אביבה סמדר וילד הפלא יאיר שריון שרים ''חשוף''", "entities": [{"start": 21, "end": 31, "label": "SINGER"}, {"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "דקל יעל מרגשים לכבוד חנוכה ''מעוז צור''", "entities": [{"start": 0, "end": 7, "label": "SINGER"}]}
+{"text": "בני מקמל מרגש במיוחד לחנוכה לחן חדש ל''חשוף''", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "מרדכי דהאן מארח את מוטי רוטמן ''יסים ונפלאות''", "entities": [{"start": 19, "end": 29, "label": "SINGER"}, {"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "11 רחמי שמים וידידים בביצוע אדיר לחשוף של עוזי ניסנוב", "entities": [{"start": 3, "end": 12, "label": "SINGER"}, {"start": 42, "end": 53, "label": "SINGER"}]}
+{"text": "13 עמירם שחר, ליאון מישקובסקי, שמעון דז'יגאן ורובין קניגסברג מנורה", "entities": [{"start": 3, "end": 12, "label": "SINGER"}, {"start": 14, "end": 29, "label": "SINGER"}, {"start": 31, "end": 44, "label": "SINGER"}]}
+{"text": "14 שמחה דיין - הנרות הללו", "entities": [{"start": 3, "end": 12, "label": "SINGER"}]}
+{"text": "09 אלן צימבלר וילד הפלא בשיר לחנוכה ולעמך ישראל", "entities": [{"start": 3, "end": 13, "label": "SINGER"}]}
+{"text": "15 זאב אגרונוב - בעט ניסים", "entities": [{"start": 3, "end": 14, "label": "SINGER"}]}
+{"text": "21 שאול ידלין - מחרוזת חנוכה - ליייב", "entities": [{"start": 3, "end": 13, "label": "SINGER"}]}
+{"text": "19 נאור כרמי ונריה בר במחרוזת חנוכה", "entities": [{"start": 3, "end": 12, "label": "SINGER"}]}
+{"text": "22 דוד רוזנפלד אייל נוקד הכהן וגדולי הזמר במחרוזת ''חנוכה ליכט''", "entities": [{"start": 15, "end": 29, "label": "SINGER"}, {"start": 3, "end": 14, "label": "SINGER"}]}
+{"text": "12 עקיבא בן חמו, אהר'לע סאמעט, יצחק ברכה, מורי רחמים - מיין לעכטעלע", "entities": [{"start": 31, "end": 40, "label": "SINGER"}, {"start": 42, "end": 52, "label": "SINGER"}, {"start": 3, "end": 15, "label": "SINGER"}]}
+{"text": "07 יענקי לעממר שר את היצירה של החזן יעקב יצחק רוזנפלד לחנוכה", "entities": [{"start": 36, "end": 53, "label": "SINGER"}]}
+{"text": "16 שיר מעודה ויריב הרוש עם גרסה מקפיצה לעל הניסים", "entities": [{"start": 3, "end": 12, "label": "SINGER"}]}
+{"text": "06 אודי אבוג'דיד ושלו רכטמן - דער מגידס מנורה", "entities": [{"start": 3, "end": 16, "label": "SINGER"}]}
+{"text": "08 קדם ראובן ודין ליפשיץ מבצעים ''הנרות", "entities": [{"start": 3, "end": 12, "label": "SINGER"}]}
+{"text": "17 מיוחד ל-זאת חנוכה אפק שפר מגיש - הנרות הללו", "entities": [{"start": 21, "end": 28, "label": "SINGER"}]}
+{"text": "10 ראם יצחק - די דריידל ניגון", "entities": [{"start": 3, "end": 11, "label": "SINGER"}]}
+{"text": "20 עמירם ירוחם, גל פריד , אדוארד הדר, מיכאל ווייס & שמריהו מסיקה ב''מזמור שיר - מחרוזת חנוכה''", "entities": [{"start": 3, "end": 14, "label": "SINGER"}, {"start": 52, "end": 64, "label": "SINGER"}, {"start": 38, "end": 49, "label": "SINGER"}, {"start": 26, "end": 36, "label": "SINGER"}, {"start": 16, "end": 23, "label": "SINGER"}]}
+{"text": "02 סאן טאובר ובניהו פולק בביצוע לחנוכה ''הנרות הללו''", "entities": [{"start": 3, "end": 12, "label": "SINGER"}]}
+{"text": "05 יפתח גולד, יוסף דניאל, אהרון ישראל, עילאי רוטביין - חשוף", "entities": [{"start": 3, "end": 12, "label": "SINGER"}, {"start": 14, "end": 24, "label": "SINGER"}, {"start": 26, "end": 37, "label": "SINGER"}, {"start": 39, "end": 52, "label": "SINGER"}]}
+{"text": "01 לראות בנים - הלהיט החדש של אורין ברמן וסיני ברנע", "entities": [{"start": 30, "end": 40, "label": "SINGER"}]}
+{"text": "03 אפרים כרמון וזלמן שטוב בחידוש מרגש ''מעוז צור''", "entities": [{"start": 3, "end": 14, "label": "SINGER"}]}
+{"text": "דניס אדם עם מחרוזת של מיטב שירי חג החנוכה", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "ליאו אלפסי מודה על הנס בשיר חדש ''על הניסים''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "ים צנוירט משחרר לקראת חנוכה ''הנרות הללו''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "יונתן שלגבוים רייכמן ואפיקו.מן במחרוזת שירי חנוכה אפ-מיקס", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "אילן מזרחי בסינגל חדש לחנוכה ''כדי להודות''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "עוזי מלר פנחס צונדק וגדולי הזמר במחרוזת ''חנוכה ליכט''", "entities": [{"start": 9, "end": 19, "label": "SINGER"}, {"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "אביב הדס וגילה מנדלבאום ובלטי עם מחרוזת ''צמאה'' של חב''ד", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "מנדי ווארש ואילן אטדגי מחדשים הניגון העתיק ''אַ ירוּשׇׁלַימֶער טַאנְץ''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "יהודה צייק בשיר חדש שמתאר את הימים בתקופה האחרונה ''לא אירא רע''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "גד מידלר מגיש סינגל מרגש ''עלה''", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "חנן גבאי סחף מול אלפים עם הלהיט ''עברו בשערים''", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "גל אורן וחי קארו בביצוע משותף ליצירה ''סם שפילט'' (Sam Shpielt)", "entities": [{"start": 0, "end": 7, "label": "SINGER"}]}
+{"text": "שמוליק גפנר בקאבר לבן זימט ''חשוף''", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "עפרה חזה בביצוע כינור לשיר ''הצילני נא'' (קטונתי)", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "מקהלת הילדים שיר הלל והלהקה במחרוזת חדשה של שירי תפילה וגאולה", "entities": [{"start": 0, "end": 20, "label": "SINGER"}]}
+{"text": "חנניה ממיה עם מחרוזת ''ליל חנוכה''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "ר' כפיר רינגל הי''ו ב''גראמען'' במעמד סיום חצי ש''ס", "entities": [{"start": 3, "end": 13, "label": "SINGER"}]}
+{"text": "הרב עמינדב קוטובסקי בביצוע מחודש להניגון הגדול של רבי הלל מפאריטש", "entities": [{"start": 4, "end": 19, "label": "SINGER"}]}
+{"text": "צוריאל רחמים, יוסף בנישו, ניק מנדלסון ויוסף צבי ''ביום ההוא''", "entities": [{"start": 26, "end": 37, "label": "SINGER"}, {"start": 14, "end": 24, "label": "SINGER"}, {"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "גור גרדנה & תמיר זילברמן ''אני עמהם''", "entities": [{"start": 12, "end": 24, "label": "SINGER"}, {"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "יקיר אטיאס חיליש בריכטא והחברים לכבוד חג הגאולה  ''פדה בשלום''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "חנוך אטיאס מגיש סינגל חדש ''לא מפחדים''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "ג'וליאן ויינברג מבצע את היצירה של אריה קסורלה ''ישתבח''", "entities": [{"start": 34, "end": 45, "label": "SINGER"}, {"start": 0, "end": 15, "label": "SINGER"}]}
+{"text": "יניר קילינסקי מארח את מקהלת חיפה לדואט משותף ''כי בשם קדשך''", "entities": [{"start": 0, "end": 13, "label": "SINGER"}, {"start": 22, "end": 32, "label": "SINGER"}]}
+{"text": "ליאו אפל בשיר מרגש למען החטופים ''ושבו בנים''", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "רפאל שאול ורוני רומי בדואט מקפיץ ''ותמיד נספר''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "הרב עקיבא קנדלקאר בלחן חדש בביצוע יהודה שפירא ומנשה ברנר ''בתמימות''", "entities": [{"start": 4, "end": 17, "label": "SINGER"}, {"start": 34, "end": 45, "label": "SINGER"}]}
+{"text": "שיאל סילמן בסינגל חדש ''אור באפלה''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "שמי מרציאנו יוצא בסינגל שני מקורי ''בשיר חדש''", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "שרון רוזנבלום ויאיר אליאס במחרוזת ''שירי רפואה''", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "רחמים ירושלמי בקאבר משובח ללהיט ''אתה זוכר''", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "שלמה לוונשטיין וירין שניידר בדואט לייב ''אתה זוכר''", "entities": [{"start": 0, "end": 14, "label": "SINGER"}]}
+{"text": "רעם גורמן ונמרוד ריינר במחרוזת שירי פאנק", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "אליחי אגיב בסינגל חדש של תפילה לימים אלו ''ארדוף אויבי''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "ישעיה מסיקה מתפלל במחרוזת ''אחינו''", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "עמרם רוזן משחרר היום (שני) סינגל חדש עוצמתי ומרגש בשם ''הכל יעבור''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "יוסף וולטרסקי מבקש בסינגל חדש ''בקרוב ממש''", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "רונאל חסון בסינגל חדש ''קשר של קיימא''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "אביעד אגיב אבירן אלמקייס בשירת המונים ''רחם''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}, {"start": 11, "end": 24, "label": "SINGER"}]}
+{"text": "ארמונד סוסנה ואביחי סולומון בדואט מרגש ''לב של אמא''", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "פנחס כהן מארח את מכלוף יעקובוביץ' ואבישי פלד ''חמשה קולות''", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "אלכסנדר מוקדון בסינגל מרגש ''גם כי אלך''", "entities": [{"start": 0, "end": 14, "label": "SINGER"}]}
+{"text": "אפרים ביתאו' בסינגל בכורה ''נקודה טובה''", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "אסף בר בשיר מצמרר לנוכח המצב ''תחזור הביתה''", "entities": [{"start": 0, "end": 6, "label": "SINGER"}]}
+{"text": "אביאל חן בסינגל חדש לרגל שמחת חתונת ''תדבק''", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "ניסים יזקאל ואלקנה וולפסון ב'שירה נעימה' בדינר שומרי החומות תשפד", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "יוסי מאייער שר לכבוד שבת קודש ''לכה דודי'' (מודז'יץ)", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "אלכסנדר יוסופוב בשיר בכורה בעקבות המצב ''חרבות של ברזל''", "entities": [{"start": 0, "end": 15, "label": "SINGER"}]}
+{"text": "עדן אגסי מגיש סינגל חדש בשם ''קינדערלעך''", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "ר' רמי אביבי בסינגל חדש ''ווען נישט קרית יואל''", "entities": [{"start": 3, "end": 12, "label": "SINGER"}]}
+{"text": "צחי והבה  שמואל אביטל וגדי בלטמן בסינגל חדש ''וואו ביסטו''", "entities": [{"start": 0, "end": 8, "label": "SINGER"}, {"start": 10, "end": 21, "label": "SINGER"}]}
+{"text": "שלומי טוסיג שר ומרגש בחופה", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "טנא שלומי בסינגל באווירת הימים למשפחות החטופים ''ליבי ער''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "משה ושמעון הערשאפט ירין אייזנבך ואנשי 'נקודה טובה' בלהיט מלחמה החדש ''הצילני''", "entities": [{"start": 19, "end": 31, "label": "SINGER"}]}
+{"text": "אליהו בבאי בסינגל חדש ומושקע ''איך בין א העלד'' (אני גיבור)", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "מישאל מרציאנו ומרדכי ווברמן בדואט חדש בעקבות המלחמה '' השתוקקות''", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "מאיר ריבקין בסינגל חדש ''ככה מנצחים''", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "מקהלת הילדים 'קורן שוייגר' בסינגל חדש לזכרו של ראש הישיבה ''התעוררי''", "entities": [{"start": 14, "end": 25, "label": "SINGER"}]}
+{"text": "חיים ישעיה ווייל ויוחאי קנטור שרים ''הגלה נא''", "entities": [{"start": 0, "end": 16, "label": "SINGER"}]}
+{"text": "רגב משהדי בסינגל מחזק ''עם הנצח''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "ירון אזוגי בסינגל חדש ומלא תקווה ''נר דולק''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "אדי בן-גיגי בוכה בסינגל כואב ''אין נחמה''", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "זיו נפומניאשצ'י קיים תפילה מוזיקלית למען החטופים מול הבית הלבן", "entities": [{"start": 0, "end": 15, "label": "SINGER"}]}
+{"text": "ניל מעוז בביצוע מרגש ללהיט הנוסטלגי ''אחינו''", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "ויקטור אנדועלם וחברים בפרוייקט מחזקת אמונה וניצחון 1", "entities": [{"start": 0, "end": 14, "label": "SINGER"}]}
+{"text": "חיים דב בער מוישי באנדא וספיר חוזה ''לכבוד החתן''", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "ברק מור בסינגל חדש בהשראת התקופה ''אני מאמין''", "entities": [{"start": 0, "end": 7, "label": "SINGER"}]}
+{"text": "אלעד אלנתן ומשה גרין בשיר מחזק ''אזעקות של אמונה''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "בניהו רייספלד בסינגל חדש ''נופל וקם''", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "עמרם אקער וארן שורץ בתוכנית שרים בסלון - הידברות", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "אביב צימרמן מפתיע בגרסת האידיש ''מלחמת גוג ומגוג''", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "חילי גענוד בסינגל שהלחין ועיבד בעצמו ''כי אתה עמדי''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "שקד רותם ונועם פראנקל בתוכנית שרים בסלון - הידברות", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "נחמיה כרמלי פונה בסינגל חדש ''אם תבקש להיות חבר שלי''", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "מקהלת אריאל וגדליה סלושי מחדשת את שירו של נתנאל שבת ''שמע ישראל''", "entities": [{"start": 0, "end": 11, "label": "SINGER"}, {"start": 42, "end": 51, "label": "SINGER"}]}
+{"text": "ברוך בר בסינגל חדש ומעודד לימים אלו ''התעוררי''", "entities": [{"start": 0, "end": 7, "label": "SINGER"}]}
+{"text": "שמעיה קדוש בסינגל עידוד חדש ''לא מפחד''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "זכריה וונה ואילעי אלוני בתוכנית שרים בסלון - הידברות", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "בניה מילוא בשיר אנחנו עומדים עם ישראל - We Stand With Israel", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "לירון כרקוקלי ואברום לייב בורשטיין עם היצירה שנכתבה אחרי הפוגרום בעיירה", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "יהלי פרנקל ומשה זוהר בביצוע מחודש ''לא תנצחו אותי''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "עילי שניר בסינגל חדש ''תהיה מלא תקווה''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "מאיר צ'טרקוב במשדר מרגש מביתו 'מאמינים בניסים'", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "אבירן שדה משחרר מחרוזת אינסטרומנטלית ל'חג החנוכה'", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "ישעיה מלמד בשיר זעקה אל הקב''ה ''למה''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "קורן שיר מגיש 'טרק הניצחון' שירי חיזוק ואמונה", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "דניאל גרוס מגיש סינגל חדש ''ערימות געגועים''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "הרב אביר קמפה ועוד בקומזיץ מרגש בישיבת מערבא מוצ''ש חי", "entities": [{"start": 4, "end": 13, "label": "SINGER"}]}
+{"text": "אלאורי בויאר בסינגל בכורה ''בעזרת ה' ביחד ננצח''", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "שלמה יואל בסינגל מלא חיבוק וגעגוע לחטופים ''ואם פתאום''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "חנן רבינוביץ מגיש בעיצומם של ימי המלחמה את שירו ''אהבת חינם'' - גרסת הרמיקס", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "סער גבעון ואחיה הכהן בתוכנית שרים בסלון - הידברות", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "מתנאל מלב מארח את סימן טוב ברדוגו ''כל העולם בשבילי''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}, {"start": 18, "end": 33, "label": "SINGER"}]}
+{"text": "יום פיין בסינגל בסגנונו היחודי ''דרך מלך''", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "אשר ברדה בהופעה מרגשת באולפן - שרים בסלון - הידברות", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "מיכאל טייטלבוים ועובדיה הוניגמן במוצ''ש חי בצל המלחמה", "entities": [{"start": 0, "end": 15, "label": "SINGER"}]}
+{"text": "זיו כנען בסינגל ביתי ''העולם הבא''", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "כתריאל ישראלזון מארח את נמואל ארוש שרים בסלון - הופעה מרגשת באולפן - הידברות", "entities": [{"start": 24, "end": 34, "label": "SINGER"}, {"start": 0, "end": 15, "label": "SINGER"}]}
+{"text": "דיאנה גולבי ולוטם גרוזמן מתחננים ''אבא תרחם''", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "מלך זילברשלג בסינגל חדש ''תמיד''", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "בר בלום בסינגל לזכר הנרצחים ''קהילות הקודש''", "entities": [{"start": 0, "end": 7, "label": "SINGER"}]}
+{"text": "יהודה מנהיים מארח את שמואל שרים בסלון - הופעה מרגשת באולפן - הידברות", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "אלי מרקוס לרגל ה'שלושים' בשיר מצמרר ומרגש לזכר הקדושים ''ארץ אל תכסי דמם''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "יוני Z (זיגלבוים)וואג ואיצי קפלוביץ מבקשים ''אנא ה' עננו''", "entities": [{"start": 0, "end": 6, "label": "SINGER"}]}
+{"text": "ענבר ידיד בסינגל חדש ''אם אשכחך ירושלים''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "בנימין אליאס במחרוזת חיזוק ותפילה", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "דיויד טויב שר ''מילה של נחמה''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "גילי גמליאל שר את להיט המלחמה ''השם ישמור''", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "ישראל קצובר וטל שגב בשיר תודה ''הודו להשם''", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "חגי גרינבוים בסינגל חדש ''בקרוב ממש''", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "אופיר פדלון ומקהלת הרצל חברוני בקומזיץ מחזק ומרומם", "entities": [{"start": 0, "end": 11, "label": "SINGER"}, {"start": 19, "end": 30, "label": "SINGER"}]}
+{"text": "צור שרון מרגש בתקווה לגאולה ולישועה עם סינגל חדש ''לישועתך''", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "האסק וידידים ב'מחרוזת דדי' מחווה לבניהו מיכאלי ז''ל", "entities": [{"start": 0, "end": 4, "label": "SINGER"}]}
+{"text": "יצחק יהודה פלטשק מגיש ברקע המצב ביצוע מיוחד ''פרוק ית ענך''", "entities": [{"start": 0, "end": 16, "label": "SINGER"}]}
+{"text": "נחמן קסוס וירדן פלטה בסינגל חדש ''חברות-ברזל''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "סלע אלבז שרים בסלון - הופעה מרגשת באולפן - הידברות", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "שילה שפרוני מארח את ריש גלותא ברוח הימים ''עד הסוף''", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "אמיר אליהו בשיר תפילה חדש ''אבא תראה''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "ריי קצב בסינגל לכבוד בר המצווה של בנו ''מי כעמך ישראל''", "entities": [{"start": 0, "end": 7, "label": "SINGER"}]}
+{"text": "אלרועי אוקנין ארנון שרעבי ומיכאל כדורי בהופעה מרגשת ''שרים בסלון''", "entities": [{"start": 14, "end": 25, "label": "SINGER"}, {"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "מרק לנדסמן מרגש שוב ''מוציא אסירים'' (קרליבך)", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "פרחי טורנטו ואבי גולדשמיט בביצוע מרגש ללהיט ''תן לי תפילה''", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "אוראל לאסרי בסינגל חדש שהלחין במלחמה ''ושבו בנים''", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "משה דאודי בסינגל של תפילה ''דבר אלי''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "תם מורדכייב ושמחה שור בשיר הודיה ''קלי אתה ואודך''", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "גד אורינובסקי משחרר סינגל חדש ושקט ''הדרך בחיי''", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "סתיו המילטון ושגיא לבקוביץ בזעקה שפרצה ''בכל מקום''", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "נחל עבד במופע לייב לרגל המצב", "entities": [{"start": 0, "end": 7, "label": "SINGER"}]}
+{"text": "גדעון ג'יאמי בסינגל חדש ומרגש ברוח התקופה ''נותן לי את הכוח''", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "עומר ונונו בסינגל חדש לרגל המצב ''שומר ישראל''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "נוגה טאובה בביצוע מרגש ''מאמע רחל''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "דוד היל ואביחי דורי בעקבות המצב ''מחרוזת תפילה''", "entities": [{"start": 0, "end": 7, "label": "SINGER"}]}
+{"text": "חיים מרדכי פייערווערגר ואמיתי דיסקינד בסינגל לקראת הילולת רחל אמנו ''ושבו בנים''", "entities": [{"start": 0, "end": 22, "label": "SINGER"}]}
+{"text": "מרום דלמן קאבר מרגש ללני ברזילי ''מאמע רחל''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "הילל דנה בשידור שרים אמונה - שידור חוזר", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "הרב דוד חסין הי''ו בשיר חדש בשם ''רפאנו השם''", "entities": [{"start": 4, "end": 12, "label": "SINGER"}]}
+{"text": "שרגא הדס בביצוע אינסטרומנטלי מרגש ''אחינו''", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "עידן טנדלר במסר לעולם ''ירושלים הבנויה''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "חביב צימרמן ואליסף אטיאס שרים אמונה", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "רז בלילתי וברי הירשמן ''לקראת שבת''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "אלישיב הלל מגיש ניגון גוט שבת", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "ידידיה שפירא בשיר מלא אמונה חדש ''עולה תפילה''", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "רפאל ברדיצ'בסקי מקפיץ עם הלהיט החב''די ''עוצו עצה''", "entities": [{"start": 0, "end": 15, "label": "SINGER"}]}
+{"text": "זאב שמעון מפתיע בסינגל חדש לתקופה המטלטלת ''שם איתי''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "אליעזר קאליש משחרר סינגל המתאים במיוחד לימים אלו ''האירה פניך''", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "חיים מרדכי עקשטיין ואלקנה פרוים חנה רפפורט שרים אמונה", "entities": [{"start": 0, "end": 18, "label": "SINGER"}, {"start": 32, "end": 42, "label": "SINGER"}]}
+{"text": "אהרן שפיצר בשיר תפילה בעקבות המצב ''בשורות טובות''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "חגית דויטש בצל המלחמה נותן תקווה בשיר חדש ''גם זה יעבור''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "אוראל מטוסוב ולהקת משאלות מרימים את המורל בשירי אמונה של ניצחון חלק א'", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "אופיר מוסקוביץ ורזיאל סטביצקי בדואט מלחמה משותף ''עם הנצח''", "entities": [{"start": 0, "end": 14, "label": "SINGER"}]}
+{"text": "אור מויאל ותודה לך השם במחרוזת ''שירי החיילים''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "יצחק חיים בליווי אמן הקלידים זאב נחמה שרים אמונה", "entities": [{"start": 29, "end": 37, "label": "SINGER"}, {"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "דקל קונסקי בסינגל מחזק (שלישי) באווירת המלחמה ''השם ישמור''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "מיכאל פרץ משחרר סינגל ייחודי בעקבות המצב", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "אלכס מנדלסון וטוני חגג שרים שמע קולנו", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "שמואל ויינגרטן בסינגל חדש למצב ''כי בא מועד''", "entities": [{"start": 0, "end": 14, "label": "SINGER"}]}
+{"text": "מוישי וולס וצפריר דרעי בסינגל אמונה ''מאמינים ולא שואלים''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "גואל שמעה ואלימלך רחמים ''שרים אמונה''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "דוד דויטש בסינגל חדש לרגל המצב ''מולדת''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "עמיחי אדיבי שר מוטי אשר ''הבט נא'' (נוסטלגיה)", "entities": [{"start": 15, "end": 23, "label": "SINGER"}, {"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "ברק צרפתי בסינגל חדש למצב ''לא שכחנו''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "פאר בינייב בסט ''עד מתי'' - מחרוזת שירי חיזוק ותפילה לרגל המצב", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "יעקב חמו במחרוזת חיזוק ''עם ישראל חי''", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "יותם קטלן ושקד ממן בביצוע מיוחד בזמן המלחמה ''יזכרם''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "דייויד ריצ'ארד וחברים בזיץ מרגש במוצ''ש חי", "entities": [{"start": 0, "end": 14, "label": "SINGER"}]}
+{"text": "ערן ינאי במיזם מחזק ''שרים אמונה'' שידור חוזר מקול חי מיוזיק בניהול דוד ביתן", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "מידן דובדבני בסינגל חדש לרגל המצב ''נֶחָמַת צִיּוֹן''", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "יהורם רבין בסינגל חדש ''ובלע המוות לנצח''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "ויקטור פיטוסי ומקהלת שיר מקודש מבצעים ברגש הלחן של ר' אבינועם דרור ''אמונה''", "entities": [{"start": 54, "end": 66, "label": "SINGER"}, {"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "עמרם יקיר בסינגל עידוד לעת מלחמה ''לא לפחד''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "ירמיהו חדש בסינגל תפילה ''אלוקיי''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "ישי מאיר בסינגל תפילה למצב ''קיויתי''", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "עודד חולדרוב מגיש לרגל יום ההילולא שחל השבוע ''רבונו של עולם''", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "אוריה גורן מצמרר וקורע לב בשירו דממה (שטילקייט)", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "אביהו עמוס בסינגל מרגש ומלא אמונה לאור התקופה הקשה ''כשיחשוב האדם''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "חגי אברמס ביצוע ווקאלי מיוחד לשיר ''אחינו'' בלחנו של נס איצקוביץ'", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "רונלד קובר במופע מרגש במיוחד בליווי תזמורת של 40 נגנים ''אחינו כל בית ישראל''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "פנחס דיגי ריגש בסיום דרשו למען יהודי אוקראינה ''אחינו כל בית ישראל''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "מיכה אהרוני הלחין אלעזר בייסה שר - אחינו כל בית ישראל", "entities": [{"start": 0, "end": 11, "label": "SINGER"}, {"start": 18, "end": 29, "label": "SINGER"}]}
+{"text": "מנחם קצנשטיין & מור פקר - ''אנחנו לא מפחדים''", "entities": [{"start": 0, "end": 13, "label": "SINGER"}, {"start": 16, "end": 23, "label": "SINGER"}]}
+{"text": "מקהלת 'קולות המלאכים' וגל זוסמן ביצוע מוזיקלי ''ממעמקים''", "entities": [{"start": 7, "end": 20, "label": "SINGER"}]}
+{"text": "אלקנה פינטו, לאל אמסלם וליבי גרבי ''לחי עולמים''", "entities": [{"start": 0, "end": 11, "label": "SINGER"}, {"start": 13, "end": 22, "label": "SINGER"}]}
+{"text": "נתן דוד אטינגר בשיר חדש ''כמה יוסף''", "entities": [{"start": 0, "end": 14, "label": "SINGER"}]}
+{"text": "ינום גולדמן ובחורי מחנה בני תורה שרים ב'שירושיר' ''בני תורה אנחנו''", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "עירן שולמן בסט להיטים לשמחת חג", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "אודי ענתבי סוגרת מעגל עם ישיבת ירוחם ומגישים ''שירי הלל לחג הסוכות''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "גלעד איזגייב ומעניין מיוזיק מגישים מחרוזת אינסטרומנטלית לחג הסוכות", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "מאיר רוזינגר במחרוזת קומזיץ ''כמעט ליל שישי''", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "חזקי ליבוביץ ופלג הררי במחקוזת הקפה ב'", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "יצחק לוי, ניב אקרמן ועירן גולדין ''בר יוחאי''", "entities": [{"start": 10, "end": 19, "label": "SINGER"}, {"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "נפתלי מינקוב שר קרליבך ''ובנה אותה''", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "נבו פרלסון הלחין ושר ''ופרוש עלינו''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "מני גל שר את צוואתו של הרב יעקב אקוקה זצ''ל ''האחדות'", "entities": [{"start": 0, "end": 6, "label": "SINGER"}]}
+{"text": "ניב אדן בביצוע ללהיט ''והראינו בבנינו", "entities": [{"start": 0, "end": 7, "label": "SINGER"}]}
+{"text": "עמיר זומרפלד שמעוני בסינגל חדש ומרגש ''וקרב פזורינו''", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "יניב כהן בביצוע לייב ''קרבני אליך''", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "אריה בלום בסינגל חגיגי באווירת החג ''הושענא''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "יריב אברהמי מקפיץ עם מחרוזת הורה סוערת", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "חן הראל בביצוע תוסס ''עולם הבא איז א גוטע זאך''", "entities": [{"start": 0, "end": 7, "label": "SINGER"}]}
+{"text": "אביהו צפירה ומגן הבר בביצוע אנרגטי ''אתה בחרתנו''", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "יצחק וועבערמאן עם גירסה בשפת האידיש ''מיין זיידעלע''", "entities": [{"start": 0, "end": 14, "label": "SINGER"}]}
+{"text": "נתי חדד ונריה לוין בביצוע מלהיב נוסף מתוך פרויקט 'צמאה' ''ושמחת בחגך''", "entities": [{"start": 0, "end": 7, "label": "SINGER"}]}
+{"text": "חגי גנות וצוריאל קופרמן הקפיצו בביצוע לייב ''הטוב הטוב''", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "יהל הלפרין מגיש מיקס שמחת בית השואבה", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "אביעד ברקן עם משיח עובדיה מחדשים ניגון חב''די ''הנה מה טוב''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}, {"start": 14, "end": 25, "label": "SINGER"}]}
+{"text": "הרב ראם חדד בשיר חדש 'אמת ואמונה' לשמחת בית השואבה בתולדות אהרן", "entities": [{"start": 4, "end": 11, "label": "SINGER"}]}
+{"text": "זבולון טויב בניגון שמח לקראת חג הסוכות ''והכל טוב''", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "אורי מנדלוביץ ואברומי שטרנפלד חוברים שוב ''וטהר ליבנו''", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "עמית מרואני הקומזיצר מלייקווד בסינגל בכורה תוסס ''הושענא''", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "ענבר צור ואליהו חזן שרים מתוך פרויקט ''ותן חלקנו'' ''לא לבד''", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "מקהלת אושר סירוטה בסינגל חדש ''צאצאינו''", "entities": [{"start": 6, "end": 17, "label": "SINGER"}]}
+{"text": "משה גאלדמן במחרוזת מקפיצה ''סוכות טאנ'ץ''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "אלרז סמוליאנסקי במחרוזת חדשה של שירי חג הסוכות", "entities": [{"start": 0, "end": 15, "label": "SINGER"}]}
+{"text": "עקיבא סצ'קוב ויוסף גיניגר בקאבר ''שומע תפילה''", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "הנריק השיל ושחרי ספיבקוואג בסינגל חדש ''הושענא''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "שי מאיר בסינגל חדש ''זיידע שלי''", "entities": [{"start": 0, "end": 7, "label": "SINGER"}]}
+{"text": "סנדי שמואלי בסינגל תודה ''הודיה להשם''", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "אברומי ספיץ מגיש דדי ז''ל - השירים שאהבתי", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "פרץ יוסופוב מגיש מחרוזת מקפיצה במיוחד לכבוד חג הסוכות תשפ''ד", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "רונאל רחמן איאן סיגל וסהר חלוצי נפגשים שוב ''מ׳גייט מאכן קידוש''", "entities": [{"start": 11, "end": 20, "label": "SINGER"}, {"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "אלתר אררה בסינגל חדש מיוחד לסוכות ''בסוכות תשבו''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "אלירן סוקולובסקי בסינגל חדש ליום כיפור ''אפתחה פי''", "entities": [{"start": 0, "end": 16, "label": "SINGER"}]}
+{"text": "ראול לופברי מגיש הפעם מחרוזת שירי הימים הנוראים", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "טל סרלין בסינגל חדש ''השיר שלי''", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "אלי ומקהלת קולות המלאכים בסינגל חדש ''ממלא כל עלמין''", "entities": [{"start": 11, "end": 24, "label": "SINGER"}]}
+{"text": "גל שקד מגיש סינגל מקפיץ ושמח במיוחד ''אושפיזין קדישין''", "entities": [{"start": 0, "end": 6, "label": "SINGER"}]}
+{"text": "דודי הרבסט מארח את עומר טורצ'ינסקי למחרוזת ''ושמחת טאנץ''", "entities": [{"start": 19, "end": 34, "label": "SINGER"}]}
+{"text": "יונתן גלזומיצקי שר ורוקד לכבוד חג הסוכות ''למען ידעו''", "entities": [{"start": 0, "end": 15, "label": "SINGER"}]}
+{"text": "חזקיה הרוש ועידו סוסן מחדשים את הלהיט ''זה הזמן לסלוח''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "נתן בראונר דונין עם יצירה חדשה על סדר עבודת הכהן הגדול ביום הכיפורים ''וכך היה אומר''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "גלעד ואשד רזון שרים מיקי סמולנסקי ''היום הרת עולם''", "entities": [{"start": 20, "end": 33, "label": "SINGER"}]}
+{"text": "אלרואי ליבשיץ במחרוזת מרגשת ''חתימה''", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "עמי לייפר מארח את מאיר גפני בלחן חדש ''חמול''", "entities": [{"start": 18, "end": 27, "label": "SINGER"}, {"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "דובי מייזעלעס בסינגל ראשון מחצר הקודש ''אין קצבה''", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "צחי שרצר מכניס לאווירת הימים הנוראים ''שמע קולינו''", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "נאור קלאוס ומרדכי הרשמן ''כל התפילות''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "יניר גרינוולד מבצע באידיש את הלהיט הישראלי ''היט אויף מיר''", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "מישל זיגי רני אוסקר וזינגערליך ומנדי ברנדויין מגישים שוב ''פינקי'ס ניגונים #2''", "entities": [{"start": 10, "end": 19, "label": "SINGER"}, {"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "ארבל שמעונוביץ בסינגל אותו כתב והלחין בעצמו ''רק בשבילך''", "entities": [{"start": 0, "end": 14, "label": "SINGER"}]}
+{"text": "ליאור וואזנר ויוסי גלנט בביצוע נוגע ואקוסטי ''תפילה אחת''", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "נפתלי זגדון טום זקן צחי מסלטי במחרוזת אחת עם 5 ניגוני ''רחמנא''", "entities": [{"start": 0, "end": 11, "label": "SINGER"}, {"start": 20, "end": 29, "label": "SINGER"}, {"start": 12, "end": 19, "label": "SINGER"}]}
+{"text": "אהרלה נחשוני משחרר סינגל נוסף בשם ''תודה על הכל''", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "אדם זיו בביצוע מרגש לניגון ''הבן יקיר לי", "entities": [{"start": 0, "end": 7, "label": "SINGER"}]}
+{"text": "רובין שץ בסינגל בכורה ''בזאת אני בוטח''", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "אביה קוואז גפן מליח ופרדי שובקס בביצוע לשיר ''עינינו תלויות''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}, {"start": 11, "end": 19, "label": "SINGER"}]}
+{"text": "אוריה רונן וקן ברג'ס בדואט שיר פסיכולוגי ''ילד טוב''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "מוטי אברהם מגיש ''מחרוזת ימים נוראים''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "דוד חזיזא בסינגל נוסף באווירת הימים ''אחת שאלתי''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "נחשון דוד מימון קסטרו ואברהם יעקב טיילור בדואט מיוחד ''כתר מלוכה''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}, {"start": 10, "end": 21, "label": "SINGER"}]}
+{"text": "שיא שלזינגר וייצי רוזינגר ''תשובה''", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "יהודה מעטוף ושמילי אונגר בדואט חדש ''אתה זוכר''", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "יאן בגייב' מחדש את השיר המרגש של ר' יום טוב עהרליך ''כל נדרי''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "סטיבן וינגוטטבוים מארח את אור רצון בסינגל ''איזה חסדים''", "entities": [{"start": 26, "end": 34, "label": "SINGER"}]}
+{"text": "איציק קופמן מגיש ''ימים נוראים לייב'' עם כל הנשמה", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "ליעד שוורץ בסינגל חדש פרי יצירתו ''וואס וויל א איד''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "מוטי שטינמיץ בסינגל לימים הנוראים ''וכתבנו בספר החיים''", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "שי שלום בסינגל חדש ''תפילה''", "entities": [{"start": 0, "end": 7, "label": "SINGER"}]}
+{"text": "עזרא גל באווירת הימים הנוראים ''עננו''", "entities": [{"start": 0, "end": 7, "label": "SINGER"}]}
+{"text": "דוד צ'אוסקי מארח את החברים לשנה החדשה 'שנה וברכותיה'!", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "דובי ברסטון בסינגל חדש ''יש כח''", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "יחיאל ביטרן מחדש נוסטלגיה ''קוה אל השם''", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "מייק לוזון הורוויץ ושמואל חיות עם היצירה של יוסל'ה ''ואף הוא''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "בנו גרוסברד ואופיר אשרוב בסינגל חדש ''פתחי לי''", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "עקיבא הלטובסקי בסינגל חדש ומרגש לקראת הימים הנוראים מתוך צמאה 7 ''ישוב''", "entities": [{"start": 0, "end": 14, "label": "SINGER"}]}
+{"text": "ארז יחיאל בני בוקסבוים מוטי פגראו איציק פילמר ושניאור זיכלינסקי מרגשים ''ויאמר סלחתי''", "entities": [{"start": 10, "end": 22, "label": "SINGER"}, {"start": 0, "end": 9, "label": "SINGER"}, {"start": 23, "end": 33, "label": "SINGER"}]}
+{"text": "שירין פינקל מגיש מחרוזת ''ימים נוראים גור''", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "בן ציון קלצקו בסינגל עוצמתי ''צמאה לך נפשי''", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "ר' אדיר גץ ריגש את האדמו''ר מבעלזא והחסידים ''ועל ידי עבדיך''", "entities": [{"start": 3, "end": 10, "label": "SINGER"}]}
+{"text": "יעקב חליו ושמואל בסינגל משותף ''יש בי אמונה''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "אלי בן ארי ומשה יחזקיה וייס בסינגל חדש ''ארשת שפתינו''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "ינון טייב בסינגל מקורי ''חסדי אבות''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "יהודה בן-נון וישיבת אורייתא נוקדים במחרוזת ימים נוראים", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "אדי ליאון מגיש את הפיוט המרגש ''עת שערי רצון''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "אראל אורנשטיין משחרר סינגל נוסף ''פינה בחדר''", "entities": [{"start": 0, "end": 14, "label": "SINGER"}]}
+{"text": "גילי מנחם קרליבך בסינגל חדש ומרגש ''פתחתי לדודי''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "אשר ינאי ונוחי קרון מאחלים ברכת ''שנה טובה'' מוזיקלית", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "משה מנדלובי'ץ מארח את לוי יצחק כהן בדואט מרגש ''מה אנוש''", "entities": [{"start": 22, "end": 34, "label": "SINGER"}]}
+{"text": "מעיין גנון בסינגל עוצמתי ''לבדי''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "יניב אלון משיק סינגל חדש ''חזקנו''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "להב סיידון מגיש יצירה לכבוד הימים הנוראים ''אוחילה לקל''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "מקהלת תל אביב מגיש - ברוך חסידים ''הנשמה לך''", "entities": [{"start": 0, "end": 13, "label": "SINGER"}, {"start": 21, "end": 32, "label": "SINGER"}]}
+{"text": "יואב לביא בסינגל חדש באווירת ימי התשובה - ''זמן למעשים''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "זוהר גויטיין מחדשים לקראת ראש השנה ''א-ל אדיר''", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "בועז שוהם עם מחרוזת ממיטב הלהיטים של נדב מוסקוביץ", "entities": [{"start": 0, "end": 9, "label": "SINGER"}, {"start": 37, "end": 49, "label": "SINGER"}]}
+{"text": "עדן איליאייב ואלישמע הלברשטאם בסינגל חדש ''שיר שבחה''", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "צפריר שרוני מגיש ''עברתי בחושך''", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "שרון רוטמן בביצוע לייב ''יוסף מוקיר שבת''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "עילאי פשקוס ריגש בחופה עם ''קול דודי''", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "יאיר ארלנגר בסינגל חדש ''וידע כל פעול''", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "יוסף גרינבוים מארח את אחיו יהודה לדואט ''מים רבים''", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "לביא חביב ומקהלת הישיבה לצעירים ''ידידותו''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "אבישי הימלפרב עם מחרוזת משובחת באווירת ''ימי הרחמים''", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "שלשלת גוניור ורואי חשין – מחרוזת סליחות 2023", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "מוטי יפה אריה עדן ואלכסנדר אוחנה עם להיט מלא כיסופין ורגשי קודש ' 'לבוחן לבבות''", "entities": [{"start": 0, "end": 8, "label": "SINGER"}, {"start": 9, "end": 17, "label": "SINGER"}]}
+{"text": "רגב דגן מתכונן לימים הנוראים בסינגל מרגש ''להגיע מוכן''", "entities": [{"start": 0, "end": 7, "label": "SINGER"}]}
+{"text": "אליעד חימוביץ ובני עזריהו ''ראש השנה שלי'' (רבי נחמן 8)", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "נ.-ש. הרשטיק בסינגל חדש ''בתשובה''", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "ינון סופר בשיר תפילה מרגש ''שמע קולי''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "אהרון פרוכטר בסינגל חדש ''ואני''", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "אגם הכט בועז ביסמוט ואלדר כרמל-שלושת ענקי המוזיקה במחרוזת להיטים אגדית", "entities": [{"start": 0, "end": 7, "label": "SINGER"}, {"start": 8, "end": 19, "label": "SINGER"}]}
+{"text": "עובדיה חממה ופיני פולק ומראה הנגינה, בשיר חדש קצבי לשבת ''וברכתו''", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "יחיעם דהן בסינגל חדש על בסיס דברי רבי נחמן ''שיר געגועים''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "רמי לוטטי תזמורת 'פריילך' וזכריה רוזן ''תהילת השם''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "אלישע אברמוב צוריאל אמון וענהאל טרכטנברג במחרוזת מרגשת ''רגעי אלול''", "entities": [{"start": 0, "end": 12, "label": "SINGER"}, {"start": 13, "end": 24, "label": "SINGER"}]}
+{"text": "מוטי עמר ורביב רובינשטיין בדואט לייב ''אבא''", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "יגאל לורנס מארח את ניסים קפלן ומקהלת שירו לו לשיר רבי נחמן אור העולם", "entities": [{"start": 19, "end": 29, "label": "SINGER"}, {"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "תודה - יורם ענבר שר מלחניו של א.א. שטרן", "entities": [{"start": 7, "end": 16, "label": "SINGER"}]}
+{"text": "נתנאל ביננשטוק מחדש את השיר ''שבת היום להשם''", "entities": [{"start": 0, "end": 14, "label": "SINGER"}]}
+{"text": "פרחי גייטסהד בביצוע חסידי ומקפיץ ''ניגון מויטבסק''", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "טוהר זיכר ושלמה צע'צניקער'ס במחרוזת שירי ''אלול''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "מקהלת מאיר קאהן חוזרים בסינגל בכורה ''ברכי נפשי''", "entities": [{"start": 6, "end": 15, "label": "SINGER"}]}
+{"text": "ימין ישראל בביצוע לייב ליצירה ''השם מלך'' של אלי וויס", "entities": [{"start": 0, "end": 10, "label": "SINGER"}, {"start": 45, "end": 53, "label": "SINGER"}]}
+{"text": "שמואל לייכטר יגאל עמי והאחים רזאל במחרוזת אנרגטית", "entities": [{"start": 0, "end": 12, "label": "SINGER"}, {"start": 13, "end": 21, "label": "SINGER"}]}
+{"text": "גיורא קוזר מרגש עם סינגל בכורה ''אם ננעלו''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "בנימין פחימה מתחזק בסינגל חדש ''הייליג אויף אייביג''", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "אורון עוזרי ומשה פרץ שרים בלייב ''אהבת תורה'' מתוך מופע ההשקה", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "מרדכי בן ראובן מרגש לימי הרחמים ''ישתבח שמך''", "entities": [{"start": 0, "end": 14, "label": "SINGER"}]}
+{"text": "שייע ומרדכי בן-דוד שלח גולדשמידט ועיליי טוניאן - באוסף מלכותי מחרוזת יהודה ביטון", "entities": [{"start": 69, "end": 80, "label": "SINGER"}, {"start": 19, "end": 32, "label": "SINGER"}]}
+{"text": "זעירא (הילל אביעזר) בסינגל בכורה ''בלבבי משיח''", "entities": [{"start": 7, "end": 18, "label": "SINGER"}]}
+{"text": "שלו אידלמן משחרר סינגל נוסף מתוך פרוייקט ההודיה שלו! ''תודה לקב''ה''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "להקת נהורא מנחם ברקן ארהלה סאמט, בניה גיטליץ ואליאור קפלן בלהיט חדש ''קול מבשר''", "entities": [{"start": 33, "end": 44, "label": "SINGER"}, {"start": 0, "end": 10, "label": "SINGER"}, {"start": 11, "end": 20, "label": "SINGER"}]}
+{"text": "נמרוד גולדברג בסינגל מרגש לכבוד חתונתו (הערב) ''תחת החופה''", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "אליאב עזריאל וגדולי הזמר במחרוזת פאנק 2023", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "ארי הבר יוצא עם סינגל הבכורה ''ללכת איתך''", "entities": [{"start": 0, "end": 7, "label": "SINGER"}]}
+{"text": "דוד מ. ברוינשטיין וצדוק בוסקילה בביצוע משותף ''משכני''", "entities": [{"start": 0, "end": 17, "label": "SINGER"}]}
+{"text": "נטורי גודו חוזר למוזיקה ולסגנון הישן עם שיר חדש ''הדרך שלי''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "יואש כהנוביץ מגיש את סינגל הבכורה - ''זכור''", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "אשר אלפסי בסינגל ביכורים ''מפתח הפרנסה''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "אלמוג קצב מארח את מורן קושנר ''כי אשמרה שבת''", "entities": [{"start": 18, "end": 28, "label": "SINGER"}, {"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "דגן מרגליות ועובד שובל וארגון 'תודה לך השם' מגישים סינגל ''יידען''", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "אליעזר בלומן בסינגל ''הפעם אני בא כדי לעלות עד למעלה''", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "אוריה ניסאני בביצוע סליחות מרגש ''חצות''", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "עילי מוטל בשיר חדש ונוגע ''איש מההרים''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "הרב שרה שלו ונתיב אלקיים ביצעו ב-live את הקלאסיקות הגדולות", "entities": [{"start": 4, "end": 11, "label": "SINGER"}]}
+{"text": "שגיב מרקובסקי יואל פאלקאוויטש ויוסלה רוזנבלט בשירת המונים - פאר דיר", "entities": [{"start": 0, "end": 13, "label": "SINGER"}, {"start": 14, "end": 29, "label": "SINGER"}]}
+{"text": "חן איילאו בסינגל אלולי ''קול דודי דופק''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "יגאל שינה בשיר עכשווי ''טיפת אמונה''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "איצלה וקובי מחדשים את ''אחת שאלתי'' של ''לביא ארן''", "entities": [{"start": 41, "end": 49, "label": "SINGER"}]}
+{"text": "תור תעיזי וסהר חגג באווירת ימי הרחמים והסליחות ''אשוב אליך''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "לייבי ווידער בשיר מהלב בורא עולם גוט מארגן", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "אוהד ציון בסינגל חדש ומרגש ''לב חזק שבור''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "מישאל איזון אלירן דולב ו'שיר ושבח' בביצוע ''קץ הפלאות''", "entities": [{"start": 0, "end": 11, "label": "SINGER"}, {"start": 12, "end": 22, "label": "SINGER"}]}
+{"text": "יהושע אלון שר באווירת אלול לחני רונן איזנברג", "entities": [{"start": 0, "end": 10, "label": "SINGER"}, {"start": 32, "end": 44, "label": "SINGER"}]}
+{"text": "נחמן בוימל עם סינגל ישיבתי אלולי מרגש לקראת אלבום שני ''שלוש עשרה''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "ששון ליברמן ושחר זוארי במחרוזת להיטים מגוונת", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "רוברט כרמלי מגיש סינגל כל העולם כולו - ניגון ברדיטשוב", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "ריי ליפשיץ ותלמידיו בסינגל חדש ''הבוטח בהשם''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "יואב אלקלעי מחדשת את ''רגעים'' של בניהו קירשנבוים", "entities": [{"start": 0, "end": 11, "label": "SINGER"}, {"start": 34, "end": 49, "label": "SINGER"}]}
+{"text": "ליאון מנור בסינגל שני ''יד ביד''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "ר' איתמר פיכמן בסינגל חדש ''מי שברך'' לקראת הילולת בעל התוספות יו''ט זי''ע", "entities": [{"start": 3, "end": 14, "label": "SINGER"}]}
+{"text": "אושרי דדיה וילדי ת''ת חזון אברהם שובו ב''שירושיר'' מחזק ומעצים", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "רון שובל וילד הפלא חנניה וקנין", "entities": [{"start": 19, "end": 30, "label": "SINGER"}, {"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "לדוד מזמור דקל בזק ולוטם ויסבורד", "entities": [{"start": 11, "end": 18, "label": "SINGER"}]}
+{"text": "גילי עמיאל - מזמור לדוד", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "שלומי רובינשטיין ומקהלת הילדים שרים ישראל המחכים", "entities": [{"start": 0, "end": 16, "label": "SINGER"}]}
+{"text": "ז'אן-ז'אק גולדמן בראיון מיוחד נולדתי מחדש -", "entities": [{"start": 0, "end": 16, "label": "SINGER"}]}
+{"text": "'לילה טוב ילד' – להקת 'רן דוהל בסינגל חדש", "entities": [{"start": 23, "end": 30, "label": "SINGER"}]}
+{"text": "אליהו סבן והחבר'ה- לחדש נעורי", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "דורון קור בשיר ויחן שם ישראל", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "איליי גפנר מבצע רצה הקבה לזכות את ישראל", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "לידור דיין & ילד הפלא - נפלאים - ניגוני חסידי בעלזא", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "צבי גינדין - אני מאמין", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "חנן דביר ודדי פקדה בדואט לשבועות – 'לקח טוב'", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "עזי שוורץ במחרוזת חסידית תוססת", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "גולן יונתן ודיויד זוסמן היום תאמצנו", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "עם פתיחת עונת השמחות רומן גואטה בלהיט חתונות חדש", "entities": [{"start": 21, "end": 31, "label": "SINGER"}]}
+{"text": "מחרוזת חופה בביצוע עמירם חירק ואורין נפתליאב", "entities": [{"start": 19, "end": 29, "label": "SINGER"}]}
+{"text": "אליהו לייפר, רן מוסרי ותזמורת מורחבת עם מיטב להיטי השנה", "entities": [{"start": 0, "end": 11, "label": "SINGER"}, {"start": 13, "end": 21, "label": "SINGER"}]}
+{"text": "רחמים דיין מציג – והראינו", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "אשר מדינה ויואל לזר במחרוזת של מיטב ניגוני פסח", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "אחד מי יודע – יריב לנדי ואלישב סורקין", "entities": [{"start": 14, "end": 23, "label": "SINGER"}]}
+{"text": "אריק שיבר ויוסף צבע בדואט מרגש והערב נא", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "רותם חיימי ותזמורת 'בלו מלודי' תוכו רצוף אהבה", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "פנחס מדיני בסינגל בכורה – 'קל נקמות'", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "התו השמיני של סהר מורי בביצוע מחודש", "entities": [{"start": 14, "end": 22, "label": "SINGER"}]}
+{"text": "עידו דנון שר והלחין לכבוד חתונת הנכדה – בואי בשלום", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "מתנת בר המצווה שנתנו ילדי איילת ארזי לאחד מילדי המקהלה", "entities": [{"start": 26, "end": 36, "label": "SINGER"}]}
+{"text": "יוחנן שבתאי - אל תירא", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "מור אדלסון הלחין ותאי האלטר בן ה-16 מבצע נכספה", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "יהל יפת - רבון העולמים", "entities": [{"start": 0, "end": 7, "label": "SINGER"}]}
+{"text": "שלום פפנהיים וניסים סאל בסינגל חדש – 'שמור עליי'", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "ארי טוטיאן שר את 'לב טהור' בסגנון ווקאלי", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "מיאל ענקי בגרסה ווקאלית ללהיט אין גדולה כגדולתך", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "אילון עמרם - וזכנו", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "שחף מימון בילה יותר מדי זמן בשטיפת הרכב", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "מנחם פויר שר 'נכספה' – גם בספירת העומר", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "מוטי k ו'נרננה' מגישים שתיים במחיר אחד", "entities": [{"start": 0, "end": 6, "label": "SINGER"}]}
+{"text": "נגן הקלרינט פרחי אנטוורפן ויבוא עמלק", "entities": [{"start": 12, "end": 25, "label": "SINGER"}]}
+{"text": "אורן דוד ולהקת תכלת – ונהפוך הוא", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "לקראת פורים טוביה אייכלר שר המלך", "entities": [{"start": 12, "end": 24, "label": "SINGER"}]}
+{"text": "אבנר מינסקי ומנדי וייס בדואט מרגש – 'ראטעווע'", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "יער מרכוס בסינגל חדש לפורים וודקה", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "אחיעד חודפי ומועצת השירה היהודית הקפיצו עם מחרוזת חבד", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "יומם של בן-ציון קלצקו עי Strumz באנד", "entities": [{"start": 8, "end": 21, "label": "SINGER"}]}
+{"text": "הזמר והיוצר מידן ואקנין בסינגל חדש – הוא יגלה לך", "entities": [{"start": 12, "end": 23, "label": "SINGER"}]}
+{"text": "הבדחן מקהלת 'זמרו' עם הילד הפלא שוהם שרון", "entities": [{"start": 32, "end": 41, "label": "SINGER"}]}
+{"text": "ברוך הירש ותזמורת 'בלו מדלי' במחרוזת מקפיצה", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "לי אלקין בסינגל בכורה – בואי כלה", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "אליעד קסלסי שרים 'ישעיה ברקו'", "entities": [{"start": 0, "end": 11, "label": "SINGER"}, {"start": 18, "end": 28, "label": "SINGER"}]}
+{"text": "לייבו לוין בסינגל חדש לאותו הזמן", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "האחים ברקו - ס'גוט פאר מיר ס'גוט פאר דיר", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "צח יגן בסינגל חדש מודה", "entities": [{"start": 0, "end": 6, "label": "SINGER"}]}
+{"text": "14 - ניגון שמחה - גלית שרון", "entities": [{"start": 18, "end": 27, "label": "SINGER"}]}
+{"text": "07 - הניגון האבוד - מקהלת המשמחים, יהושע חסון וגיא קהלני", "entities": [{"start": 35, "end": 45, "label": "SINGER"}]}
+{"text": "11 - קול דודי - שניאור אוחיון", "entities": [{"start": 16, "end": 29, "label": "SINGER"}]}
+{"text": "05 - נחל נובע - אסי לחמי", "entities": [{"start": 16, "end": 24, "label": "SINGER"}]}
+{"text": "03 כרחם אב על בנים - שושנה גורן וילד הפלא הרשי וייס", "entities": [{"start": 21, "end": 31, "label": "SINGER"}]}
+{"text": "01 - אהללה - נגב אלמלח", "entities": [{"start": 13, "end": 22, "label": "SINGER"}]}
+{"text": "מרהיב אשר שמואלי, דניאל גליק וילד הפלא - אילן -", "entities": [{"start": 6, "end": 16, "label": "SINGER"}, {"start": 18, "end": 28, "label": "SINGER"}]}
+{"text": "אִילָן, אִילָן - סטיבן קדוש בלהיט חדש לטו בשבט", "entities": [{"start": 17, "end": 27, "label": "SINGER"}]}
+{"text": "בר צברי עם היצירה 'משכיל לדוד', עם ילד הפלא נח גורדון וגרשון איפרגן", "entities": [{"start": 44, "end": 53, "label": "SINGER"}, {"start": 0, "end": 7, "label": "SINGER"}]}
+{"text": "טומי תומפסון ו'ידידים' – 'אני מאמין'", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "עוזי גופמן - זה העסק שלנו - לעסוק בדברי תורה", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "אלי ביער ואבי דונט בשילוב של קומזיץ", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "נועם אברמוב והאחים גערשי – על ישראל ועל רבנן", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "החזן העולמי חיים רוט מבצע שהחיינו", "entities": [{"start": 12, "end": 20, "label": "SINGER"}]}
+{"text": "החזן אלכס קינן מבצע אריאל רייכל", "entities": [{"start": 5, "end": 14, "label": "SINGER"}, {"start": 20, "end": 31, "label": "SINGER"}]}
+{"text": "מוריאל לובלינסקי - ואהבת", "entities": [{"start": 0, "end": 16, "label": "SINGER"}]}
+{"text": "מאיר גרשטיין, זושא שמעלצר והקהל שרים ברגש ''השבעתי אתכם'' -", "entities": [{"start": 0, "end": 12, "label": "SINGER"}, {"start": 14, "end": 25, "label": "SINGER"}]}
+{"text": "אימרי רותם עם חאפלת חתונה מזרחית", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "ניר הוברמן עם בנשמעון", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "מנדי ג'רופי וששון שבת במחרוזת 'אילנות'", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "ניסים צורי עם סינגל חדש ומקפיץ – כח השמחה", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "אלי דן ומנחם קובי בדואט מתוך האלבום החדש של פיני מאיר", "entities": [{"start": 44, "end": 53, "label": "SINGER"}, {"start": 0, "end": 6, "label": "SINGER"}]}
+{"text": "האזינו גלי גוגנהיים שב עם אלבום חדש - צעקה", "entities": [{"start": 7, "end": 19, "label": "SINGER"}]}
+{"text": "אלדד אלמלח חוזר ובענק", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "פלג גבריאלי ואושר לוזון בדואט מיוחד לשבועות אשר בחר בנו", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "אוראל יצחק הלוי - בשורות טובות", "entities": [{"start": 0, "end": 15, "label": "SINGER"}]}
+{"text": "מוטי ברקו ורענן מור - פרויקט רילקס שוב", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "עמיעד ינקלביץ שר לכבוד הרב פינטו את השבעתי", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "מיכאל סורה עם סינגל חדש קאבר ללהיט 'מלך העולם'", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "לידור קליר בסינגל חדש ומרגש 'תהילת הניצחון'", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "אלבום חדש לר' שובל טבדידישוילי", "entities": [{"start": 14, "end": 30, "label": "SINGER"}]}
+{"text": "הנשמה בקרבי – סינגל מתוך האלבום הבכורה של יוסף קרדוונר", "entities": [{"start": 42, "end": 54, "label": "SINGER"}]}
+{"text": "שמואל גרינמן בסינגל חדש ומקפיץ – כי בשמחה", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "לירון אסולין ו'מלכות' שרים 'עזר נישואין' של באבוב", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "עודד בלוי בסינגל חדש – 'ישמחו במלכותך'", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "שבוע טוב - יוני אליאב", "entities": [{"start": 11, "end": 21, "label": "SINGER"}]}
+{"text": "שובל שמואל ואסי אלקיים בקומזיץ 'ואהבת'", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "שניאור לרר בביצוע מרגש – השבת נועם", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "עמנואל שולמן וחברים שרים בוואקלי – 'הנרות הללו'", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "משה מנדלוביץ מגיש ״א ויז׳ניצער חנוכה״", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "מקהלת ידידים וידידים בביצוע אדיר לחשוף של שמעון קרליץ", "entities": [{"start": 0, "end": 12, "label": "SINGER"}, {"start": 42, "end": 53, "label": "SINGER"}]}
+{"text": "ליאור אלמליח, נריה גספן ועקיבא פמנסקי שרים – 'אני מאמין'", "entities": [{"start": 14, "end": 23, "label": "SINGER"}, {"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "רחמים זיאת וידידים עם אחד מניגוני הרגש הגדולים", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "להקת פומפדיתא ומיכאל דנדקר בדואט - חנוכה", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "ניתאי חיון, נרננה וטובי בעלי מנגנים שרים פיטסבורג", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "אין כאלוקינו-דן גולדבלום", "entities": [{"start": 13, "end": 24, "label": "SINGER"}]}
+{"text": "אבירן גבאי ותזמורתו בסימפוניה קלאסית", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "פז ברגר בסינגל חדש ומקפיץ – אמת", "entities": [{"start": 0, "end": 7, "label": "SINGER"}]}
+{"text": "חנניה סעד במחרוזת דאנס מקפיצה", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "הכנר שי זוהר ואברומי הולצלר מבצעים את ניגון הופ קוזק", "entities": [{"start": 5, "end": 12, "label": "SINGER"}]}
+{"text": "יעקב שלמה גרוס ויעקב רוזנפלד במחרוזות ריקוד", "entities": [{"start": 0, "end": 14, "label": "SINGER"}]}
+{"text": "לוטן שוואב, ירום קראוס, עם תזמורתו של דני חלמי", "entities": [{"start": 38, "end": 46, "label": "SINGER"}, {"start": 0, "end": 10, "label": "SINGER"}, {"start": 12, "end": 22, "label": "SINGER"}]}
+{"text": "איתן אוחנונה ותום פיינרמן בדואט מיוחד נפשה חמדה", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "מחרוזת נוסטלגיה עם הזמר איתמר ברים", "entities": [{"start": 24, "end": 34, "label": "SINGER"}]}
+{"text": "סינגל בכורה לזמר אלישיב פיט וכולהון", "entities": [{"start": 17, "end": 27, "label": "SINGER"}]}
+{"text": "אשר שיק בשיר חדש שלום", "entities": [{"start": 0, "end": 7, "label": "SINGER"}]}
+{"text": "אליעד זלצברג יקפיץ אתכם עם מחרוזת קצבית", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "מנחם קליין והנחמנים שרים – כן זה רבנו", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "הזמר והיוצר יששכר ארדיטי בסינגל חדש – לא תדעי כמה", "entities": [{"start": 12, "end": 24, "label": "SINGER"}]}
+{"text": "הופעה ברק כוהניאן ותזמורת כרומה", "entities": [{"start": 6, "end": 17, "label": "SINGER"}]}
+{"text": "ניסן דוקרקר וה'ברודערס' מרגשים 'עננו'", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "עוז ישעיה החסידית שרים מוצראט", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "ינון פרץ בביצוע חי לשירו נשמה", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "'חדוה שולקין' בסינגל 'אחת שאלתי'", "entities": [{"start": 1, "end": 12, "label": "SINGER"}]}
+{"text": "רפי גלנטי וכרמל מרה במז'יבוז עם ניגון הבעל שם טוב", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "שלום עמרני שמע ישראל", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "קובי ללוש ואריאל הרמן מקפיצים את השבת – 'מלכה'", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "מלך הקומזיצים גולן קלופפר - קומזיץ", "entities": [{"start": 14, "end": 25, "label": "SINGER"}]}
+{"text": "אברהם שמיאן ומקהלת ויז'ניץ בביצוע ללהיט כנשר", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "מרק כצמן ושלוימי קנצלבוגן מבצעים את ''ממקומך'' של בעלזא", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "נחום ארדיטי מגיש מחרוזת כניסה לחופה, נוסח בני עדות המזרח", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "טרוי סיון ודורון מילר בדואט מפתיע – הללויה", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "מטר בראונר בסינגל חדש – המלאך הגואל", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "משה מינץ ואלעד בוסקילה העולמית 'חשבה לטובה'", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "אפרים ווברמן עם גפן נוימן מבצעים את ניגון הצמח צדק", "entities": [{"start": 16, "end": 25, "label": "SINGER"}, {"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "אליהו גרינבאום - נער המדבר", "entities": [{"start": 0, "end": 14, "label": "SINGER"}]}
+{"text": "החזן ברוך אורצקי מציג סינגל חדש כולי-כולו", "entities": [{"start": 5, "end": 16, "label": "SINGER"}]}
+{"text": "קולות של תקווה", "entities": [{"start": 0, "end": 14, "label": "SINGER"}]}
+{"text": "עלאי סימוני מקפיץ עם הלהיט שלו -אמת", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "יעקב ליבוביץ מארח את אליאור זרביב וחן נאמן – 'מי להשם אלי'", "entities": [{"start": 21, "end": 33, "label": "SINGER"}, {"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "אמיר קולקר בסינגל חדש – יאמנסאלה", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "אלירן ורדי שר 'ירושלים", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "אביעד סביליה עם קאבר ל'שער הרחמים'", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "עמוס בראונר מבצע לראשונה את 'יומם'", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "ארי הרמן בלהיט חדש נעשה ונשמע", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "לייב פוזן בבלדה מרגשת לעיר הבירה – שר שירך", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "שרגא ארז שר – שהשלום שלו", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "דב חיט (בצעירתו) שלום עליכם", "entities": [{"start": 0, "end": 6, "label": "SINGER"}]}
+{"text": "ניר לנדה בביצוע עוצר נשימה למחול החרבות", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "מילן גולדשטיין מחדש את הנוסטלגיה באלבומו רגעי קסם", "entities": [{"start": 0, "end": 14, "label": "SINGER"}]}
+{"text": "החזן חנניה בית מגיש שמע ישראל", "entities": [{"start": 5, "end": 14, "label": "SINGER"}]}
+{"text": "הזמר יובל טייב - רחמנא", "entities": [{"start": 5, "end": 14, "label": "SINGER"}]}
+{"text": "הייליגע'ר בעל שם טוב שירה מבצעת שירי שמוליק אורן", "entities": [{"start": 37, "end": 48, "label": "SINGER"}]}
+{"text": "הביצוע של סיני הרי ללהיט של יהל אשר", "entities": [{"start": 28, "end": 35, "label": "SINGER"}, {"start": 10, "end": 18, "label": "SINGER"}]}
+{"text": "חיים תגר בבלדת חופות חדשה – בואי כלה", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "ישי ריבו מגיש מושי מזל טוב", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "ליל שישי חי עם בערי וועבער וחברים", "entities": [{"start": 15, "end": 26, "label": "SINGER"}]}
+{"text": "החזן עדי אטיאס ובנו – קרב יום", "entities": [{"start": 5, "end": 14, "label": "SINGER"}]}
+{"text": "עם ישראל חי - רמיקס - אוריאל יעקבי", "entities": [{"start": 22, "end": 34, "label": "SINGER"}]}
+{"text": "05-ניגון ר' נפתלי ביטון", "entities": [{"start": 12, "end": 23, "label": "SINGER"}]}
+{"text": "אלעאי אוזן ומשוררים בהופעה חיה עם תזמורת קראֹהמה", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "עמית דהאן, גפן קינן ומיכאל בן דוד עם מיטב ניגוני בעלזא", "entities": [{"start": 0, "end": 9, "label": "SINGER"}, {"start": 11, "end": 19, "label": "SINGER"}]}
+{"text": "גד רמי ונחמיה כץ במחרוזת מקפיצה", "entities": [{"start": 0, "end": 6, "label": "SINGER"}]}
+{"text": "אלי זיידנפלד - לשמח כלה", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "צוריאל סולטן שר ומגיש דעם רבינ'ס צמאה נפשי", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "ח.א. הרשטיק מארח את נפתלי גבאי לשירי חתונה", "entities": [{"start": 0, "end": 11, "label": "SINGER"}, {"start": 20, "end": 30, "label": "SINGER"}]}
+{"text": "שליו פיליפסון וקובי לוי - הבית ההוא", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "גיל אסרס ו'ירוחם ניר' שרים עמרם פלק 'יעלה'", "entities": [{"start": 27, "end": 35, "label": "SINGER"}, {"start": 11, "end": 20, "label": "SINGER"}, {"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "יובל סלע׳, ומקסים לבנת בביצוע מעולה - 'תהום'", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "ומשתוקק – אורי גברא מבצע טקסט שכתב השפת אמת", "entities": [{"start": 10, "end": 19, "label": "SINGER"}]}
+{"text": "חנניה גולן ו'נרננה' בביצוע לייב ללחנו של אלכס סלע ודבריו חיים", "entities": [{"start": 0, "end": 10, "label": "SINGER"}, {"start": 41, "end": 49, "label": "SINGER"}]}
+{"text": "תאהב ותאמין – ישעיהו הבר בלהיט קיץ חדש ~1", "entities": [{"start": 14, "end": 24, "label": "SINGER"}]}
+{"text": "יוסי רייזנר שר מרדכי פריד 'מזמור לדוד'", "entities": [{"start": 0, "end": 11, "label": "SINGER"}, {"start": 15, "end": 25, "label": "SINGER"}]}
+{"text": "לוי פאלקאויטש מקפיץ עם 'ניגון באבוב'  -", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "'להנשא הלילה' נעמן בלייך וישראל לאם מרגשים בחתונה", "entities": [{"start": 14, "end": 24, "label": "SINGER"}]}
+{"text": "'הנני רופא לך' עי מקהלת ילדי אריק רודיך ושירה", "entities": [{"start": 29, "end": 39, "label": "SINGER"}]}
+{"text": "זיו גבאי ממלא את העולם באור", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "שיע רובינשטיין – שבת היום", "entities": [{"start": 0, "end": 14, "label": "SINGER"}]}
+{"text": "רומי בן-דב - אלוקים", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "ילד הפלא אברהם יצחק רוזנצווייג בביצוע מיוחד - יהיו לרצון", "entities": [{"start": 9, "end": 19, "label": "SINGER"}]}
+{"text": "הראל לסקו באלבום חדש באידיש א גוטע ברכה • האזינו לטעימות", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "תומר ליכטנשטיין ומעוז וקנין – א ישוע׳לע", "entities": [{"start": 0, "end": 15, "label": "SINGER"}]}
+{"text": "לקראת ה-30 לפטירתו - פנחס בראון מגישה מחרוזת שנקר", "entities": [{"start": 21, "end": 31, "label": "SINGER"}]}
+{"text": "גילי מנחם מבצע את אחד מלהיטיו הגדולים במהלך קומזיץ  –", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "שאול קאופמן בסינגל בכורה – מי כמוני ילד", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "גלעד דוידי ואליעד שוורץ מבצעים את מחול החרבות", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "אלרן פליישמן נקום", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "זושא גזית - אור האמת", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "חגי מלמוד שר ממעמקים", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "טוביה אזולאי - ידיד נפש", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "נחמיה שריקי - ותערב", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "שמחה כהן - ערבים עלי דברי דוד", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "גדליה אקרמן במחרוזת מרגשת", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "עמלים בתורה – סינגל ראשון לזמר אילנה גרנות", "entities": [{"start": 31, "end": 42, "label": "SINGER"}]}
+{"text": "מיילך קאהן מגיש מחרוזת ראש חודש", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "נפתלי מיכאלי, ידידים - חופה", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "יצחק דדיה - שמחת בס מיקס -רמיקס לכבוד שמחת בית השואבה", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "גוונים של גרין אלחנן וינטראוב שר תן לי ברכה", "entities": [{"start": 15, "end": 29, "label": "SINGER"}]}
+{"text": "חננאל משיח מגיש לכם להיט חתונות מקפיץ", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "עופר לב מאחל לכם אושר עד בלהיט חדש", "entities": [{"start": 0, "end": 7, "label": "SINGER"}]}
+{"text": "להקת דברים בסינגל חדש אבינו", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "חיים מרדכי אקשטיין בסינגל בכורה – אל תוותר", "entities": [{"start": 0, "end": 18, "label": "SINGER"}]}
+{"text": "אוריאן דדוש - דור בנדק", "entities": [{"start": 0, "end": 11, "label": "SINGER"}, {"start": 14, "end": 22, "label": "SINGER"}]}
+{"text": "חידוש וקידוש אמיתי טספה בסינגל חדש בואו נעשה קידוש", "entities": [{"start": 13, "end": 23, "label": "SINGER"}]}
+{"text": "עמיר קורזון - הושיעה", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "אברהם תייר חוזר לרחבת המוסיקה עם להודות לך", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "נתי ברזילי אמן הקלרינט לוטן ישראלוב וברק מגידש ותזמורתו", "entities": [{"start": 23, "end": 35, "label": "SINGER"}, {"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "סהר סרודי שר טוב להודות לה ואמונתך בלילות", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "אליעד שפילמן ורועי אמיר - י-ה שמע אביוניך", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "סינגל מהאלבום – מתנה בלחן ומילים שחיבר מייק גנץ.", "entities": [{"start": 39, "end": 47, "label": "SINGER"}]}
+{"text": "בדרך לאלבום שלישי אוראל בלס בסינגל חדש", "entities": [{"start": 18, "end": 27, "label": "SINGER"}]}
+{"text": "נותי פוקס בסינגל חדש – נשמח עם החתן", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "לוטם גולדבאום בלחן חדש אגדלך", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "השיר המרטיט של ר אבירן פורטוגלי בביצוע מיוחד לילדים", "entities": [{"start": 17, "end": 31, "label": "SINGER"}]}
+{"text": "רעי פינק ועופרי נפתלי במבואות ירושלים העתיקה  נחמו", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "שלמה לדרמן ויואלי דווידוביץ מתכוננים לימי הסליחות", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "אושר גדילוב והתזמרות מקפיצים במחרוזת", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "עידו מונט בסינגל בכורה – אהבתי", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "שלמה אייזנבך בסינגל בכורה– דרכה של תורה", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "שאלתיאל מגירה - אומן אומן ראש השנה", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "צבי רייך - דספזלטוב", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "אוריאן קצנלנבוגן - היטן מיינע אוייגן", "entities": [{"start": 0, "end": 16, "label": "SINGER"}]}
+{"text": "ניגון מלא רגש וגעגועים להקב''ה עם דרור מימרן", "entities": [{"start": 34, "end": 44, "label": "SINGER"}]}
+{"text": "סהר מלוב בסינגל חדש עד הנה", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "להקת גב רכטמן בסינגל חדש ומקפיץ במיוחד", "entities": [{"start": 5, "end": 13, "label": "SINGER"}]}
+{"text": "קלמן דגן בלסופסקי - כי עליך עינינו", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "דודי פוקס בלהיט היפ הופ חדש חדש מרכבות פרעה", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "הנס שפירא - גיל מצוות", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "יהודה אברהם מגיש את השיר הוואקלי 'מעל פסגת הר הצופים'", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "רמי קליינשטיין מגיש פרק שירה", "entities": [{"start": 0, "end": 14, "label": "SINGER"}]}
+{"text": "אבי שבשמים - ינאי יצקן & דניאל דהאן", "entities": [{"start": 25, "end": 35, "label": "SINGER"}, {"start": 13, "end": 22, "label": "SINGER"}]}
+{"text": "אבינועם חינגה וידידים מרגשים באקפלה ״ותתפרקון״", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "אריה אסולין פותח את הקיץ עם להיט חדש – והיה ה", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "לוי גולן - ברכת הבנים", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "אליה דרעי - אהבת חינם (ווקאלי)", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "ילד הפלא ראובן פלדמן מרגש עם 'מודה אני לפניך'", "entities": [{"start": 9, "end": 20, "label": "SINGER"}]}
+{"text": "מנשה מלול בלונדון עם מוטי וולר 'מודים'", "entities": [{"start": 21, "end": 30, "label": "SINGER"}, {"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "מישאל גולה, יומי לאווי, ושרולי ברגר – נשמת כל חי", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "שירה ואלרואי ישורון מבצעים ניגון שבע ברכות של ליאל דורי", "entities": [{"start": 46, "end": 55, "label": "SINGER"}]}
+{"text": "מרק ורשבסקי נזכר ברב'ה מהחיידר", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "גואל בוטא משחררת סנונית ראשונה מהאלבום שבדרך", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "עופרי זכות מגיש שמחה ונחת", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "מלך העולם שיעה ברקו מקפיץ עם הלהיט של יונתן מולאי", "entities": [{"start": 38, "end": 49, "label": "SINGER"}]}
+{"text": "מחרוזת חתונה של אריה לייב שוואקי עם תזמורתו של עקיבה פטל", "entities": [{"start": 16, "end": 25, "label": "SINGER"}, {"start": 47, "end": 56, "label": "SINGER"}]}
+{"text": "ג'ואל ברנזון ומשוררים מחדשים את מי שעשה ניסים", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "אבינו אב הרחמן ביצוע מחודש לשיר של לוי גדסי", "entities": [{"start": 35, "end": 43, "label": "SINGER"}]}
+{"text": "יוסי צפוני ומושמוש מגישים מחרוזת נוסטלגיה", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "יגדיל תורה עמוס סויסה ועמי אור בשיר חדש", "entities": [{"start": 11, "end": 21, "label": "SINGER"}]}
+{"text": "חגי ביליצר והערשי פליגמאן - כי אתה עמדי", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "טום אור ונתן יפת משוררים עם רבי קלונימוס קלמן", "entities": [{"start": 0, "end": 7, "label": "SINGER"}]}
+{"text": "היוצר החבדי אוריאל בכור מציג ביצוע לייב לשיר חדש על הרבי", "entities": [{"start": 12, "end": 23, "label": "SINGER"}]}
+{"text": "ההמגיד – סינגל בכורה לזמר נתנאל טולדו", "entities": [{"start": 26, "end": 37, "label": "SINGER"}]}
+{"text": "רחל כהן זועק בסינגל  חדש ליבי ליבי", "entities": [{"start": 0, "end": 7, "label": "SINGER"}]}
+{"text": "נתאי צרפתי ריגש את הילדים החולים 'רפאינו'", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "אהרון קידן, שמעי לוי וטוביה שטרן שרים קווה אל ה'", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "איצי שטארק ודין איסאקוב – אש רוקדת", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "נמרוד קלר וישראל טייטלבוים, במחרוזת חופה מרגשת", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "שלוימי מאיר, מקהלת הילדים וידידים שרים פתח לנו שער", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "​​לרגל ג' תמוז נוריאל טאובה, אייל דביר ולירן מוחה במחרוזת", "entities": [{"start": 29, "end": 38, "label": "SINGER"}, {"start": 15, "end": 27, "label": "SINGER"}]}
+{"text": "אופק שטרית - אלוקים", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "אביאל בלוי שר 'הולך תמים'", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "ליפא רייף ומיכאל שמחי כובשים את רחבת הריקודים", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "אבי מנחם ותזמורתו המורחבת של ז'ורז' מוסטקי", "entities": [{"start": 0, "end": 8, "label": "SINGER"}, {"start": 29, "end": 42, "label": "SINGER"}]}
+{"text": "דוד סיטבון בליווי תזמורתו של אלישיב ברבי מקפיצים עם מחרוזת קצבית", "entities": [{"start": 0, "end": 10, "label": "SINGER"}, {"start": 29, "end": 40, "label": "SINGER"}]}
+{"text": "דקל הרוש, המשוררים ותזמורת A TEAM במחרוזת חופה", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "יורם אברהם - קלאסיקות יעקב בר דוד", "entities": [{"start": 22, "end": 33, "label": "SINGER"}, {"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "מנואל שירוני מרגש עם 'רחמנא'", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "אייל דניאל & ישעיה ברו מרקידים במחרוזת שטרם הכרתם", "entities": [{"start": 0, "end": 10, "label": "SINGER"}, {"start": 13, "end": 22, "label": "SINGER"}]}
+{"text": "מקהלת ברודערס מבצע את השיר שכתב 'לא איש'", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "כוכב הזמר ליעם דוד בביצוע מרשים ל״גלגל החוזר״ של ליפא", "entities": [{"start": 10, "end": 18, "label": "SINGER"}]}
+{"text": "מקהלת הפנסאים - קולי", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "נבו חייקין בביצוע מרשים  לא תחמוד", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "שובל אהרון - כתר יתנו לך", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "אתה נגלית יואלי וייס", "entities": [{"start": 10, "end": 20, "label": "SINGER"}]}
+{"text": "אידיש נחת ואושר זיסר משוררים ווקאלית", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "ארד חזני וטופז מרגוליס בסינגל ווקאלי לימי העומר", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "ריבונו של עולם (ספירת העומר) מתתיהו וולקוביסקי", "entities": [{"start": 29, "end": 46, "label": "SINGER"}]}
+{"text": "לירון טויטו וגלי טילמן קול תורה ווקאלי", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "ירחמיאל זכריהו - טעיתי - ווקאלי", "entities": [{"start": 0, "end": 14, "label": "SINGER"}]}
+{"text": "ליאם כץ וקורן שיפמן סלסלו על שפת הכנרת", "entities": [{"start": 0, "end": 7, "label": "SINGER"}]}
+{"text": "רבי אלעד אוזנה אין רום", "entities": [{"start": 4, "end": 14, "label": "SINGER"}]}
+{"text": "שראל הורביץ אליקים חדד וזיו אלל", "entities": [{"start": 0, "end": 11, "label": "SINGER"}, {"start": 12, "end": 22, "label": "SINGER"}]}
+{"text": "עדן צליח׳ ומ.-ש. קוסביצקי – ונתנה תוקף", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "בכל צער וצער...אני עמהם בדינר של ארגון RCCS ביחד מתתיהו שלו - בראל שפנייר - ושירה קווייער", "entities": [{"start": 62, "end": 73, "label": "SINGER"}, {"start": 49, "end": 59, "label": "SINGER"}]}
+{"text": "וואקלי שירה במחווה ללהיט של ר' אביגדור לוי – מה תשתוחחי", "entities": [{"start": 31, "end": 42, "label": "SINGER"}]}
+{"text": "גילי פיטוסי בגילופין", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "ריו גל בביצוע ווקאלי 'התנערי' של ברוך של", "entities": [{"start": 0, "end": 6, "label": "SINGER"}]}
+{"text": "אריה לייב הורוויץ וה'משוררים' במחרוזת ווקאלית", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "05-ר רגב גברילוב", "entities": [{"start": 5, "end": 16, "label": "SINGER"}]}
+{"text": "נתנאל כהן מגיש אדרבה, הגירסא הווקאלית", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "אלימלך פנחסי ואביגדור ברגסון בביצע וואקלי אנא בכוח", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "רגב ויגדורוביץ שר ושמרו של פריד", "entities": [{"start": 0, "end": 14, "label": "SINGER"}]}
+{"text": "יחיאל גלר מגישה- -ויהיו רחמיך- בביצוע ווקאלי", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "נועה אורן - למען תורתך הקדושה", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "עופרי שלו בסינגל מיוחד לחג הפסח לשנה הבאה", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "אילון פאס במחרוזת מרגשת", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "מוישי אייזנברג - כל המשמח", "entities": [{"start": 0, "end": 14, "label": "SINGER"}]}
+{"text": "עילם דדון ויום צעירי בביצוע לניגון הקדום ידיד נפש", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "עירד חג'בי מארח את ישראל מן – מחרוזת ליונל מזרחי", "entities": [{"start": 37, "end": 48, "label": "SINGER"}, {"start": 0, "end": 10, "label": "SINGER"}, {"start": 19, "end": 27, "label": "SINGER"}]}
+{"text": "אוריאן גרינהויז וים רוחלין והביאנו", "entities": [{"start": 0, "end": 15, "label": "SINGER"}]}
+{"text": "המתנה הפילהרמונית של ריי מסינגר לישיבת מיר", "entities": [{"start": 21, "end": 31, "label": "SINGER"}]}
+{"text": "שי המבר מגיש סינגל בכורה בדרך לאלבום 'הורני'", "entities": [{"start": 0, "end": 7, "label": "SINGER"}]}
+{"text": "הביצוע של גיא ברק ללהיט יומם", "entities": [{"start": 10, "end": 17, "label": "SINGER"}]}
+{"text": "כולם נקבצו המנגנים מיכאל אלחנתי חיים מרדכי פייערווערגער עירן סלקמן מקהלת הילדים חסידימל'ך", "entities": [{"start": 67, "end": 89, "label": "SINGER"}, {"start": 19, "end": 31, "label": "SINGER"}, {"start": 56, "end": 66, "label": "SINGER"}, {"start": 32, "end": 55, "label": "SINGER"}]}
+{"text": "להקת פרדס בקאבר לאוהד עזרא 'ותמלוך'מו", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "מרטין שרעבי וסימפיני בביצוע", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "שרון פרברוב - מחרזות ריקודים", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "'מני זטולובסקי' ו'ברוך מוגמי' מציגים מחרוזת 'עוד ישמע'", "entities": [{"start": 18, "end": 28, "label": "SINGER"}, {"start": 1, "end": 14, "label": "SINGER"}]}
+{"text": "עמרם אלישע - אהבה ואחווה", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "סינגל לחתן מאמריקה על השיר של פנחס דהן", "entities": [{"start": 30, "end": 38, "label": "SINGER"}]}
+{"text": "זיו רובינשטין בביצוע מרגש לשיר אדרבה", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "חיים קניג בסינגל חדש בצאת ישראל", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "ביום ההוא הבלדה השקטה של יהודה גרין", "entities": [{"start": 25, "end": 35, "label": "SINGER"}]}
+{"text": "ברי וובער בסינגל ראשון – בלהט הנשמה", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "אילן דותן מבטיח לא אשקוט", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "כפיר פרטוש ו'ידידים' מחדשים את 'מארש צמאה'", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "אילון ביק והזמר עדן בדלוב במחרוזת חופה מרגשת", "entities": [{"start": 16, "end": 25, "label": "SINGER"}, {"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "אפיק וולמן שר לכבוד שמחת הרנטגן", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "יהונתן חולי מגיש סינגל משותף עם נאור הרוש", "entities": [{"start": 0, "end": 11, "label": "SINGER"}, {"start": 32, "end": 41, "label": "SINGER"}]}
+{"text": "אלמוג פרז ברסון בסינגל בכורה – אחד ה'", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "החזן איצי וולדנר מארח ומגיש אוצר מניגוני ר' תבור זיני זל – J", "entities": [{"start": 5, "end": 16, "label": "SINGER"}, {"start": 44, "end": 53, "label": "SINGER"}]}
+{"text": "זליג זינגר חוזר ובענק בואו נשמח", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "יוסי גלנץ מגיש מחרוזת ניגוני חבד בקצב מזרחי", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "אריק איינעלם במחרוזת חתונה", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "הילל הרוש, מתנאל וינרסקי וצבי זילברברג על במה אחת", "entities": [{"start": 0, "end": 9, "label": "SINGER"}, {"start": 11, "end": 24, "label": "SINGER"}]}
+{"text": "גור יצחק בסינגל ראשון בדרך לאלבום חדש ואשא", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "אלידע שגב בסינגל בכורה – השם מלך", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "לכבוד פורים ישראל וויגדער בסינגל חדש", "entities": [{"start": 12, "end": 25, "label": "SINGER"}]}
+{"text": "ילד הפלא גיל גולן ויענקי לנדאו – נשמה", "entities": [{"start": 9, "end": 17, "label": "SINGER"}]}
+{"text": "שגב ירמיאייב בסינגל מקפיץ אצלי על ראש השנה", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "שביט אסולין במחרוזת אנרגטית", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "שרגא פהימה ואמיתי קרימר שרים לזכרו של הרב נריה זצל", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "חי מוספי בקטע חזנות אשכנזית למהדרין", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "גורל אלקלעי ומקהלת ינון שטרן במחרוזת להיטים", "entities": [{"start": 19, "end": 28, "label": "SINGER"}, {"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "מה תשתוחחי– הלהיט החדש עם שמואל הוניגמן, אורי אטלי", "entities": [{"start": 41, "end": 50, "label": "SINGER"}, {"start": 26, "end": 39, "label": "SINGER"}]}
+{"text": "טוב חפץ-לכו נרננה", "entities": [{"start": 0, "end": 7, "label": "SINGER"}]}
+{"text": "יקותיאל אהרון מבצע את 'הודו לה' כי טוב' של ריקי גל", "entities": [{"start": 0, "end": 13, "label": "SINGER"}, {"start": 43, "end": 50, "label": "SINGER"}]}
+{"text": "יעקב אונגר מגישה מחרוזת אילן", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "יאיר כלב וילד הפלא מוישי וויינשטאק בדואט מרגש – 'נשמה'", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "יהושע זיו - נעשה שמח", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "דני אקריש בסינגל חדש – קורא בשמך", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "דן קרויזר ומשה מרגליות - רבות מחשבות", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "הבעל המנגן ר' מור נחמיה בשירי שמחה והתעררות בכניסה לחדרו בביהח של מרן ראש הישיבה", "entities": [{"start": 14, "end": 23, "label": "SINGER"}]}
+{"text": "דוגמה - נדב הרשקוביץ", "entities": [{"start": 8, "end": 20, "label": "SINGER"}]}
+{"text": "אביאל אליהו ביחד עם גיתאי מסינגר", "entities": [{"start": 0, "end": 11, "label": "SINGER"}, {"start": 20, "end": 32, "label": "SINGER"}]}
+{"text": "שיר מסתורי של אהרון ערגי שטרם הכרתם", "entities": [{"start": 14, "end": 24, "label": "SINGER"}]}
+{"text": "שירה ותזמורתו של חזקי שישא - ״ניגון הרכבת״", "entities": [{"start": 17, "end": 26, "label": "SINGER"}]}
+{"text": "ניקיטה בוטראשוילי בסינגל חדש ומרגש רחם בחסדך", "entities": [{"start": 0, "end": 17, "label": "SINGER"}]}
+{"text": "מוני טרי וניר עוזר ליבי במזרח", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "סיון ציפריס במחרוזת שירי חופה", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "אהרון הרר שורץ & לונדון קווייער", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "מעוז מאירוביץ מציע 'אל תאמין לו'", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "הוד חמלניק עם בנשמעון", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "ענבר שינא - ממעמקים", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "החזן טימור קורצווייל מבצע את בריך שמיה של רוזנבלט", "entities": [{"start": 5, "end": 20, "label": "SINGER"}]}
+{"text": "מתנאל אוזר-בואי כלה", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "יצחק לנדאו בסינגל חדש ומרגש – חבל", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "מוש בן ארי בסינגל בכורה מתחננים", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "אורי ויסמן מרגש בהופעה חיה 'שוועתי'", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "רחמים ברי מרגש עם 'והנה ה' ניצב עליו' – JDN – חדשות", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "חיים שמרלר מארח את הראפר ניסים  – לחיים", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "ארי רוזנפלד מפליא בביצוע קאבר לשירו של אליעזר אייזנברג 'בואי בשלום'", "entities": [{"start": 0, "end": 11, "label": "SINGER"}, {"start": 39, "end": 54, "label": "SINGER"}]}
+{"text": "חייבים להודות - אלבום חדש מלחני ר' שוהם רוט", "entities": [{"start": 35, "end": 43, "label": "SINGER"}]}
+{"text": "הילד הפלא אחיעד יעקובוף ושירה שרים נשמה", "entities": [{"start": 10, "end": 23, "label": "SINGER"}]}
+{"text": "עמית נובוסלסקי שלא עשני גוי", "entities": [{"start": 0, "end": 14, "label": "SINGER"}]}
+{"text": "ינון נתניאל ונתי לוין – מחרוזת אלחנן בוטא", "entities": [{"start": 31, "end": 41, "label": "SINGER"}, {"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "מחרוזת חופה מרגשת עם תזמורת א טים וגבריאל דרילמן", "entities": [{"start": 21, "end": 33, "label": "SINGER"}]}
+{"text": "אבי גבאי, ערן פיין & מתנאל גליס – ניגון באבוב –", "entities": [{"start": 10, "end": 18, "label": "SINGER"}, {"start": 21, "end": 31, "label": "SINGER"}, {"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "מיוחד ל-זאת חנוכה מיכה קמינר מגיש - הנרות הללו", "entities": [{"start": 18, "end": 28, "label": "SINGER"}]}
+{"text": "זאבי וינשטוק והסימפונית – את אחי", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "שמשון סגל ואלון שחם מקפיצים", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "עמית גורן – מחרוזת נגילה הללויה", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "החזן בצלאל אסרף ומקהלת ישיש הוא אלוקינו~1", "entities": [{"start": 5, "end": 15, "label": "SINGER"}]}
+{"text": "מקהלת הילדים שיר ושבח – ברכת כהנים", "entities": [{"start": 0, "end": 21, "label": "SINGER"}]}
+{"text": "מנחה של ר' שימי שטיינמץ", "entities": [{"start": 11, "end": 23, "label": "SINGER"}]}
+{"text": "מידד צימבל ושירה בביצוע אדיר לשמע ישראל~1", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "בערי ועבער בביצוע ייחודי לפיוט מעוז צור", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "רותם פדורנקו וידידים מבצעים את אני לדודי של רכניץ", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "רואי מלייב שר מעין עולם הבא של וידרקר", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "אריה קרלינסקי ואריאל בראנץ ריגשו את ההמונים", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "לייב תעסה מבצע מחדש את 'הטוב' של המלחין ר' חיים חדד זל", "entities": [{"start": 0, "end": 9, "label": "SINGER"}, {"start": 43, "end": 51, "label": "SINGER"}]}
+{"text": "מאיר צרפתי ושובל פנחס בדואט – אנעים זמירות", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "החזן גיא קפלינסקי ובנו בדואט מרגש רחל מבכה", "entities": [{"start": 5, "end": 17, "label": "SINGER"}]}
+{"text": "הזמר כרם הרמבם בסינגל חדש – קשר של קיימא", "entities": [{"start": 5, "end": 14, "label": "SINGER"}]}
+{"text": "יצחק ליובאשבסקי, עוז חג'ג' ותזמורתו וסעדיה מרדכי - חופה מושלמת", "entities": [{"start": 0, "end": 15, "label": "SINGER"}]}
+{"text": "יעקב עמידרור בסינגל חדש – יומם", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "בן הלאלי וכתר לאופר בדואט – כ׳הייב אויף מיינע אויגן", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "יוסף גוטמאן וגיל עקביוב מחרוזת ליפא", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "קָטֹנְתִּי מִכֹּל הַחֲסָדִים - אליה צפניק שר", "entities": [{"start": 31, "end": 41, "label": "SINGER"}]}
+{"text": "רפאל דוד - מחרוזת חנוכה - ליייב", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "ילד הפלא משה הולצמן + גבריאל פלקוביץ-", "entities": [{"start": 22, "end": 36, "label": "SINGER"}]}
+{"text": "שרון יטמניו ותזמורת 'A TEAM' – מחרוזת ברידרלאך", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "ארנון וויס מחדש את יותם ברהון – אמונה", "entities": [{"start": 19, "end": 29, "label": "SINGER"}, {"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "רני יזרלביץ בשיר חדש – אבא", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "הלל קפניק בסינגל חדש – לא לבד", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "הבל פיהם – להקת 'קינן גלברט' בסינגל חדש! רדיו גאולה", "entities": [{"start": 17, "end": 27, "label": "SINGER"}]}
+{"text": "מנין בהשגחה פרטית ולכבודו גיא דמארי ביצע לחן חדש", "entities": [{"start": 26, "end": 35, "label": "SINGER"}]}
+{"text": "אלראי סעדה בביצוע מרגש לשיר נשמה", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "נרננה ונחמיה צעירי מבצעים את הנה אנוכי של שלומי בלסם", "entities": [{"start": 42, "end": 52, "label": "SINGER"}]}
+{"text": "עמיצור רוט מציג 'הבט' – סינגל ראשון מתוך אלבום", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "גדול המלחינים ר' ארז דקל זל בסקווירא", "entities": [{"start": 17, "end": 24, "label": "SINGER"}]}
+{"text": "רפי איזביצקי זל 18 דקות של מיטב שיריו", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "ויקטור קסוטו וידידים – מתנות קטנות", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "רונן ברדה וידידים – למלך", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "סיני רוזנברג והחזן יואל אויש – בעבור דוד", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "'נא רחמיך' החדש של שרון דרעי", "entities": [{"start": 19, "end": 28, "label": "SINGER"}]}
+{"text": "הרמן פליישמן, אריק רצבי ושרגא ברנשטיין במחרוזת", "entities": [{"start": 14, "end": 23, "label": "SINGER"}, {"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "מלכות, יפתח דוד וגל שמיס בלהיט חתונות • 'ניגון באב", "entities": [{"start": 7, "end": 15, "label": "SINGER"}]}
+{"text": "פלא קופרמן ומשוררים מקפיצים עם מחרוזת דאנס חסידי", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "עוזי גז – שובה השם", "entities": [{"start": 0, "end": 7, "label": "SINGER"}]}
+{"text": "איזי בשארי מגיש את 'יצחק ורבקה'", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "יונה זליג מארח את גדולי הזמר במחרוזת", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "הרב דוד כהן זל שר הניגון הטוב הטוב הטוב", "entities": [{"start": 4, "end": 11, "label": "SINGER"}]}
+{"text": "הראפר אלי יחיא מארח את ירין גדאמו A Million years‏", "entities": [{"start": 23, "end": 33, "label": "SINGER"}, {"start": 6, "end": 14, "label": "SINGER"}]}
+{"text": "הזמר והקלידן יהונתן לביא מגיש ביצוע מקורי ליצירה כנפי רוח", "entities": [{"start": 13, "end": 24, "label": "SINGER"}]}
+{"text": "האם הניגון העתיק של הסבא הרב סתיו נחמן זל יציל בעה את הנכד", "entities": [{"start": 29, "end": 38, "label": "SINGER"}]}
+{"text": "חורש ורטהיים והחברים בקומזיץ", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "לייבי שימאנאוויטש בסינגל בדרך לאלבום דלתות רחמים", "entities": [{"start": 0, "end": 17, "label": "SINGER"}]}
+{"text": "שבתאי דר בקומזיץ", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "ר׳ שמואל ברזיל מבצע לחן חדש בתוכנית השירים שאהבנו -", "entities": [{"start": 3, "end": 14, "label": "SINGER"}]}
+{"text": "און שרון שר קרליבך שובה", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "עמיר גאן שר קרליבך לחן ישן, מילים חדשות", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "פינחס כהן בהופעה חיה", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "עומרי זיידן – אהבתי", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "לירון חסן, ומשה אאוסלנדר והכלייזמרים בביצוע מרגש", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "הזמר הרב גמליאל רבינוביץ בביצוע מרגש ברכת הכהנים", "entities": [{"start": 5, "end": 24, "label": "SINGER"}]}
+{"text": "הזמר כתריאל ברזאני שר בשנת תשנ", "entities": [{"start": 5, "end": 18, "label": "SINGER"}]}
+{"text": "האזינו איתמר ערקי בסינגל חדש – כי אל אשר תלכי אלך", "entities": [{"start": 7, "end": 17, "label": "SINGER"}]}
+{"text": "מוטי איידנסון אם אשכחך", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "'מלכות' וילדי 'גוני רוטמן' באלבום חדש", "entities": [{"start": 15, "end": 25, "label": "SINGER"}]}
+{"text": "פליישמן ו'יוני בקר'", "entities": [{"start": 10, "end": 18, "label": "SINGER"}]}
+{"text": "שיר 2 מלחניו של הנגיד סיימון לבייב - האזינו לטעימות", "entities": [{"start": 22, "end": 34, "label": "SINGER"}]}
+{"text": "אדם ברגר ו'נרננה' עם 'רחל מבכה על בניה'", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "דודי קרליבך באלבום חדש ומשובח אגודה אחת", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "אלישע ספיאשווילי במחרוזת שירי ברסלב", "entities": [{"start": 0, "end": 16, "label": "SINGER"}]}
+{"text": "יאיר וכטל - אבי שבשמיים", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "הבדלה דניאל דייטשמן שבת חיי שרה התשע-ו בית הכנסת אבוהב יחיאל נהר", "entities": [{"start": 6, "end": 19, "label": "SINGER"}]}
+{"text": "איליי זאיד ושאולי גרוסמן בדואט מרגש אשת חיל", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "ניתאי עידן. שר ניגונים ישנים", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "עוז גריינר בסינגל בכורה דבר נאה ומתקבל", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "יהושע ברקו ומושיקו מור שרים 'א שבת אין סאדיגורה'", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "קול הכוכבים – אלבום הדואטים של עמיקם הורביץ", "entities": [{"start": 31, "end": 43, "label": "SINGER"}]}
+{"text": "גדעון חסון הימם את הכפר אדרבה  ", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "יונת שלום בביצוע מרהיב שערי דמעות", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "אלפים בזיץ בבנייני האומה עם רעי גולדצויג וענק הזמר החסידי שראל סופר, ועוד", "entities": [{"start": 28, "end": 40, "label": "SINGER"}, {"start": 58, "end": 67, "label": "SINGER"}]}
+{"text": "אסף יונתן", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "אביה פיטקובסקי וישל''צ - תורת השם", "entities": [{"start": 0, "end": 14, "label": "SINGER"}]}
+{"text": "הילל ברייטשטיין ועמנואל דוידוב בזיץ ישיבתי", "entities": [{"start": 0, "end": 15, "label": "SINGER"}]}
+{"text": "חזקיה משולם - אשת חיל", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "אברומי שפיץ - שוש אשיש", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "שמחת בית השואבה סמוך לקבר דוד בירושלים עם יוסף מרדכי, ואורן בורנשטיין, ועוד", "entities": [{"start": 42, "end": 52, "label": "SINGER"}]}
+{"text": "ים רובין בסינגל חדש – איך העולם מסתובב", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "13 זה לזה - ז'ק פרידריך וקובי אפללו", "entities": [{"start": 12, "end": 23, "label": "SINGER"}]}
+{"text": "12 אור החיים - אליעזר אסתרזון", "entities": [{"start": 15, "end": 29, "label": "SINGER"}]}
+{"text": "10 תהום אל תהום - האחים ויזל ירין סמיונוב", "entities": [{"start": 18, "end": 28, "label": "SINGER"}, {"start": 29, "end": 41, "label": "SINGER"}]}
+{"text": "14 הים ראה וינוס - נפתלי יוסף ולהקת השיליצים", "entities": [{"start": 19, "end": 29, "label": "SINGER"}]}
+{"text": "09 רזי עולם - אריק שרון", "entities": [{"start": 14, "end": 23, "label": "SINGER"}]}
+{"text": "08 אשרי העם שככה לו - בנימין הלפגוט ונריה קרפמן", "entities": [{"start": 22, "end": 35, "label": "SINGER"}]}
+{"text": "06 רפאנו - שיע ברים ייטב בונן ונתי פוקס", "entities": [{"start": 11, "end": 19, "label": "SINGER"}, {"start": 20, "end": 29, "label": "SINGER"}]}
+{"text": "07 יהודה אביטבול - אבא תעזור רוצים לחזור", "entities": [{"start": 3, "end": 16, "label": "SINGER"}]}
+{"text": "04 אבות הקדושים - קובי פרץ", "entities": [{"start": 18, "end": 26, "label": "SINGER"}]}
+{"text": "02 הנה ה' ניצב עליו - ניר ניסטל פרחי אהרון וילד הפלא יואל פארן", "entities": [{"start": 53, "end": 62, "label": "SINGER"}, {"start": 22, "end": 31, "label": "SINGER"}, {"start": 32, "end": 42, "label": "SINGER"}]}
+{"text": "01 בספר חיים  - שרה יפתח", "entities": [{"start": 16, "end": 24, "label": "SINGER"}]}
+{"text": "אתה בחרתנו – רביד כהנא שר מתוך האלבום של החדש רכניץ", "entities": [{"start": 13, "end": 22, "label": "SINGER"}]}
+{"text": "אלבום חדש לזמר חיים נוטוביץ שירו לה' שיר חדש", "entities": [{"start": 15, "end": 27, "label": "SINGER"}]}
+{"text": "יקיר מובשוביץ, וולוי אדלר ונרננה – ונתנה תוקף", "entities": [{"start": 0, "end": 13, "label": "SINGER"}, {"start": 15, "end": 25, "label": "SINGER"}]}
+{"text": "יוסי ניילנדר בסינגל חדש – עשה למען", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "אליהו בוזגלו בסינגל חדש – כי לא ידח", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "מקהלת שובו בנים ועילאי אבידן - רחמנות", "entities": [{"start": 0, "end": 15, "label": "SINGER"}]}
+{"text": "יונתן אלקובי בביצוע מרגש ועוצמתי כח הרבים", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "חי זבולון וחנוך שער בדואט מרגש – לב טהור", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "אמני ישראל וכהן צדק אטינגר אלוקי", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "דולב אלמייהו ואלימלך וינר - היום תאמצנו", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "טוביה ידיד בביצוע אדיר לקנא לשמך", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "איתן צור מארח את אודי גפן ואומרי סורין אבינו מלכנו", "entities": [{"start": 0, "end": 8, "label": "SINGER"}, {"start": 17, "end": 25, "label": "SINGER"}]}
+{"text": "בכורה ניסים רוזנבלט שר מרטין בן-ציון מועלם – וזכנו", "entities": [{"start": 6, "end": 19, "label": "SINGER"}, {"start": 29, "end": 42, "label": "SINGER"}]}
+{"text": "אליעד רייר עם כל הברכות לשנה החדשה", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "ברק גרוסברג ו'ידידים' מבקשים מחילה", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "צור מלטבשי וסתיו בלן מגישים 'ועל ידי עבדיך'", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "עליזה אביב בביצוע ל'רצה עתירתם'", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "אלעזר אסתרזון וארתור לביא - על התורה", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "אברהם אלימלך פויגל - יש לי ת'ניגון", "entities": [{"start": 0, "end": 18, "label": "SINGER"}]}
+{"text": "נחמן פלימר ואלי גרונר - קום התהלך", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "ליאב שפירא ארי - הרכן ראש", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "אבי סלמה - שמע קולנו", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "יהונתן פלח - קראתי", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "רענן שמן - קול דודי", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "מאור יצחק - אור החיים", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "זכריה ברגינסקי וישעיה ויטמן - ריבון העולמים", "entities": [{"start": 0, "end": 14, "label": "SINGER"}]}
+{"text": "יוסי נתן - עומק האהבה", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "עדיאל אולמן - רוח של שקט", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "דני בנימין ואנסמבל שיר ידידות - ידידי רועי", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "מילאן ברדוגו - אם זה דולק", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "אילון הרפז - ישמח מלך", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "ארז אלשוילי ואביעד איילאו – רם ונשא", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "אלנתן פרילינג בסיגל חדש לימים נוראים בספר חיים", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "באווירת הימים הנוראים - מוטי רוזנפלד מרגש עם תקע", "entities": [{"start": 24, "end": 36, "label": "SINGER"}]}
+{"text": "גואל אלקריף ורועי אלקיים בסליחות ראשונות", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "אבי דלבנטי בסינגל חדש אב הרחמן", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "'זיץ' אלול מרגש עם הדר אימבר", "entities": [{"start": 19, "end": 28, "label": "SINGER"}]}
+{"text": "יוחנן שהרבני מרגש עם מחרוזת לימים הנוראים", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "אהוד עמר בסינגל בכורה – אין כל עצב", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "שגיא ראסל והמשוררים במחרוזת מרגשת לימים הנוראים", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "יקותיאל גורן בסינגל חדש – בך בטחו אבותינו", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "אדרבה אופק רום שר ר' מיילך מליז'ענסק", "entities": [{"start": 6, "end": 14, "label": "SINGER"}]}
+{"text": "ברי סחרוף ומעוז שוקרון מגישים 'לשמוע אל הרינה'", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "אשר טוב - פלג שפיגל", "entities": [{"start": 10, "end": 19, "label": "SINGER"}]}
+{"text": "איסר דוידוביץ - דרוש נא", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "מלכיאל קמפלר בקטע וואקלי אחת שאלתי", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "חיבור נדיר - מאיר בורשטיין ואלרואי רותם בשבע דקות קסומות", "entities": [{"start": 13, "end": 26, "label": "SINGER"}]}
+{"text": "החזן ניר מויאל שר, זכרנו לחיים באידיש", "entities": [{"start": 5, "end": 14, "label": "SINGER"}]}
+{"text": "דורש נא דורשיך – עדי עובדיה בסינגל אלולי", "entities": [{"start": 17, "end": 27, "label": "SINGER"}]}
+{"text": "הבדחן שהפך לזמר ניתאי קריאף עם 'לעולם אודך'", "entities": [{"start": 16, "end": 27, "label": "SINGER"}]}
+{"text": "גדעון לוין ודובער בלשניקוב - ״אמר רבי עקיבא״", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "אברהם דהאן - נישט קיין חילוק וואס די ביסט", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "מרגש אבי דדוש בשיר וסיפור – כי לעולם חסדו", "entities": [{"start": 5, "end": 13, "label": "SINGER"}]}
+{"text": "יהלי פפר, יששכר משולם ו'שירה' בסינגל חדש - 'תבוא'", "entities": [{"start": 10, "end": 21, "label": "SINGER"}, {"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "סינגל חדש לזמר בארי קובץ – ה' מלך", "entities": [{"start": 15, "end": 24, "label": "SINGER"}]}
+{"text": "ר' לב רונן וחברים - זכרנו לחיים", "entities": [{"start": 3, "end": 10, "label": "SINGER"}]}
+{"text": "אליעזר אורבך - בואי כלה", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "זיון אקשטיין ולידור אהרוני - ויבואו למקרא", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "דוד מושקוביץ ומלכות – תינוקות של בית רבן", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "גולן ממן הלחין, תמיר גוטקין שר – מאיפה להתחיל", "entities": [{"start": 16, "end": 27, "label": "SINGER"}, {"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "ילד הפלא שרגא גולדנברג בשירה מרגשת - כי הם חיינו", "entities": [{"start": 9, "end": 22, "label": "SINGER"}]}
+{"text": "שלום חריטונוב ומוריס שבתאי במופע בתא  -", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "לוטם סינייור - היום טוב", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "עקיבא סגל מרגש עם 'איש כשר'", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "העולם הזה - מקהלת רבותי", "entities": [{"start": 12, "end": 23, "label": "SINGER"}]}
+{"text": "צפריר חמאמה שר – תרימו את הקצב", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "אליעד באום - אשא עיני", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "להקת קרגיושנקפיה איז נישט א ברסלבער, אין פארט קיין אומן", "entities": [{"start": 0, "end": 16, "label": "SINGER"}]}
+{"text": "סינגל שני לזמר איתם איתן – שעון החול", "entities": [{"start": 15, "end": 24, "label": "SINGER"}]}
+{"text": "לוי גניש – ניגון הבעל שם טוב", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "פותחים את זמן אלול מנדי ג'קובס – אור החיים", "entities": [{"start": 19, "end": 30, "label": "SINGER"}]}
+{"text": "אביתר קסטרו - יבנה המקדש", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "שייע אילוביץ - רחמנא", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "בערי ובר - מי שברך", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "אלדד רוזנר ריגש עם יצירה בעלזאית - חסל סידור פסח", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "שרלי אלול לשוקי הונגר", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "ביארצייט לאביו אהרן מושקוביץ בסינגל חדש", "entities": [{"start": 15, "end": 28, "label": "SINGER"}]}
+{"text": "שוהם קוטלר בסינגל חדש – הללוי-ה", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "בני פרלשטין אלורו וחברים - יוסף ניגון", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "יחזקאל רוגוב בסינגל חדש – וידע כל", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "אדיב יתח בפיוט סליחות חדש – אדון הסליחות", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "רז קלדרון – ידיד נפש", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "דודי הורביץ – וי", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "קלמן עובדיה בסינגל חדש – אוי א בראך", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "לא רק מבצע גם יוצר – יהושע טננבאום בלהיט אלולי מקפיץ רוצים לחזור", "entities": [{"start": 21, "end": 34, "label": "SINGER"}]}
+{"text": "דין צרני - בזכות רבינו", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "רון אהרוני מרגש – לקבל שבים", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "אביאור זבולון בן ארויה בסינגל חדש אבנים מספרות", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "ארד לבנוני ושירה מרגשים מליץ יושר", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "אופק בידרמן בקומזיץ בבר מצווה", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "ישראל גוגנהיים ומשה רוזנברג – והנה ה' נצב עליו", "entities": [{"start": 0, "end": 14, "label": "SINGER"}]}
+{"text": "אליאב לוגסי ועידו אוליאל מציגים – מחרוזת ריקוד", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "להקת מזמור שיר מרגשים עם מלוך בלחנו של ר בועז מנשרוב", "entities": [{"start": 41, "end": 52, "label": "SINGER"}]}
+{"text": "ישי חפץ פותח את שערי הלב ''אתה עמדי''", "entities": [{"start": 0, "end": 7, "label": "SINGER"}]}
+{"text": "עינב ישראלי פותח את חודש אלול עם בלדת תפילה מסולסלת ומרגשת", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "רפאל מאיר הלפרט & רווה בורמן - וידעו כי אתה", "entities": [{"start": 18, "end": 28, "label": "SINGER"}, {"start": 0, "end": 15, "label": "SINGER"}]}
+{"text": "אגם הורוביץ עם לחן מקורי לפיוט המוכר אדון הסליחות", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "ישראל ויליגר בסינגל בכורה ''ויברכוני''", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "בניהו מדינה בסינגל חדש ''תפילתי''", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "זיו קימה שר אסתר רוזנברג לחודש אלול 'דרוש נא'", "entities": [{"start": 0, "end": 8, "label": "SINGER"}, {"start": 12, "end": 24, "label": "SINGER"}]}
+{"text": "אנריקו מסיאס בשיר תשובה חדש ימי הרחמים והסליחות", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "ליאב גולדשטיין בסינגל חדש מתוך המזמור של חודש אלול שמע השם", "entities": [{"start": 0, "end": 14, "label": "SINGER"}]}
+{"text": "שי-לי עזרא ולהקת הווקאל'ס ''עננו''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "תמיר וילנסקי בסינגל חדש ''ויהי אור''", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "רחל מרים ופרחי שמים מרגשים עם ''כרחם אב''", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "שרגא שלו - שמש רוח וקפה", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "יגאל רובינשטיין סינגל מקורי חדש ''אתה עמדי''", "entities": [{"start": 0, "end": 15, "label": "SINGER"}]}
+{"text": "ר' אלעד חמו ותלמידיו מתחננים פתח לנו את השער לאומן", "entities": [{"start": 3, "end": 11, "label": "SINGER"}]}
+{"text": "חילי ברנד באלבום חסידי חדש ''הגיע זמן גאולתכם''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "ישראל אליאס פותח את חודש בסינגל חדש ''אלול''", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "גד חיימוביץ מגיש סינגל חדש ומקורי מתוך אלבום שני שבדרך שאגת הארי", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "נאור אילן בסינגל חדש ''רק אמונתי'' ההספד של אבי הילדים שנהרגו באסון מירון", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "יוסי אליטוב & סנדי דינקל - תזכור", "entities": [{"start": 14, "end": 24, "label": "SINGER"}, {"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "אנטוני סביון וילדיו בסינגל חדש ''השיבנו''", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "נפקא מינה מתכונן לשבת", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "יהודה בורן וריף כוכבי - מחרוזת צמאה", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "גדעון אנה & חיים איצקאוויטש הננו מוכן ומזומן", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "יועד זייף מארח את נוה זיו משרתי האמונה", "entities": [{"start": 18, "end": 25, "label": "SINGER"}, {"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "דין סירי מגיש פרויקט חדש  ניגוני חב''ד מרגיעים", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "הרב נחמן שטיינמן בניגון לשבת ויום טוב מתוך אלבום געגועים 6", "entities": [{"start": 4, "end": 16, "label": "SINGER"}]}
+{"text": "פינחס שיינברגר מקפיץ מצווה גדולה להיות בשמחה", "entities": [{"start": 0, "end": 14, "label": "SINGER"}]}
+{"text": "אודי ספקטור בסינגל בכורה ''אחכה לו''", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "אברומי דערמר בהופעה חיה אצל נתן זאב במוצש חי", "entities": [{"start": 0, "end": 12, "label": "SINGER"}, {"start": 28, "end": 35, "label": "SINGER"}]}
+{"text": "מיכה גולן ואריק שחר מציגים ''אבא תודה''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "ברי ורקר הלחין סינגל על המילים ''בצילו של הבעש''ט הק'", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "אלירן סופיר בסינגל חדש מתוך אלבום הבכורה ''מה טובו אוהליך''", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "אורין קיסר בעקבות אסון באוקראינה בשיר חדש ומרגש ''א בריוו''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "ישראל דדון' - 'והביאותים'", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "בן-עמי פרידריך הלחין סינגל על המילים ''אודך השם''", "entities": [{"start": 0, "end": 14, "label": "SINGER"}]}
+{"text": "שלוק רוק ושגב ברס בסינגל חדש ''לויבען''", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "עופר בן-נון מברזיל חוזר בסינגל חדש ומאיר – ''כל האור בעולם''", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "יוגב עדני בשיר חדש ''יבוא היום''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "אליסף חפץ מקפיץ בסינגל ראשון בדרך לאלבום חדש ''בני ברק''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "לני הרשקוביץ, יהושע האנשטטר וגדולי הזמר במחרוזת חתונה מקפיצה", "entities": [{"start": 14, "end": 27, "label": "SINGER"}, {"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "שרגא קראוזה בסינגל ''צומת דרכים''", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "ארן מירוני שר לכבודה של תורה ''הוי רץ למשנה''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "יואלי פישער ותזמורתו, ישעיה אורטל, עומרי אבוקסיס, בנצי ועברמן, יששכר גוטמאן, יהלי סבג, עמרם חיון - במחרוזת חתונה", "entities": [{"start": 87, "end": 96, "label": "SINGER"}, {"start": 22, "end": 33, "label": "SINGER"}, {"start": 35, "end": 48, "label": "SINGER"}, {"start": 77, "end": 85, "label": "SINGER"}]}
+{"text": "שון איאסו בסינגל בכורה - ואמר ביום ההוא", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "יששכר גוטמן, עירן דרבקין, ויקטור ויטמן - משכני", "entities": [{"start": 26, "end": 38, "label": "SINGER"}, {"start": 13, "end": 24, "label": "SINGER"}, {"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "אדר טיסון שר לזכרו של שרגי ''והאר עינינו''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "טום דורפמן בסינגל מרגש ''קער מיך צוריק''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "ארד פלא מטייל בשוק ומגיש מחרוזת שירי שבת", "entities": [{"start": 0, "end": 7, "label": "SINGER"}]}
+{"text": "חיים מאיר פליגמאן & לירוי טובול - לב שמח", "entities": [{"start": 0, "end": 17, "label": "SINGER"}, {"start": 20, "end": 31, "label": "SINGER"}]}
+{"text": "חיים מאיר פליגמן שר באנגלית ''אף פעם לא מספיק", "entities": [{"start": 0, "end": 16, "label": "SINGER"}]}
+{"text": "פ. אספיסהש ריגש בגראמען בעברית בדינר של חב''ד", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "אורין וולך וקובי אלקובי במחרוזת שירי שבת", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "יענקי זינגבוים בסינגל חדש - שמע בקולה", "entities": [{"start": 0, "end": 14, "label": "SINGER"}]}
+{"text": "רות דיין בגרסת הרמיקס הרשמית ל''בית נאמן'' בהפקתם של טל בורמן ויוסף מחלין לולו", "entities": [{"start": 53, "end": 61, "label": "SINGER"}, {"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "הילאי רואש & אלון רצין - שיר החתונות", "entities": [{"start": 0, "end": 10, "label": "SINGER"}, {"start": 13, "end": 22, "label": "SINGER"}]}
+{"text": "10 זיץ עם אלמוג קורצברג חלק א", "entities": [{"start": 10, "end": 23, "label": "SINGER"}]}
+{"text": "11 זיץ עם לביא עובדיה חלק ב", "entities": [{"start": 10, "end": 21, "label": "SINGER"}]}
+{"text": "מוטי נחמני מזמין אתכם לעשות ''לחיים''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "שאול גרניט בסינגל חדש ''כל חלום''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "יוסף ניוקם ואריה הורוויץ בדואט ''החיינו א-ל''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "חנן זינו בשיר נושא האלבום  - ''ניצוץ יהודי''", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "מקסים אבבו בסינגל חדש ''שמע''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "אוריאל קלפהולץ זמר חדש בשיר חדש – ''שובי''", "entities": [{"start": 0, "end": 14, "label": "SINGER"}]}
+{"text": "אלעזר שחור בביצוע ללחנו של שמואל דוד לנדא – ''ונזכה''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}, {"start": 27, "end": 41, "label": "SINGER"}]}
+{"text": "רז זערור בגרסת הרמיקס הרשמית ללהיט ''אותו היום''", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "ליאור דסה בסינגל ביכורים ''מודים''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "אמרי מועלם מבצע בקונצרט את משה ואהרן", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "סימון נחום בסינגל בכורה - אתה לא לבד", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "זיו מנשביץ באלבום הבכורה - ''ניצוץ יהודי'' - תקציר האלבום", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "קומזיץ ליל שישי עם גדולי הזמר לביא גרינברג ושגב אלאלוף - שידור חוזר", "entities": [{"start": 30, "end": 42, "label": "SINGER"}]}
+{"text": "מוטי טקה (אמן הקומזיצים) בסינגל חדש ''מודים''", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "מענדי פיש בביצוע לייב''שטר התנאים'' (מתוך הופעה)", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "חוה אלברשטיין ותזמורת פריילך בדואט ''חנני''", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "נטע ירוחם אחרי 5 שנות ציפייה באלבום בכורה ''מן השמים'' - דוגמה", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "טומי גולדשמיט בסינגל חדש -''גשר''", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "גד דחליקה מאחל לכם בסינגל חדש א גוטע נאכט", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "אדי אליה בסינגל חדש ''אתה שלום''", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "נחת בודינגר בסינגל חדש יש מקום בלב", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "דודי קנופלר מגיש סינגל שלישי וייחודי - 'להיות'", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "גיא רוזנבאום בניגון שמחה - מתוך פרויקט 'צמאה'", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "לוי מדר וענן איציקסון, גרי הצדק שרים יחד ''ניסים''", "entities": [{"start": 0, "end": 7, "label": "SINGER"}]}
+{"text": "שבתאי טלקר ותזמורתו מבצעים מחרוזת משירי נעמה אופק", "entities": [{"start": 0, "end": 10, "label": "SINGER"}, {"start": 40, "end": 49, "label": "SINGER"}]}
+{"text": "אושר כהן בסינגל חדש ומקפיץ אבא גדול", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "יעקב רוטנברג מגיש את 'ותחזינה' מתוך אלבום בכורה חדש", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "אדם ברק ותושבי הכפר שרים ''חראשו''", "entities": [{"start": 0, "end": 7, "label": "SINGER"}]}
+{"text": "יותם בוקריס ונתנאל אבקסיס במחרוזת חתונה", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "רוני גרינברגר & האחים שפירו במחרוזת שמחה אנרגטית", "entities": [{"start": 0, "end": 13, "label": "SINGER"}, {"start": 16, "end": 27, "label": "SINGER"}]}
+{"text": "יהונתן רביב ונטע קנדלקר מרקידים ''שכוייח!''", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "15 משפחת ברגמן בסינגל חבל לע''נ האברך משה יהודה וויינער ע''ה", "entities": [{"start": 3, "end": 14, "label": "SINGER"}]}
+{"text": "16 להקת שפתיים בסינגל בכורה ברוך השם", "entities": [{"start": 3, "end": 14, "label": "SINGER"}]}
+{"text": "17 אוריה שפירא ואליאב עמר שואלים ''הלילה הזה''", "entities": [{"start": 3, "end": 14, "label": "SINGER"}]}
+{"text": "08 זיו גוטליב & מקהלת זמרו - זיי גיט", "entities": [{"start": 3, "end": 13, "label": "SINGER"}, {"start": 16, "end": 26, "label": "SINGER"}]}
+{"text": "12 איילה חכם ובנו שמעון שרים ליקוטי מוהרן", "entities": [{"start": 3, "end": 12, "label": "SINGER"}]}
+{"text": "11 ברוך שטרן - די דריידל ניגון", "entities": [{"start": 3, "end": 12, "label": "SINGER"}]}
+{"text": "06 אושר טוואבה ובנו בסינגל חדש יא אדער ניין ביי אתה חונן", "entities": [{"start": 3, "end": 14, "label": "SINGER"}]}
+{"text": "09 נדב שגב, אביגדור לנג ויעקב ברכה בלהיט חדש – פשיסחא ניגון", "entities": [{"start": 3, "end": 10, "label": "SINGER"}, {"start": 12, "end": 23, "label": "SINGER"}]}
+{"text": "03 בניה להב בסינגל ראשון מתוך אלבום באידיש", "entities": [{"start": 3, "end": 11, "label": "SINGER"}]}
+{"text": "07 זלמן דוידוב בסינגל חדש ומקפיץ – 'הדרן'", "entities": [{"start": 3, "end": 14, "label": "SINGER"}]}
+{"text": "14 יהונתן אוחנה וישראל חיים רייזמאן - בטחו", "entities": [{"start": 3, "end": 15, "label": "SINGER"}]}
+{"text": "04 יפתח נבון מבקש וקבץ נדחינו (מילים מהסליחות)", "entities": [{"start": 3, "end": 12, "label": "SINGER"}]}
+{"text": "01 הרב בר יפרח בסינגל חדש וקיצבי – נאך אביסל", "entities": [{"start": 7, "end": 14, "label": "SINGER"}]}
+{"text": "02 דוד הלל ואהרן אוסטרליץ בסינגל מרגש תפילות", "entities": [{"start": 3, "end": 10, "label": "SINGER"}]}
+{"text": "05 יהל גויכמן ודני גלוטר בדואט מקפיץ - 'בר אלעאי'", "entities": [{"start": 3, "end": 13, "label": "SINGER"}]}
+{"text": "שגיא שלום מארח את ניסים קיסר עם מחרוזת שירי ירושלים", "entities": [{"start": 18, "end": 28, "label": "SINGER"}, {"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "פאר נזרי מגיש משאפ הפיוטים עם מיטב הלהיטים", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "יצחק אביטן וילד הפלא זלמן לייב פרידמן נחמו עמי", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "מ. הרשמן ומשה לוונבראון בשיר חדש הללו", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "אליעד אליהו בסינגל חדש בן אדם", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "אביתר אושרי ונתנאל גרוסמן מגישים לחן חדש של רכניץ ''כולנו''", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "אוהד קלונימוס בסינגל חדש ''הכל עובר''", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "אביעד עזר משיק סינגל חדש ואנרגטי ''אחינו מתחתן''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "יועד ואזנה בסינגל קצבי חדש סעודה לצדיקים", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "נטע ברזילי מוציא סינגל נוסף שכתב והלחין בשם 'דרך חדשה'", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "אור אילוז בסינגל פופ חדשני - דף חדש", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "אליעזר הופמן בשיר חדש לרגל בר המצווה של אחיו 'א אידישע נשמה'", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "זויתן גוגנהיים פותח את עונת האירועים בלהיט חדש ''חתן וכלה''", "entities": [{"start": 0, "end": 14, "label": "SINGER"}]}
+{"text": "סאלי גלעד פותח את עונת החתונות הנה לפניך", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "מנחם זיידה פותח את עונת הקיץ בסינגל קצבי ומרענן – ''תרקדו''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "מקסים יחזקאל הלחין סינגל על המילים ''ישמחו במלכותך''", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "קובי ישראל ותובל חליוה בדואט מזמור לתודה", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "יוסף איבגי בסינגל חדש ואז יהיה יותר טוב", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "הוד נאמן מבצע את הקינה הנודעת עמוס פלק ועריה", "entities": [{"start": 30, "end": 38, "label": "SINGER"}, {"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "אודי דאמרי מגיש הנוסח המלא של תפילת ליל שבת", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "ר' רועי ידיד בתפילה חרישית בשם השם", "entities": [{"start": 3, "end": 12, "label": "SINGER"}]}
+{"text": "יוסי לוי ויהודה אברמוביץ מרגשים באקפלה נחמו עמי", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "בניה פרקל בביצוע ווקאלי אשא עיני", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "ליבי צסלר במסר גראמען מיוחד לתשעת הימים", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "נריה עוקבי מגיש גירסה ווקאלית ללהיט מי כעמך ישראל", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "11 רבי מנשה ברו שושן", "entities": [{"start": 7, "end": 15, "label": "SINGER"}]}
+{"text": "10 רבי יואלי דיקמן שושן", "entities": [{"start": 7, "end": 18, "label": "SINGER"}]}
+{"text": "09 רבי סער יהודה שושן", "entities": [{"start": 7, "end": 16, "label": "SINGER"}]}
+{"text": "08 רבי בנימין קלצקו שושן", "entities": [{"start": 7, "end": 19, "label": "SINGER"}]}
+{"text": "דוד שמולא שר חזנות מתוך התפילת השבת והשבוע ''רצה השם''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "אבינועם שטרית מגיש ''חבלי משיח'' הגירסה הווקאלית", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "הלהיט של ליבי שפיגלר ''סיבת הסיבות'' בגירסה ''ווקאלית אלקטרונית''", "entities": [{"start": 9, "end": 20, "label": "SINGER"}]}
+{"text": "עברי כלפה מארח את נתנאל גם זו לטובה רק עוד רגע", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "אפרים סולומון וסתיו חזן בביצוע ווקאלי 'על אלה'", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "ישי גויכמן ועוז בר שרים א-ל אדון בגירסה הווקאלית", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "ירדן שושני מגיש לכתחילה אריבער – הגרסה הווקאלית", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "זיולי ליפקין בביצוע ווקאלי 'בעבור דוד'", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "איסר זיו מגיש את הקלאסיקה נחמוני בגרסה ווקאלית", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "שמשון ישראל ואבי רז בביצוע ווקאלי - 'ריבון'", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "איתמר בלטר בגרסה ווקאלית לשיר מזמור לתודה", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "שרולי ליפשיץ ואביה שמולביץ שרים על האסון במיאמי ''רחם נא''", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "נמרוד אריש & איציק אלקיים - שירת העשבים - ווקאלי", "entities": [{"start": 13, "end": 25, "label": "SINGER"}, {"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "צחי וייספלד ודן יוסופובוואג מגישים מחרוזת שירים ווקאליים ''נשמתי 2''", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "רוני דודיאן - מלאכי השרת - ווקאלי", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "שריה אסף בגירסת קאבר ווקאלית אמונה בת מלך", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "אלמוג קראוטהמר בבציוע ווקאלי ''תנה בני לבך''", "entities": [{"start": 0, "end": 14, "label": "SINGER"}]}
+{"text": "יוסף בן עטר בגרסה ווקאלית לשירו ''חיבור חזק''", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "שמילו רוזנברג בסינגל בכורה ווקאלי אזמרה לך", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "אושי כץ בביצוע ווקאלי ומרגש לעוסק בתורה", "entities": [{"start": 0, "end": 7, "label": "SINGER"}]}
+{"text": "בניהו גונן בגרסה ווקאלית – נחם ה'", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "מלאכי אמיר ואורי בצון בגרסה ווקאלית - שיר היונה", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "ארבל ליבוביץ מגיש קאבר ווקאלי לשיר ברכת כהנים", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "07 שירה חדשה", "entities": [{"start": 3, "end": 12, "label": "SINGER"}]}
+{"text": "רובי אלבז גילה את כשרונו של דניאל בן ה-9 והזמין אותו לדואט", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "לביא יוסף וילדי הפלא שרים לכבוד שבת המלכה", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "חנוך גרוסמן וראובן (רועי) אדרי הקפיצו את הרבבות בבריכת הסולטן", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "הנחת אבן הפינה לעיר התורה של אמריקה הלטינית - עיר התורה במקסיקו - שקד אפללו", "entities": [{"start": 66, "end": 75, "label": "SINGER"}]}
+{"text": "משה ווייס וילד הפלא לירון מלכה ואיתי מתתיהו הרטיטו בדינר - בהיכלו", "entities": [{"start": 0, "end": 9, "label": "SINGER"}, {"start": 20, "end": 30, "label": "SINGER"}]}
+{"text": "פרחי בני הישיבות 'אריה הלוי' משתתפת בפרויקט של שדה ויסוקר ולשלום", "entities": [{"start": 47, "end": 57, "label": "SINGER"}, {"start": 18, "end": 27, "label": "SINGER"}]}
+{"text": "חנניה אדר ומיכה ריבין בביצוע קאבר לייב ''הולך איתך''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "רונן עזרא מבצע את רצה במנוחתינו בנוסח התפילה", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "אברהם בר (בני מזרחי) ז''ל בשירו 'סילבר לייניג' (Silver Lining) המדבר על העיר ירושלים", "entities": [{"start": 10, "end": 19, "label": "SINGER"}]}
+{"text": "פנחם נויהאוס מארח את גל וייס - יודו לה' חסדו (רמיקס)", "entities": [{"start": 21, "end": 28, "label": "SINGER"}, {"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "יחיאל מועלם מגיש סינגל חדש ''מקלט''", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "ספיר בליטשטיין שר לילדים המיוחדים באנגלית לבבות מיוחדים", "entities": [{"start": 0, "end": 14, "label": "SINGER"}]}
+{"text": "גיל לדין מארח את יאן וסרמן ואדם בן לאווי עמנואל", "entities": [{"start": 17, "end": 26, "label": "SINGER"}]}
+{"text": "יהודה שוקרון ריגש עם גראמען בדינר", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "אליעזר ווקנין עם ביצוע ייחודי לניגון שבת ויו''ט של חב''ד", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "מתנאל שורץ שר את הלהיט ''בקרוב'' בגרסת לייב מיוחדת על פסנתר", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "עמי קרמר מבצע – הר מירון", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "15 הקדמה ''אם אשכחך'' - בשעה שהקב''ה בועז פיטוסי זאנויל ואיתן בן משה", "entities": [{"start": 37, "end": 48, "label": "SINGER"}, {"start": 62, "end": 68, "label": "SINGER"}]}
+{"text": "07 בן סנוף הלל ברמן – נפשי", "entities": [{"start": 3, "end": 10, "label": "SINGER"}, {"start": 11, "end": 19, "label": "SINGER"}]}
+{"text": "14 אלחנן הלפגוט ובנימין מילצקי בליווי לב לנג חננו ועננו", "entities": [{"start": 38, "end": 44, "label": "SINGER"}]}
+{"text": "03 זוהר עבר ואביעד ציון רוקדים עם 'רבי שמעון' במירון", "entities": [{"start": 3, "end": 11, "label": "SINGER"}]}
+{"text": "09 אלדר אביבי וילד הפלא מרגשים מאמע רחל", "entities": [{"start": 3, "end": 13, "label": "SINGER"}]}
+{"text": "05 איציק וינגרטן ושלוימי אייזנטל מרגשים ''עמו אנוכי בצרה''", "entities": [{"start": 3, "end": 16, "label": "SINGER"}]}
+{"text": "10 עמיקם אלחזוב מרגש עם יצירה מיוחדת לימים הנוראים אזכרה", "entities": [{"start": 3, "end": 15, "label": "SINGER"}]}
+{"text": "12 הזמר החסידי רחמים פרץ תניא אמר ר' יוסי", "entities": [{"start": 15, "end": 24, "label": "SINGER"}]}
+{"text": "אלברטו מזרחי עם שיר חדש ומרענן 'אחד מי יודע'", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "מוטי ברייער מקפיץ עם מחרוזת שירי חב''ד", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "משה עיליי קינדלר בשיר חתונה - עוד ישמע", "entities": [{"start": 4, "end": 16, "label": "SINGER"}]}
+{"text": "עז יוסף מפתיע בשיר חדש והריקותי", "entities": [{"start": 0, "end": 7, "label": "SINGER"}]}
+{"text": "שמואל רודענסקי & אבי לרנר – חיות הנוהמות", "entities": [{"start": 17, "end": 25, "label": "SINGER"}, {"start": 0, "end": 14, "label": "SINGER"}]}
+{"text": "אלון רובין ומרדכי ברוצקי ב'ניגון לר' מיכל מזלוטשוב'", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "לירון ששון מתנאל ברקוביץ' ואילון ליבמן במחרוזת ריקודים אנרגטית - קומזאלץ 2021", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "אביתר צדוק בגראמן (חרוזים) באידיש על ידידו מצליח מרדכי ז''ל", "entities": [{"start": 0, "end": 10, "label": "SINGER"}, {"start": 43, "end": 54, "label": "SINGER"}]}
+{"text": "צוק אייזנברג המלאכים ילדי מגדל אור - מחרוזת שירי שבת", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "תמוז טיץ, ריבי שוועבעל, ארי שונפלד, דניאל סגל A Thousand Voices - ''אלף קולות''", "entities": [{"start": 36, "end": 45, "label": "SINGER"}, {"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "ישעיה לוין בסינגל חדש ''שמע בני''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "מלאכי טלקר הלחין ושר 'גדלו'", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "חושן בוסקילה וצח משולמי שרים ידיד נפש של חסידות ברסלב", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "עומר מורד משיק סינגל חדש וקצבי - ''בית נאמן''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "הדר רחני בשיר אקטואלי, מקפיץ ובעיקר מעודד מגן ומושיע", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "עופר שועלי בסינגל געגועים לרבי חסיד ותו לא", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "סטיב רביע מארח את צוף יהוד מחרוזת מצפים לגאולה", "entities": [{"start": 0, "end": 9, "label": "SINGER"}, {"start": 18, "end": 26, "label": "SINGER"}]}
+{"text": "עודד רובינשטיין משיק את סינגל הבכורה שלו ''השיבה''", "entities": [{"start": 0, "end": 15, "label": "SINGER"}]}
+{"text": "ידיד שאלתיאל  נתי F.M הראפר שחזר בתשובה בסינגל ראשון", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "מנחם מנדל כהנא, יתפאר בי וגד ליאור במחרוזת שירים", "entities": [{"start": 16, "end": 24, "label": "SINGER"}, {"start": 0, "end": 14, "label": "SINGER"}]}
+{"text": "אליאב ברשטיין מחדש את הקלאסיקה - נחמוני", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "עינב שיף שר לכבוד שבת קודש ישמחו במלכותך", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "אסי דנינו חוזר לשיר - שבת המלכה", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "שמעיה פישר בשיר ''לחיים'' מתוך אלבומו החדש", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "החזן חן אמסלם שר מרטין וידרקר יוסף ה עליכם", "entities": [{"start": 5, "end": 13, "label": "SINGER"}]}
+{"text": "כפיר מיסיחייב שר ''קול דודי'' מתוך פרוייקט 'סדר הניגונים'", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "אורי זיו בסינגל חדש ''דקה של תודה''", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "יגל הרוש ואביאל צ'פובצקי במחרוזת שירי נשמה לזכר הנספים במירון", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "ליאו אביד וינאי משולם עם גירסת הרמיקס ללהיט של מאיר גולדשטיין", "entities": [{"start": 0, "end": 9, "label": "SINGER"}, {"start": 47, "end": 61, "label": "SINGER"}]}
+{"text": "ענת רונן בסינגל שני 'רצונות טובים ולמחרת בקרשים'", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "אמרי גנקין מכה שנית בסינגל מרגש ואהבת לרעך כמוך", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "אלמוג פרבר, האחים שמוליק וילד הפלא ריגשו בחופה", "entities": [{"start": 12, "end": 24, "label": "SINGER"}, {"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "הרשי רוזנבאום בשיר תפילה ''אנא בכוח'' בעקבות המצב", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "אמיתי פז משחרר גרסת הרמיקס ללהיט ''עם סגולה''", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "מיקי גבריאלוב שר שירו למלך לכב' עשור לקהילת ויזניץ בעפולה", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "ניסן שרבאני - חי (קאבר)", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "עופר רוזנבאום שוורץ ויובל אזולאי במחרוזת חופה מרגשת (כחצי שעה)", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "אלרואי שגיב ופיני שכטר במחרוזת שירי ירושלים", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "אבירן צור שר ללא מילים על אסון מירון – ניגון מה נאמר", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "הדף היומי מסכת יומא דף נ''ח סיון תשפ''א - שיעור בעברית מאת הרב שר נוריאל הי''ו מקול חי", "entities": [{"start": 63, "end": 72, "label": "SINGER"}]}
+{"text": "אלרואי לנדוי חוזר שוב עם סינגל חדש כי מלאכיו", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "צבי גרינהייים בשיר חדש ומרגש כל יכול", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "ברוך שלום בסינגל חדש ''במדבר''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "לי אוברלנדר, שרוליק כהן ו'משולם גרינברג' שרים פתחו לי", "entities": [{"start": 13, "end": 23, "label": "SINGER"}, {"start": 0, "end": 11, "label": "SINGER"}, {"start": 26, "end": 39, "label": "SINGER"}]}
+{"text": "מייק טויבר וברוך פרידמן שרים למסע של בחורים פועל'ט אלעס גוטס (תפעלו הכל לטובה)", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "אביגדור גולדברג בסינגל חדש לחיות עוד פעם", "entities": [{"start": 0, "end": 15, "label": "SINGER"}]}
+{"text": "יגל מועד מרגש בסינגל בעקבות אסון מירון 'שותלים בשביל העתיד'", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "הראל שוער, שון אהרון ומקהלת ויז'ניץ בביצוע מרגש ''והי' ה' למלך''~1", "entities": [{"start": 11, "end": 20, "label": "SINGER"}]}
+{"text": "אברומי רוזנבאום בסינגל מרגש על המילים שכתב הרב מטלון ז''ל ''רבה אמונתך''", "entities": [{"start": 0, "end": 15, "label": "SINGER"}]}
+{"text": "תזמורת פילהרמונית מפתיע באלבום חדש ''לחיים'' - דוגמה", "entities": [{"start": 0, "end": 17, "label": "SINGER"}]}
+{"text": "אביאל אילון באלבום בכורה יברכך - דוגמה", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "מוישי רוט משיק סינגל שני - ''בורח מעצמי''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "אשר גילן בסינגל חדש מלא חיזוק הדרך אליך", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "פיני דרעי והילד זאבי גיניג'ר בסינגל חדש אני מאמין", "entities": [{"start": 16, "end": 28, "label": "SINGER"}, {"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "שניאור דלרוזה הלחין ושר את הפיוט של רבי ישראל נגארה זצוקל", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "יומי האס & הוד עמית - ניגון", "entities": [{"start": 0, "end": 8, "label": "SINGER"}, {"start": 11, "end": 19, "label": "SINGER"}]}
+{"text": "ששי המאירי בסינגל חדש בואי בשלום", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "צח בלינדר ופריילאך באלבום שירי החתונה SING IT (תשיר את זה)", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "מידד טסה - אני בחור רגיש", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "הראל פרוש וזמירות בביצוע לייב לשירו א אידן טובה (לעשות טובה ליהודי) מתוך אלבומו החדש", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "הערשי אורטנער שהיה באסון מירון שר את השיר של תזמורת פריילאך – באידיש", "entities": [{"start": 45, "end": 59, "label": "SINGER"}]}
+{"text": "ויצמן לבל שר ברוך ה אני נושם", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "שרון חביב בסינגל חדש מה הסיפור", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "אבנר הלל שר לזכר הראשון לציון תפילת הרב", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "יוסף חפצדי הלחין ושר ברוך השם", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "מנחם לובטון שר את הלחן של אביו אין ערוך", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "יוסי מייבסקי ורצברגר עם ''מהרה'' בטעם של פעם", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "יחזקאל רווח בסינגל חדש מי אדיר", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "אמנון דיין בסינגל בכורה השלך", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "פינחס ברמן בסינגל חדש מדוע למה ואיך", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "עמק אוסטרמן ויוסף סלע במחרוזת ריקודים סוחפת", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "ילדי סוריה ו'מלכות' בסיום השס - והגית בו", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "נתנאל כליף בסינגל ראשון לא מבקש טופס", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "אליה ברנד - הגואל המשיח", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "מורן שטרייכר וג'וש וולמרק בביצוע לייב ידיד נפש", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "רותם גויכמן בשיר חדש עוקר הרים", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "רז ביטון בשיר תפילה לבורא עולם - ''תמיד איתי''", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "מיקי הללי בסינגל חדש כל זמן", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "עדן ברזילי מגיש - 'מי אדיר' (נפשי)", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "אהוד ריק, יוגב סבלייב ומשה אברהם (מושמוש) קדושי מירון", "entities": [{"start": 10, "end": 21, "label": "SINGER"}, {"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "אייל חסיד הלחין ושר אתה קדוש", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "יואב כץ שזכה בתואר 'הקול הבא במוזיקה היהודית' שר כרחם אב של שרגי ז''ל", "entities": [{"start": 0, "end": 7, "label": "SINGER"}]}
+{"text": "ארתור נריה בשיר חדש - לכתחילה אריבער", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "ר' מוטי מיכאלי שר לכבוד שמחת סערט ויז'ניץ אלה וכאלה יוסף עמנו", "entities": [{"start": 3, "end": 14, "label": "SINGER"}]}
+{"text": "קאי רוקח דניאל דרמון ודודי פלדמן - שפע רב בכל העולמות", "entities": [{"start": 0, "end": 8, "label": "SINGER"}, {"start": 9, "end": 20, "label": "SINGER"}]}
+{"text": "אליאב טיבי אלישע קוסטיקה ודותן יהודה - יזכרם", "entities": [{"start": 0, "end": 10, "label": "SINGER"}, {"start": 11, "end": 24, "label": "SINGER"}]}
+{"text": "גולן יצחק בסינגל חדש לעונת החתונות", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "חיים צדיק במחרוזת אנרגטית", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "דניאל טייב וחברים שרים את ניגון ראדושיץ לקראת היארצייט", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "מרדכי בן דוד מבקש ימים של שקט", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "הרב עוז אלבז מגיש ניגון לר אלחנן דוב (חוניע) מרוזוב", "entities": [{"start": 4, "end": 12, "label": "SINGER"}]}
+{"text": "דניאל שמש וגפן מויאל במחרוזת להיטים", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "אגם רוזנר באלבום חדש לעבעדיגע ספרי תורה - תקציר האלבום", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "ניתאי דרמון בסינגל חדש ''שלום קוראים לי עולם''", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "ארד קוסטיוקובסקי שוורץ בסינגל חדש - כי לא תעזוב", "entities": [{"start": 0, "end": 16, "label": "SINGER"}]}
+{"text": "שמואל טולצינסקי מרגש על אסון מירון וידום אהרן", "entities": [{"start": 0, "end": 15, "label": "SINGER"}]}
+{"text": "חיים ולדר וניתאי צרפתי מה אשיב לך", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "עתי טלקר מגיש סינגל בכורה מ'גייט ווייטער", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "אביאור בהר בקאבר מרגש עם הלהיט ''שבורי לב''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "רמי קלינשטיין בשיר חדש הלב בוער", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "משה וולפא בסינגל חדש ''מיין לעבן''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "הרצל פרייב בסינגל חדש מתוך פרויקט חיזוק אלוקינו", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "זלמן אבקסיס מחתן את בנו ומודה בשירה ישימך", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "צבי אייזנשטיין ואדי מועלם מרגשים בחופה", "entities": [{"start": 0, "end": 14, "label": "SINGER"}]}
+{"text": "כתריאל ספורטה בשירו החדש - אידישע תאוות (התאוות היהודיות)", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "פרחי מיאמי ו-10,000 בני תורה ביהורם זרקאשיר - ''בעבור אבותינו''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "רוני קראוס ב'מחרוזת גלות' מתוך מופע 'אדוארד חכם' ה34", "entities": [{"start": 0, "end": 10, "label": "SINGER"}, {"start": 37, "end": 47, "label": "SINGER"}]}
+{"text": "יענקי רובין בסינגל בכורה מוצאי שבת קודש – ברדיטשוב", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "דודי הרשקופ הלחין ושר מה יתרון", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "אוהד בכר בקאבר לשירו של עקיבא - ''לך לך''", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "שמחה ובר בסינגל רביעי ירושלים הבנויה", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "מלאכי תנעמי - מחרוזת חסידית #2", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "לירוי כרמל מארח את הלל פאלי מי שאוהב", "entities": [{"start": 19, "end": 27, "label": "SINGER"}, {"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "כלב משען ואלדד רחמים - מחרוזת דאנס", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "אילון יתח בסינגל חדש ומרגש לזכרו של אחיו ''אלקא דמאיר עננו''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "פריאל טובל מגיש מחרוזת ממקומך", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "דן בקרמן בסינגל חדש והיו עיני", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "יונגרליך & אמני המוזיקה היהודית - שיר האחדות", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "יצחק רוזנבלום מרגש בסינגל חדש - 'איך דאווען' (אני מתפלל)", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "יעקב זרוג & ישיבת בית דוד - אני אוהב אותך השם", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "נחמן אוחיון מגיש סינגל חדש ''אל תדין חברך''", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "בועז חלבי בסינגל חדש יהודי בכל כוחי", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "אביב יוסף בסינגל חדש ''אזמרה לך''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "ביני לנדאו שר לרגל היארצייט 'הייליגע בעל שם'", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "יפעת שטיינברג שר מלחניו של כצל'ה ברוך קל עליון", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "אבשלום לייזרוביץ משחרר סינגל חדש חסדו", "entities": [{"start": 0, "end": 16, "label": "SINGER"}]}
+{"text": "עמי נעים, עקיבא מוריה, אוהד סיאני ואשר וינר הייליגער ר' שמעון", "entities": [{"start": 10, "end": 21, "label": "SINGER"}, {"start": 23, "end": 33, "label": "SINGER"}, {"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "פלג רוימי & שמעיה גרוסמן - מחרוזת ל''ג בעומר", "entities": [{"start": 0, "end": 9, "label": "SINGER"}, {"start": 12, "end": 24, "label": "SINGER"}]}
+{"text": "עוזי שפיגלמן וראובן הרשיש במחרוזת ניגונים מקפיצה במיוחד", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "מיכאל קונסמן שר לכבודו של רשב''י ''זה האיש''", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "משה-דורון ברדא & עזרי גרינברג - תורתו מגן לנו", "entities": [{"start": 17, "end": 29, "label": "SINGER"}, {"start": 4, "end": 14, "label": "SINGER"}]}
+{"text": "בניה ברק מגיש את הגרסה החסידית לשירו ''עולו''", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "יפתח קלמרו מארח את שייקה אופיר וסמי רויזמן בשיר חדש ''כדאי''", "entities": [{"start": 19, "end": 30, "label": "SINGER"}, {"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "לכבוד סיים סדר זרעים ע''י רפי המלך מנחם שטיינברג, אהרון דנאי ואהרן בירק' - יגיעתי", "entities": [{"start": 50, "end": 60, "label": "SINGER"}, {"start": 35, "end": 48, "label": "SINGER"}]}
+{"text": "אביתר עוזרי בסינגל חדש 'עוסק בתורה' לקראת חג השבועות", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "דין שיטרית & שיבי קלר בסינגל חדש לשבועות ''בהגלותך''", "entities": [{"start": 13, "end": 21, "label": "SINGER"}, {"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "עינב סופר בסינגל לקראת חג השבועות ''כי המצווה''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "אבי מן וילד הפלא נוחי קאופמן שרים ותן חלקנו", "entities": [{"start": 0, "end": 6, "label": "SINGER"}]}
+{"text": "שחר לבין רעי שטרן וגיא דנינו - מחרוזת סיום הש''ס", "entities": [{"start": 0, "end": 8, "label": "SINGER"}, {"start": 9, "end": 17, "label": "SINGER"}]}
+{"text": "הרב משה הומינר ביצירה לחג השבועות ''והערב נא''", "entities": [{"start": 4, "end": 14, "label": "SINGER"}]}
+{"text": "שלוימ'לה קרישבסקי, שייע בערקא ואורן בראון עם הלחן של באבוב לשבועות  - תורת ה' תמימה", "entities": [{"start": 0, "end": 17, "label": "SINGER"}]}
+{"text": "ניתאי יעקובוב בסינגל חדש לכבוד חג מתן תורה 'התורה והשמחה'", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "זאנויל וינברגר, עילי בוטנר והילדים שרים ויהיו זרעי (יש מוזיקה)", "entities": [{"start": 16, "end": 26, "label": "SINGER"}]}
+{"text": "החזן אבישי דורון שר לכבוד שבת קודש 'שחרית לשבת'", "entities": [{"start": 5, "end": 16, "label": "SINGER"}]}
+{"text": "משה אמת מרגש עם ''אב הרחמים'' לזכר הרוגי מירון", "entities": [{"start": 0, "end": 7, "label": "SINGER"}]}
+{"text": "'יוחנן שטדלר' וילדי הפלא בשיר חדש לע''נ הקדושים שנספו במירון", "entities": [{"start": 1, "end": 12, "label": "SINGER"}]}
+{"text": "עומרי כהן בסינגל חדש ''ומחה השם דמעה'' בעקבות אסון מירון (יש מוזיקה)", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "שלמה יעקב וועבער בביצוע מחודש א-איד של תם זהר באידיש", "entities": [{"start": 39, "end": 45, "label": "SINGER"}]}
+{"text": "דותן טוסי מגיש ''א-לי למה עזבתני'' לזכר הקדושים מאסון מירון (יש מוזיקה)", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "זלמן רבין וגבע שפיגל לזכרו של שרגי 'כרחם אב' (יש מוזיקה)", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "ישראל רוזין זועק בעקבות אסון מירון 'שמעתי' (יש מוזיקה)", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "נחמן פילמר ואייל גולן עם הגרסה הווקאלית 'איך בין דיינס'", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "אסי פונפדר שר תמים תהיה לע''נ הרוגי מירון", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "תור ינקלביץ ונמרוד דייני - זיו הקודש", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "08 מנחם פיליפ שר וזכני - ווקאלי מתוך שירי פנחס 2", "entities": [{"start": 3, "end": 13, "label": "SINGER"}]}
+{"text": "02 יוסף יצחק פרקש ודן מלול בביצעו וואקלי אנא בכוח", "entities": [{"start": 3, "end": 17, "label": "SINGER"}]}
+{"text": "01 יהב סופר מגיש 'אדרבה' בווקאלי בביצוע ישראל א  גרובייס", "entities": [{"start": 40, "end": 56, "label": "SINGER"}, {"start": 3, "end": 11, "label": "SINGER"}]}
+{"text": "07 בוריס קליין, חננאל שוורצמן, שמואל יונה - נאך איין שבת - ווקאלי", "entities": [{"start": 31, "end": 41, "label": "SINGER"}, {"start": 16, "end": 29, "label": "SINGER"}, {"start": 3, "end": 14, "label": "SINGER"}]}
+{"text": "04 ר' שם ששון בגרסה ווקאלית ללהיט אין גדולה כגדולתך", "entities": [{"start": 6, "end": 13, "label": "SINGER"}]}
+{"text": "05 חן הרשקוביץ מבצע את שירו עם עדיאל בכר, בליווי אלי דקס, ו'יוני ווקסלר'  ''מה תשתוחחי'", "entities": [{"start": 49, "end": 56, "label": "SINGER"}, {"start": 3, "end": 14, "label": "SINGER"}, {"start": 31, "end": 40, "label": "SINGER"}, {"start": 60, "end": 71, "label": "SINGER"}]}
+{"text": "06 מרדכי ספוקויני & שמעון גוטפריד & סער שמע - מה תשתוחחי", "entities": [{"start": 3, "end": 17, "label": "SINGER"}, {"start": 36, "end": 43, "label": "SINGER"}, {"start": 20, "end": 33, "label": "SINGER"}]}
+{"text": "09 הרב דוד צייטאג ושמחה חביב מגישים חזק קרייתי", "entities": [{"start": 7, "end": 17, "label": "SINGER"}]}
+{"text": "הרב גיל משען מספר עדות מטלטלת - חזר מהמתים - נס מירון", "entities": [{"start": 4, "end": 12, "label": "SINGER"}]}
+{"text": "אלי גרסטנר שר לזכרו של שרגי זל 'כרחם אב'", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "שוקי נסים בביצוע ספונטני למילים של הרוג מהאסון שיר האמונה", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "יואל טייכמן ואלדד פרידמן הוציאו שיר חדש לזכר הרוגי מירון ''עד מתי''", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "'כרמל בבג'נוב' מרגשים לזכר הקדושים 'על אלה אני בוכיה'", "entities": [{"start": 1, "end": 13, "label": "SINGER"}]}
+{"text": "גדי אליהו ומשולם ויזל בסינגל ''על אלה'' בעקבות האסון", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "דפנה מטלון בשיר חדש אותו כתב והלחין נחם ה' לאחר האסון", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "דודי הרץ משתף שיר שכתב על האסון", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "יעקב זינגר בשיר ווקאלי מרטיט 'על אלה אני בוכיה' (שיר ישן)", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "גדליה ג'קסון עודכן על הטרגדיה ופתח בגראמן מרגשים", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "אביהו שוורץ שיבלח''א, אחיהם של האחים אלחדד ז''ל בריאיון", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "אלישע מנדל מגיש תשובות לזכר הטהורים שנספו בל''ג בעומר", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "הזמר החסידי ר' שמעיה דניאל ז''ל שנהרג במירון בשירה חֲמוֹל עַל מַעֲשֶׂיךָ", "entities": [{"start": 15, "end": 26, "label": "SINGER"}]}
+{"text": "אופיר בדיחי & משה גפני עם קאבר ווקאלי אני מאמין", "entities": [{"start": 14, "end": 22, "label": "SINGER"}, {"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "אברהם בן דוד שר על הטרגדיה הקשה במירון ווען איינער וויינט", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "הרב אסתר עוז השאלות הנוקבות בעקבות האסון", "entities": [{"start": 4, "end": 12, "label": "SINGER"}]}
+{"text": "דור ברין, גיא ממן, ג'ורדן ברוידא, יחיעם גינצברג, מנדי ויס, דוידוביץ - שלום זכר (ווקאלי)", "entities": [{"start": 34, "end": 47, "label": "SINGER"}, {"start": 10, "end": 17, "label": "SINGER"}, {"start": 19, "end": 32, "label": "SINGER"}, {"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "נתנאל עמר, אודי גולדברג, והחברים מגישים קידוש - ווקאלי", "entities": [{"start": 0, "end": 9, "label": "SINGER"}, {"start": 11, "end": 23, "label": "SINGER"}]}
+{"text": "06 רבון העולמים ידעתי - אלרואי תל", "entities": [{"start": 24, "end": 33, "label": "SINGER"}]}
+{"text": "05 יניב אלבום ורות בלוי – שמע בני", "entities": [{"start": 3, "end": 13, "label": "SINGER"}]}
+{"text": "03 חנניה ראקוב ואיתיאל עטר 'אמר רבי עקיבא' וואקלי", "entities": [{"start": 3, "end": 14, "label": "SINGER"}]}
+{"text": "07 ברק קרמר ומשה שטקל עם המעבד והמנצח הרשל בריסק - הנה זה בא", "entities": [{"start": 3, "end": 11, "label": "SINGER"}]}
+{"text": "04 דרור שפנגנטל וילד הפלא ציון בושרי – דע כי יש שדה", "entities": [{"start": 26, "end": 36, "label": "SINGER"}, {"start": 3, "end": 15, "label": "SINGER"}]}
+{"text": "09 מרדכי וואלף רן אדרי וילד הפלא יצחק סטום בביצוע וואקלי לשיר מזמור לדוד", "entities": [{"start": 33, "end": 42, "label": "SINGER"}, {"start": 15, "end": 22, "label": "SINGER"}]}
+{"text": "08 נחמן גולדברג ומקהלת הילדים עיליי בלטה מים רבים בביצוע וואקלי", "entities": [{"start": 30, "end": 40, "label": "SINGER"}, {"start": 3, "end": 15, "label": "SINGER"}]}
+{"text": "02 מוטי שטינץ ולהקת הילדים נולי שרדר בביצוע ווקאלי 'אתה קדוש'", "entities": [{"start": 3, "end": 13, "label": "SINGER"}, {"start": 27, "end": 36, "label": "SINGER"}]}
+{"text": "01 אל הנער הזה התפללתי - יוסף שאול וירדן בושרי - ווקאלי", "entities": [{"start": 25, "end": 34, "label": "SINGER"}]}
+{"text": "11 זליג שביט ו'זאנוויל' בביצוע ווקאלי מרגש ירושלים תתן קולה", "entities": [{"start": 3, "end": 12, "label": "SINGER"}]}
+{"text": "מחרוזת ל״ג בעומר - רבי מנחם אסולין (דיג׳יי מנשה)", "entities": [{"start": 23, "end": 34, "label": "SINGER"}]}
+{"text": "אמרי אטדגי מחדש שמע אותי - הגרסה הווקאלית", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "שגיא שפירו מגיש אלקא דרבי מאיר עננו בביצוע ווקאלי", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "מייקל מלקו בגרסה ווקאלית לשירו המרגש 'הגלה נא'", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "טומי הורביץ בקלאסיקה ווקאלית לניגון החסידי העתיק", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "נחום אריה מבצעת את הכל משמיים בגירסה הווקאלית", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "אביגיל חן חוזר בגרסת אקפלה 'יהיו לרצון'", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "03 ילד הפלא הילל לוזון מרגש עם 'מודה אני לפניך'", "entities": [{"start": 12, "end": 22, "label": "SINGER"}]}
+{"text": "11 יוסי פרנקל בלונדון עם פיני יקואל 'מודים'", "entities": [{"start": 25, "end": 35, "label": "SINGER"}, {"start": 3, "end": 13, "label": "SINGER"}]}
+{"text": "04 רועי סלוצקר וידידים מרגשים באקפלה ״ותתפרקון״", "entities": [{"start": 3, "end": 14, "label": "SINGER"}]}
+{"text": "05 מרים גיל בגרסה ווקאלית לשירו המרגש וקולו נשמע", "entities": [{"start": 3, "end": 11, "label": "SINGER"}]}
+{"text": "08 כרחם - נוהר צדר", "entities": [{"start": 10, "end": 18, "label": "SINGER"}]}
+{"text": "06 גד פיוריזין - ויהיו רחמיך (ווקאלי)", "entities": [{"start": 3, "end": 14, "label": "SINGER"}]}
+{"text": "09 יששכר חדאד להשם הארץ ווקאלי", "entities": [{"start": 3, "end": 13, "label": "SINGER"}]}
+{"text": "01 איליי אור ומקהלת הילדים שרים ישראל המחכים", "entities": [{"start": 3, "end": 12, "label": "SINGER"}]}
+{"text": "12 לדוד מזמור שניאור חמיאס ומוטי גלויברמן-גן", "entities": [{"start": 14, "end": 26, "label": "SINGER"}]}
+{"text": "07 גילי וינטר ווקאל & מתאו סנדקה - דיינו", "entities": [{"start": 3, "end": 13, "label": "SINGER"}, {"start": 22, "end": 32, "label": "SINGER"}]}
+{"text": "15 רונאל אברמוביץוואג מחדש את עידו מנדלסון 'אמת'", "entities": [{"start": 30, "end": 42, "label": "SINGER"}]}
+{"text": "13 בני שניידר׳ וגיורא פליישמן – ונתנה תוקף", "entities": [{"start": 3, "end": 13, "label": "SINGER"}]}
+{"text": "14 מקהלת ישיש והחזן אחיה אמיתי - מתי תמלוך בציון", "entities": [{"start": 20, "end": 30, "label": "SINGER"}]}
+{"text": "ברק פרידמן ממשיך ומוציא שוב ''שבחים 2'' - תקציר האלבום - ווקאלי", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "שניר יעקובוב בביצוע ווקאלי משכנו", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "להב טאובה בסינגל ווקאלי ייחודי יֻדַּד", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "גרשון ורובה מגיש לכבוד לג בעומר תורתו מגן לנו", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "אופיר ברנשטיין בביצוע ווקאלי ללהיט של צבי טוקר 'שבורי לב'", "entities": [{"start": 38, "end": 46, "label": "SINGER"}, {"start": 0, "end": 14, "label": "SINGER"}]}
+{"text": "ראם האוקיפ בקאבר ווקאלי לשיר ''אותו היום'' של אדר סבוני", "entities": [{"start": 46, "end": 55, "label": "SINGER"}, {"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "ירון פרידמן עם גירסה ווקאלית ל'מן המיצר'", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "חנן נמיר ואוהד חן לימי העומר ''מלך רחמן''", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "יהונתן זנו, ילד הפלא אדר הוניגמן - שוכן עד - ווקאלי", "entities": [{"start": 21, "end": 32, "label": "SINGER"}, {"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "אראל חג'ג מגיש ביצוע ווקאלי לשיר נוסטלגי של ר' ניסן והב 'הטוב הטוב'", "entities": [{"start": 0, "end": 9, "label": "SINGER"}, {"start": 47, "end": 55, "label": "SINGER"}]}
+{"text": "01 אלעזר סמין ויואל קליין - ואהבת", "entities": [{"start": 3, "end": 13, "label": "SINGER"}]}
+{"text": "03 משפחת 'מלכות' & נתי אילוז - 'עוד ישבו'", "entities": [{"start": 19, "end": 28, "label": "SINGER"}]}
+{"text": "02 (אביטל פלג - רפואה - (ווקאלי", "entities": [{"start": 4, "end": 13, "label": "SINGER"}]}
+{"text": "06 אברהם גונצ'רנקו - ומחה ה' דמעה - ווקאלי", "entities": [{"start": 3, "end": 18, "label": "SINGER"}]}
+{"text": "07 וזכני - ציון מינקוב & ריף דרמון & איתי עמרן ושיר ושבח - לארגון בוני עולם", "entities": [{"start": 37, "end": 46, "label": "SINGER"}, {"start": 11, "end": 22, "label": "SINGER"}, {"start": 25, "end": 34, "label": "SINGER"}]}
+{"text": "15 שרון גנדלין - מירון תש''פ", "entities": [{"start": 3, "end": 14, "label": "SINGER"}]}
+{"text": "12 יוסף דלאל - אהבת ישראל - ווקאלי", "entities": [{"start": 3, "end": 12, "label": "SINGER"}]}
+{"text": "17 אביחי שרעבי מגיש אוטוטו בביצוע וואקלי", "entities": [{"start": 3, "end": 14, "label": "SINGER"}]}
+{"text": "13 נתן וקסלר - דא וואוינט א איד (ווקאלי)", "entities": [{"start": 3, "end": 12, "label": "SINGER"}]}
+{"text": "04 יהודה וייס ואורון אוסטפלד בסינגל רווי אמונה וביטחון בהשית 'והוא לבדו' (ווקאלי)", "entities": [{"start": 3, "end": 13, "label": "SINGER"}]}
+{"text": "05 יזהר כהנא ודניאל גרינברג - אשרינו -ווקאלי", "entities": [{"start": 3, "end": 12, "label": "SINGER"}]}
+{"text": "16 יונתן שוורץ & אריאל זילבר - כי טוב השם - ווקאלי", "entities": [{"start": 3, "end": 14, "label": "SINGER"}, {"start": 17, "end": 28, "label": "SINGER"}]}
+{"text": "09 ילד הפלא נחום קוסטר שר רפאינו השם", "entities": [{"start": 12, "end": 22, "label": "SINGER"}]}
+{"text": "11 אבירן נשיא מרגש לרגל הילולת ר' ישעיל'ה  - ר' ישעי' בן ר' משה (ווקאלי)", "entities": [{"start": 3, "end": 13, "label": "SINGER"}]}
+{"text": "מתניה דפן בגרסה ווקאלית ללהיט שיר פשוט", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "מקסים אלנה עם הגרסה הוואקלית של מתי", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "איתם טיבי, מקהלת 'זמירות', אליה פנחסוב - מחרוזת אדיר ווקאלי", "entities": [{"start": 0, "end": 9, "label": "SINGER"}, {"start": 27, "end": 38, "label": "SINGER"}]}
+{"text": "אלדד כהן מגיש אוטוטו בביצוע וואקלי", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "יידאלע מנדלסון בגרסה ווקאלית ללהיט - הללו", "entities": [{"start": 0, "end": 14, "label": "SINGER"}]}
+{"text": "צליל שרון & ערן טוקרסקי העולמית - השבעתי (ווקאלי)", "entities": [{"start": 12, "end": 23, "label": "SINGER"}, {"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "ענבר אלבז בביצוע ווקאלי לשירו החדש סיבת הסיבות", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "ירון נזרי - כוכבים - הגרסה הווקאלית", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "ניק פדרמן בסינגל ווקאלי חדש הכל מלמעלה", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "להב שווב מגיש אלבום חדש 'ספירה מיט יהושע בראל' - דוגמה", "entities": [{"start": 35, "end": 45, "label": "SINGER"}, {"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "הראל ברנס בביצוע ווקאלי ללהיט החדש של ריבו 'סיבת הסיבות'", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "יניר טובול ''חוזר אל האמת'' בגרסת אקפלה לימי ספירת העומר", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "שלום לעממער שר בגרסה ווקאלית שמעה תפילתי", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "רותם קורקוס שר ווקאלי בלבבי משכן אבנה", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "להקת מזמור שיר עם 'מלך רחמן' של מרדכי ז'ורבל", "entities": [{"start": 32, "end": 44, "label": "SINGER"}]}
+{"text": "האחים פוטולסקי מבצע את היצירה של מיכאל צידון אדיר הוא", "entities": [{"start": 33, "end": 44, "label": "SINGER"}, {"start": 0, "end": 14, "label": "SINGER"}]}
+{"text": "'תראפיה' מארחים את יהודה פליישמן בסינגל חדש - רמזור", "entities": [{"start": 19, "end": 32, "label": "SINGER"}]}
+{"text": "שלומי טל & גאבור פרסר - ליל שימורים", "entities": [{"start": 0, "end": 8, "label": "SINGER"}, {"start": 11, "end": 21, "label": "SINGER"}]}
+{"text": "צבי יהודה, אליעזר תרשיש, אהר'לע סאמעט, אבידן סלוצקר - דאווענען", "entities": [{"start": 0, "end": 9, "label": "SINGER"}, {"start": 11, "end": 23, "label": "SINGER"}, {"start": 39, "end": 51, "label": "SINGER"}]}
+{"text": "אוריה ליבוביץ מבצע את היצירה של אלדד רואה לספירת העומר", "entities": [{"start": 0, "end": 13, "label": "SINGER"}, {"start": 32, "end": 41, "label": "SINGER"}]}
+{"text": "סגל ברונפמן, מנשה צ'רני וילד הפלא חסל סידור פסח", "entities": [{"start": 13, "end": 23, "label": "SINGER"}, {"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "אורין צרויה בסינגל החדש כ'דאנק כ'קען דאנקען'", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "ג'ק שחר, אברום מרדכי שוורץ, אסף פנקס, איתי וגנר, ויגל קונסטנטין על במה אחת", "entities": [{"start": 38, "end": 47, "label": "SINGER"}, {"start": 0, "end": 7, "label": "SINGER"}, {"start": 28, "end": 36, "label": "SINGER"}]}
+{"text": "טוביה פקר במחרוזת מקפיצה 'פסח דאנס'", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "ליאב שושנה ולאון זגורי בדואט חדש אם אמרתי", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "ג_וזף נולס והמקהלה מבצעים את תפילת טל של ישכר שניידרמן", "entities": [{"start": 41, "end": 54, "label": "SINGER"}, {"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "להקת נשמחה וחנניה וילנסקי - 'ישימך אלוקים", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "יענקי ברוין, פרץ בק, ודורי ברודר שרים יבואו טהורים", "entities": [{"start": 0, "end": 11, "label": "SINGER"}, {"start": 13, "end": 19, "label": "SINGER"}]}
+{"text": "יחיאל ששון מארחת את ילדי הפלא בפיוט לכבוד החג ''יום ליבשה''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "צחי דנילוב סוחף ומרגש עם 'קדש ורחץ'", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "יאיר משה עטיה מגיש מחרוזת שירי ליל הסדר", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "גרשי שווארץ מחדש את ''ממצרים גאלתנו'' במסגרת 'צמאה' של חב''ד", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "מוטי אילוביץ' ואדיב כץ בדואט זרעא חיא", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "הרב רוי מילמן ו'ומקהלת הילדים דבורה אביטל' מבצעים את היצירה חד גדיא של אהרל'ה וינטרוב", "entities": [{"start": 30, "end": 41, "label": "SINGER"}, {"start": 4, "end": 13, "label": "SINGER"}, {"start": 71, "end": 85, "label": "SINGER"}]}
+{"text": "בן-ציון מנקר בביצוע אקוסטי ללהיט אדיר במלוכה", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "אייל אורן ואודי ישראלי - זוכר אני", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "אלדד דזיאלובסקי והמעבד קיריל מושקוביץ עם והיא שעמדה של חבד", "entities": [{"start": 23, "end": 37, "label": "SINGER"}, {"start": 0, "end": 15, "label": "SINGER"}]}
+{"text": "לכבוד יום הולדת הרבי אושרי מעוז מרגש עם אבינו מלכנו", "entities": [{"start": 21, "end": 31, "label": "SINGER"}]}
+{"text": "יאן עמר וצבי לוי שרים את הלחן של הרב גינזבורג שיר המעלות אל ה", "entities": [{"start": 0, "end": 7, "label": "SINGER"}]}
+{"text": "ליאו קולקובסקי בסינגל חדש חסל", "entities": [{"start": 0, "end": 14, "label": "SINGER"}]}
+{"text": "יעקב-מרקמן מגיש בסינגל שלישי לא להישבר", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "מנשה אלון & עמוס לוינסקי - אחים", "entities": [{"start": 12, "end": 24, "label": "SINGER"}, {"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "חנוך לופס בסינגל לחג הפסח נרצה", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "ארבל פליישר במחרוזת להיטי חג הפסח", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "ענהאל סינייור בסינגל חדש ואופטימי לפסח ''מי יודע''", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "שמשון וילנסקי ב'שיר המעלות' חדש", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "טנא ווקנין עם סינגל קצבי חדש שיר ושבחה", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "עומר אדם בסינגל חדש - חסל סידור פסח", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "אמנון וינברג - 'והיא שעמדה'", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "הראל אלייב בסינגל חדש 'המלאך'", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "בן מרקוביץ בביצוע לייב ''לא אבוא''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "תיאו יונתנוב משחרר שיר נוסף סוחף ואנרגטי במיוחד חייב אדם", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "מלכיאל ליכטר בסינגל החדש 'הלב שואל'", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "אלרואי פלדמן ואלעזר קדם בסינגל חדש ייחודי אני מריח", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "לייבל השל בביצוע 'הושיעה את עמך'", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "דודו אהרון מגיש סינגל חדש 'מסע בזמן'", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "תום שניר בסינגל חדש לספר ביציאת מצרים", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "שלום צברי בלהיט חדש לחג הפסח - בני חורין", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "רם ניוטון מתכונן לפסח עם אודך, ניגון מבית סבא", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "הדר שנברגר - לחירותינו", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "הראפר עומרי זליג כובש בסינגל חדש – זמן חרותנו", "entities": [{"start": 6, "end": 16, "label": "SINGER"}]}
+{"text": "הים ראה וינוס - אליה צמח ולהקת השיליצים", "entities": [{"start": 16, "end": 24, "label": "SINGER"}]}
+{"text": "שאול ברמן בלהיט חדש לחג הפסח - בני חורין~1", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "אדר אפרגן & אייל עמיר - מחרוזת שירי פסח", "entities": [{"start": 0, "end": 9, "label": "SINGER"}, {"start": 12, "end": 21, "label": "SINGER"}]}
+{"text": "דורון ביטון, תבל נגר, שאול דורון - מחרוזת חג הפסח", "entities": [{"start": 22, "end": 32, "label": "SINGER"}, {"start": 13, "end": 20, "label": "SINGER"}, {"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "מכביטס - והיא שעמדה", "entities": [{"start": 0, "end": 6, "label": "SINGER"}]}
+{"text": "אוראל שדה - והיא שעמדה", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "חנוך רייז ומתניה גל שואלים ''הלילה הזה''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "נתנאל & ליאור גבע  - והיא שעמדה", "entities": [{"start": 8, "end": 17, "label": "SINGER"}]}
+{"text": "סינגל ביכורים מענדי טווערסקי בדרך לאלבום 'קרב יום'", "entities": [{"start": 14, "end": 28, "label": "SINGER"}]}
+{"text": "אביחי רוזנצויג והחצוצרה מבצע את והיא שעמדה של רזאל", "entities": [{"start": 0, "end": 14, "label": "SINGER"}]}
+{"text": "האחים יואלי ולהקת המושב - בני חורין של תמר אברהמי", "entities": [{"start": 39, "end": 49, "label": "SINGER"}]}
+{"text": "יוני פופוביץ  – והיא שעמדה", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "ר' ריי קלימוביצקי בביצוע מרגש ל'אדיר הוא' באידיש טעמפל שירה", "entities": [{"start": 3, "end": 17, "label": "SINGER"}]}
+{"text": "אילון גלזר מבצע עתידין להיגאל", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "ה'סדר' של צדף גורפינקל, אריה קסטנר ואלחנן בקרמן", "entities": [{"start": 24, "end": 34, "label": "SINGER"}, {"start": 10, "end": 22, "label": "SINGER"}]}
+{"text": "יניר אלזם בלחן מרגש למילותיו של ליפא שְׁפֹךְ חֲמָתְךָ", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "לעכטיג עלי וקנין וגד דיעי מרטיטים בדואט", "entities": [{"start": 7, "end": 16, "label": "SINGER"}]}
+{"text": "מימון נגר מבצע את והיא שעמדה בלחן של הרבי מליובאוויטש זצל", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "הפייטן יוחנן לקח משיק לפני חג הפסח סינגל חדש “פודה מצר ענני", "entities": [{"start": 7, "end": 16, "label": "SINGER"}]}
+{"text": "משה דוד ווייסמאנדל במחרוזת שירי פסח עם קלרינט וקלידים", "entities": [{"start": 0, "end": 18, "label": "SINGER"}]}
+{"text": "גרשון וורבה, קובי מרימי, מושי מנדלסון - מחרוזות פסח", "entities": [{"start": 0, "end": 11, "label": "SINGER"}, {"start": 13, "end": 23, "label": "SINGER"}]}
+{"text": "אלכס חמדני בסינגל חדש לפסח מה נשתנה", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "מני ללו בשיר חדש לפסח – והיא שעמדה", "entities": [{"start": 0, "end": 7, "label": "SINGER"}]}
+{"text": "פסח – פה סח - הרב אסיף שילה שליטא", "entities": [{"start": 18, "end": 27, "label": "SINGER"}]}
+{"text": "עומרי רוט מארח את שמעון פיש 'הא לחמא עניא'", "entities": [{"start": 18, "end": 27, "label": "SINGER"}, {"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "יוסי טויטו בביצוע ביתי ל'והיא שעמדה' הכי מפורסם", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "בניהו פלמון משחרר את ''והיא שעמדה''", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "יעקב מגור ומשפחתו - בצאת ישראל", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "משה לעווי מגיש גירסה וואקלית לוהיא שעמדה", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "הרשי וויינבערגער - הגדה של פסח נוסח בגדאדי עתיק יומין", "entities": [{"start": 0, "end": 16, "label": "SINGER"}]}
+{"text": "רובי גולץ וניראל אייכנשטיין - חסל סדור פסח", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "לירוי חדש מפתיע עם לחן חדש 'והיא שעמדה", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "אלטר ברמן שוורץ - אלקא", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "זוהר זבדי - אתה בחרתנו", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "יאן סירי - היא שעמדה", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "עובד מזור - והיא שעמדה", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "ישי יחזקאל עם שיר וסיפור לליל הסדר", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "חננאל צימרמן ויונה אבידור בדואט מהבית ויושע השם", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "ונצעק - שירז וויסנברג", "entities": [{"start": 8, "end": 21, "label": "SINGER"}]}
+{"text": "הרחמן - אשל חיימוביץ", "entities": [{"start": 8, "end": 20, "label": "SINGER"}]}
+{"text": "שלמה זלמן ריבלין - דיינו", "entities": [{"start": 0, "end": 16, "label": "SINGER"}]}
+{"text": "ר' שושנה בן-דוד עם שיר בניחוח מוזיקלי של פעם אברכה את ה'", "entities": [{"start": 3, "end": 15, "label": "SINGER"}]}
+{"text": "אמרי פריזנד מוציא שיר נוסף מהאלבום השני שבדרך 'אתה הולך איתי'", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "אליעד ירושלמי ברסון מתכונן לתפילות החג עם ''והשב''", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "שלוימי דסקל הלחין, גילאור כרמי שר מזמור לתודה", "entities": [{"start": 0, "end": 11, "label": "SINGER"}, {"start": 19, "end": 30, "label": "SINGER"}]}
+{"text": "אילן בן-חיים ושגיב ז'וקוב במחרוזת חתונה סוערת ומקפיצה", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "עקיבא תורג'מן בסינגל חדש תענה לי", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "דרור טל מרדכי יהודה דירנפלד ותמוז שלוסברג במחרוזת ריקודים סוחפת", "entities": [{"start": 0, "end": 7, "label": "SINGER"}, {"start": 8, "end": 27, "label": "SINGER"}]}
+{"text": "להקת חזקיה אורבך בסינגל קצבי חדש 'התעוררו יהודים'", "entities": [{"start": 5, "end": 16, "label": "SINGER"}]}
+{"text": "שמעון שפיצער מודה להשם בסינגל חדש נשמת כל חי", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "בארי לוטטי כתב הלחין ושר 'אמונה'", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "יהושע כהן ואבי שלזינגר בסינגל חדש 'למדני'", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "בני סלע, מקהלות שירה וירין אלמלח ביצעו את ובמקהלות", "entities": [{"start": 0, "end": 7, "label": "SINGER"}]}
+{"text": "שי עמר שר על הבחור שנפטר חבל על דאבדין", "entities": [{"start": 0, "end": 6, "label": "SINGER"}]}
+{"text": "יאיר שובל בסינגל חדש משירי ר פייטל לוין אין כאלוקינו", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "אהרן חריטונוב עם הלהיט החדש  'דעת תורה'", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "יוס'ל לייפר, יצחק לסלאו ו'נשמה' א חתונה טאנץ", "entities": [{"start": 13, "end": 23, "label": "SINGER"}]}
+{"text": "מכלוף סויסה ובני שר בלהיט מרגש משותף אילן", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "הדר אופנהיים חוזר עם להיט מקפיץ נא נא", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "רום לפידוס בסינגל חדש -אשריך נער ישראל", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "נחום סעדה חוזר עם סינגל חדש הגואל המשיח", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "חנוך נזר לרגל החזרה לאולמות מחרוזת החתנים של ישראל", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "אחיה אוחיון בסינגל חדש שביר", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "לאון יולס בסינגל מלא אמונה בטח בהשם", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "אפיק קוריאת הלחין ושר - 'הנה הגאולה'", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "אושר נמיר בסינגל חדש 'השם ישמור'", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "מייק קנול & מתי פקדו בדואט אני או אתה", "entities": [{"start": 0, "end": 9, "label": "SINGER"}, {"start": 12, "end": 20, "label": "SINGER"}]}
+{"text": "לייזר ברוק ו'מלכות' מרגשים בסינגל חדש והנה נער בוכה", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "יחיאל דוברי משיק שיר 'אודך' מאלבומו הבכורה 'איה'", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "זינובי שולמן שר על בבא חאקי לקראת ההילולא", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "יצחק הבר וזאנוויל וויינבערגער בקאבר ללהיט של שלום עמרם ירא שמים", "entities": [{"start": 0, "end": 8, "label": "SINGER"}, {"start": 45, "end": 54, "label": "SINGER"}]}
+{"text": "שמחה מלצר ואורן כהן הוציא לכבוד השמחה עדי עד", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "נריה מכלוף, אבינועם פרידמן ואריק ברלין שרים מים בוכים", "entities": [{"start": 12, "end": 26, "label": "SINGER"}, {"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "עידן ישעיהו בסינגל שהופק לכבוד בר המצווה", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "אמנון רוזנטל הלחין ומבצע 'כשושנה'", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "עידן דוד ושחף לאער בסינגל בחדש ''מזמור לתודה''", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "ירוחם פחימא בסינגל בכורה מרגש - יש ימים", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "נוי שלמה ויניר קנר בדואט שבת מלכתא", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "ארבל פרקר בסינגל שני אביב בפתח", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "לבוא אל המלך - ביצוע מיוחד עם שני נאמני", "entities": [{"start": 30, "end": 39, "label": "SINGER"}]}
+{"text": "לירז אהרוני שר ומזכיר כי זה הזמן לסלוח", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "זכריה גרינפלד מקדיש שיר לשוויגר (חמותו) שנפטרה אמא שלי", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "ישורון וילדרמן בדואט עם בנימין דנישמן קרוב", "entities": [{"start": 24, "end": 37, "label": "SINGER"}, {"start": 0, "end": 14, "label": "SINGER"}]}
+{"text": "גיא מרקל בסינגל - ביחד ננצח", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "ענבר אגיבייב & יוהד קטלן - אותו חלום", "entities": [{"start": 0, "end": 12, "label": "SINGER"}, {"start": 15, "end": 24, "label": "SINGER"}]}
+{"text": "שדה פרנס מתפלל בשיר חדש ''ותתן לנו חיים''", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "אברהם פריד, מנפק להיט חדש, סיבת הסיבות", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "אסי וייס מקפיץ במחרוזת שירי שמחה במסיבת פורים", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "ר' אלראי קפלן ממאנסי בקריאת מגילה בדינר לטובת מוסדות וויען בארהב", "entities": [{"start": 3, "end": 13, "label": "SINGER"}]}
+{"text": "יהושע העשיל שארף בביצוע פורימי ליהודים", "entities": [{"start": 0, "end": 16, "label": "SINGER"}]}
+{"text": "יהודה פוליקר ואורן פלדמן בביצוע אינסטרומנטלי ל'באור גדול'", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "אפרים אלמוג - א-לי למה עזבתנו", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "נירן רובינסקי, ר' ברוך צייט, שלם הורן, קנא לשמך", "entities": [{"start": 29, "end": 37, "label": "SINGER"}, {"start": 0, "end": 13, "label": "SINGER"}, {"start": 15, "end": 27, "label": "SINGER"}]}
+{"text": "שלומי דאסקל מגיש סינגל חדש לפורים איש יהודי", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "גרי שפר ואביחי האילו בקאבר ליוסי גורביץ 'א קיבוץ פון חסידים'", "entities": [{"start": 0, "end": 7, "label": "SINGER"}]}
+{"text": "אורלי שנברגר הלחין ושר קלי למה עזבתני", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "נוף חסיד עם 20 דקות של מחרוזת פורים אין מנצ'סטר", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "אמיתי לודמר בסינגל בכורה הוא ייטיב", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "אבשלום קלימיאן & ויקטור אמינוב ונהפוכו (UpsideDown)", "entities": [{"start": 17, "end": 30, "label": "SINGER"}, {"start": 0, "end": 14, "label": "SINGER"}]}
+{"text": "הלל חכם בסינגל חדש אור ליהודים", "entities": [{"start": 0, "end": 7, "label": "SINGER"}]}
+{"text": "תומר ישעיהו וחיה קיסר במחרוזת פורים מקפיצה", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "קול זמרה מקפיץ עם ''אורה ושמחה'' על הניגון הוויז'ניצאי", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "יואל מדמון - מחרוזת פורים תשפ''א", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "יהודה ניצן - טרקלין של גאולה (רמיקס)", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "הדף היומי מסכת פסחים דף צ''ה אדר תשפ''א - שיעור בעברית מאת הרב רני חזיזה הי''ו מקול חי", "entities": [{"start": 63, "end": 72, "label": "SINGER"}]}
+{"text": "אבישי בדין, ניר קורן, בצלאל גרינברג, גל בלוך ומנחם מענדל עמאר בסינגל חתן משה מרדכי'לע", "entities": [{"start": 37, "end": 44, "label": "SINGER"}, {"start": 0, "end": 10, "label": "SINGER"}, {"start": 22, "end": 35, "label": "SINGER"}, {"start": 12, "end": 20, "label": "SINGER"}]}
+{"text": "יקיר נתן במחרוזת 'פורים דאנס' לקראת פורים", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "רפאל זמיר, יורם כרמי, ישעי' גרוס ושקד בנימין ''הקרובים''", "entities": [{"start": 11, "end": 20, "label": "SINGER"}, {"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "טום אביב & האחים בלומשטיין - שפע עד בלי די", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "שמואל אלמקיאס בסינגל חדש וקצבי 'קדושת פורים'", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "רותם נתיב מחדש את הלהיט זוכה של איציק אהרונסון", "entities": [{"start": 0, "end": 9, "label": "SINGER"}, {"start": 32, "end": 46, "label": "SINGER"}]}
+{"text": "אנדי ינקלביץ & עוזיאל פרידמן - 20 דקות של שמחה לקראת פורים", "entities": [{"start": 0, "end": 12, "label": "SINGER"}, {"start": 15, "end": 28, "label": "SINGER"}]}
+{"text": "עטיר זמנהוף, שמעון שבת, שיר ושבח & שייע פרידמן במחרוזת פורים", "entities": [{"start": 0, "end": 11, "label": "SINGER"}, {"start": 13, "end": 22, "label": "SINGER"}]}
+{"text": "צוף מיטיקו בסינגל חדש - מחשבות טובו", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "פלטיאל אלטמן  זמר חדש ''חוזר אל האמת''", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "עמירן דביר מגיש שוב שמחת החיים מספר 9 - דוגמה", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "אבי ברק בסינגל מקפיץ חדש ניסים וניסיונות", "entities": [{"start": 0, "end": 7, "label": "SINGER"}]}
+{"text": "דוד זגה מתכונן לפורים עם נכנס יין", "entities": [{"start": 0, "end": 7, "label": "SINGER"}]}
+{"text": "ישיבת חיי תורה – שירה יואי מוכניק", "entities": [{"start": 22, "end": 33, "label": "SINGER"}]}
+{"text": "רמי עדרי - ישיבת גאון יעקב", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "באר התלמוד - ועד שני, עוז דובדובני מחסנים את החתנים", "entities": [{"start": 22, "end": 34, "label": "SINGER"}]}
+{"text": "שערי תורה - מאור מעודה אמרי גפנר", "entities": [{"start": 23, "end": 32, "label": "SINGER"}, {"start": 12, "end": 22, "label": "SINGER"}]}
+{"text": "מרדכי וולף & מקסים טרבלסי במחרוזת פורים", "entities": [{"start": 0, "end": 10, "label": "SINGER"}, {"start": 13, "end": 25, "label": "SINGER"}]}
+{"text": "מחרוזת פורים מתוך חתונה עי יוחנן אופנהיימר, רן דנקר, הרב דוד נדב, רעי פרג', ואברמי קלצקין", "entities": [{"start": 27, "end": 42, "label": "SINGER"}, {"start": 53, "end": 64, "label": "SINGER"}, {"start": 44, "end": 51, "label": "SINGER"}]}
+{"text": "יונתן בירנבוים & זאב שלמה במחרוזת פורים ג'אז", "entities": [{"start": 17, "end": 25, "label": "SINGER"}, {"start": 0, "end": 14, "label": "SINGER"}]}
+{"text": "פורים טאנץ • מחרוזת שירי פורים עם קורן ישראלזון", "entities": [{"start": 34, "end": 47, "label": "SINGER"}]}
+{"text": "אלדד מעוז - מחרוזת שירי פורים", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "תימור פרימוביץ במחרוזת חדשה - מחרוזת פורים", "entities": [{"start": 0, "end": 14, "label": "SINGER"}]}
+{"text": "שמואל רוזן - מחרוזת שירי פורים", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "מני שטרית ואשר קרמר - פורים (תשע''ו)", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "אדר ארטל - מחרוזת שירי פורים (הברה ספרדית) תש''פ", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "לקראת פורים משחרר שגב שולץ מחרוזת שירים חסידית קצבית", "entities": [{"start": 18, "end": 26, "label": "SINGER"}]}
+{"text": "גרי דדון ותזמורתו מגישים מחרוזת להיטי פורים עכשווית ואנרגטית במיוחד", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "תומר שפר מתכוננת לפורים משנכנס אדר", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "שלום פרוינד חוזר עם שיר חדש דרכו של כל אחד", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "לביא רוזנשטיין' שר לכבוד שבת - 'גוט שבת ויז'ניץ'", "entities": [{"start": 0, "end": 14, "label": "SINGER"}]}
+{"text": "אהרן מיללער ומירון חמו שרים אבא איתי", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "חיים ישעיה וייל עם סינגל חדש - אין לי מילים", "entities": [{"start": 0, "end": 15, "label": "SINGER"}]}
+{"text": "עילאי באייה ו'מלכות' נפגשים שוב והפעם ה''קידוש''", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "שלומיק אברג'ל, וחתן הבר מצווה נתי ליכטשטיין, בדואט משותף 'בין קודש לחול'", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "גפן רז בשיר חדש תברך", "entities": [{"start": 0, "end": 6, "label": "SINGER"}]}
+{"text": "עופרי גולד & יהב סלומון - רפאנו", "entities": [{"start": 0, "end": 10, "label": "SINGER"}, {"start": 13, "end": 23, "label": "SINGER"}]}
+{"text": "חנן מגני - קטנתי", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "אילן אלמקיאס ועוזי רכטמן התגייסו לשיר הברכות לרפואתה של גיטי בת ה-16", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "ניר וייסמן בסינגל בכורהאבא", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "נבו אקסלרד שר הלהיט הישראלי לבחור נכון", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "יואל שקורי מפתיע בשיר- רפאנו", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "אלעזר ולדמן והמקהלה בניגון ביאלה לכבוד השמחה", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "ר' ינון ביקוב בסינגל חדש ישוב הדעת", "entities": [{"start": 3, "end": 13, "label": "SINGER"}]}
+{"text": "ניב בוקר ועוזי עופר בסינגל חדש אדוני המלך", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "חגי ימיני מגיש סינגל חדש 'יבוא יום',", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "נחמן נחשון בשיר ''להתחזק'' מתוך האלבום בכורה ''תודה לך''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "אדם טנגי בסינגל חדש לכבוד פורים אם על המלך", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "מרדכי שפירא & ילד הפלא אייל צור עקבות", "entities": [{"start": 23, "end": 31, "label": "SINGER"}, {"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "שי שיין מגיש סינגל חדש - הללו", "entities": [{"start": 0, "end": 7, "label": "SINGER"}]}
+{"text": "ציון זרובבלי בגרסת הרמיקס בקרוב", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "אבנר אליהו מארח את ריבי שוובל - עדלאידע", "entities": [{"start": 19, "end": 29, "label": "SINGER"}, {"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "טום רינגל, רבקה כהן & גד פוריזן - יבוא המלך", "entities": [{"start": 0, "end": 9, "label": "SINGER"}, {"start": 11, "end": 19, "label": "SINGER"}, {"start": 22, "end": 31, "label": "SINGER"}]}
+{"text": "חנינא מן בקאבר משעשע לפורים אם תרצו", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "פז שיש בשיר פורים חדש גוט פורים", "entities": [{"start": 0, "end": 6, "label": "SINGER"}]}
+{"text": "נדב קמחי - מחרוזת חסידית #1", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "דב חייט בלהיט חדש לפורים תשפ''א 'ובכל מדינה'", "entities": [{"start": 0, "end": 7, "label": "SINGER"}]}
+{"text": "אורן גוטמן מגיש משוגע טוב לכבוד חודש אדר", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "בנימין זילברשטיין בסינגל תפילה מרגש – מן המיצר", "entities": [{"start": 0, "end": 17, "label": "SINGER"}]}
+{"text": "רפאל עדני במחרוזת פורים משנכנס אדר", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "אבי חיות והתזמורת מגישים- מחרוזת רוקדים מתוך האלבום פורים שמח", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "רוני דעדוש עוזיאל דייטש בביצוע מחודש לשושנת יעקב העתיק", "entities": [{"start": 0, "end": 10, "label": "SINGER"}, {"start": 11, "end": 23, "label": "SINGER"}]}
+{"text": "אפרים קמיסר כבר שר משנכנס אדר", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "צמד אבי וילדי 'שיר ושבח' בסינגל לקראת פורים מקפיץ במיוחד – אֹסְרִי לַגֶּפֶן", "entities": [{"start": 0, "end": 7, "label": "SINGER"}]}
+{"text": "סול דימנט ומשולם רובין פותחים את חודש אדר במחרוזת פורים תש''פ.", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "פורים חגיגה - עמי שער אריה קונצלר", "entities": [{"start": 22, "end": 33, "label": "SINGER"}, {"start": 14, "end": 21, "label": "SINGER"}]}
+{"text": "מחרוזת פורים - יעקב דוד ולהקת פומפידתא", "entities": [{"start": 15, "end": 23, "label": "SINGER"}]}
+{"text": "אליאב גריינימן ו'שירה' בביצוע אנרגטי במיוחד לשיר תמחה", "entities": [{"start": 0, "end": 14, "label": "SINGER"}]}
+{"text": "אריק כדורי בסינגל חדש לכבוד פורים – מזמור לתודה", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "יולי מולצ'דסקי - מחרוזת פורים בערוץ הידברות", "entities": [{"start": 0, "end": 14, "label": "SINGER"}]}
+{"text": "דליה פרלמוטר - מרבים בשמחה", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "חביב סנדרוביץ ות''ת אמונת ציון - הצילני", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "משנכנס אדר רפאל דנינו מכניס אל אווירת הפורים", "entities": [{"start": 11, "end": 21, "label": "SINGER"}]}
+{"text": "ראובן בקר - מרבים בשמחה", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "רואי בריזל, אליאב בוחניק וילד הפלא בלהיט פורימי חדש אבער קל מסתתר", "entities": [{"start": 0, "end": 10, "label": "SINGER"}, {"start": 12, "end": 24, "label": "SINGER"}]}
+{"text": "ריף אורצל & אורין טבול - הפורים של פסח (באגד)", "entities": [{"start": 0, "end": 9, "label": "SINGER"}, {"start": 12, "end": 22, "label": "SINGER"}]}
+{"text": "יעקב מנשה בניהולו של גד אלבז סינגל חדש ומקפיץ - לחיים", "entities": [{"start": 21, "end": 28, "label": "SINGER"}, {"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "אילון שקד, אמנון כהנוביץ ושלומי סלצמן – לך כנוס", "entities": [{"start": 11, "end": 24, "label": "SINGER"}, {"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "כפיר חסידים ושבתאי רוזן - מחרוזת פורים (פורים אין ירושלים 2)", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "רני שרף והמערבבים - קומבינה - (40 שירים שיערבבו לכם את הפורים)", "entities": [{"start": 0, "end": 7, "label": "SINGER"}]}
+{"text": "שמשון רוחלין - משנכנס אדר - הגרסה האקוסטית", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "יהל שינה בסינגל חדש לפורים – עד דלא ידע", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "אהרל’ע סאמעט במחרוזת לפורים – מפורר תתבודד", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "שאולי וואלדנער & אסף אמדורסקי וטוהר חנצ'ינסקי מגישים לבוא אל המלך", "entities": [{"start": 17, "end": 29, "label": "SINGER"}, {"start": 0, "end": 14, "label": "SINGER"}]}
+{"text": "הלהיט החדש של ינון צדוק - ליהודים", "entities": [{"start": 14, "end": 23, "label": "SINGER"}]}
+{"text": "מילאן אלמלח ושאלתיאל לוינסון מקפיצים לכם את הפורים", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "אריה אזולאי, מנדי גולדברג, שלמה מינצברג - במחרוזת פורים", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "עדי חזן - הפיל פור", "entities": [{"start": 0, "end": 7, "label": "SINGER"}]}
+{"text": "די ג'יי שאטס & רפאל קלינמן - מחרוזת שירי פורים - רמיקס", "entities": [{"start": 15, "end": 26, "label": "SINGER"}]}
+{"text": "אפיק דוידוב מארח את אשד קורדובה ושמעון ברייטקופף - מחרוזת פורים", "entities": [{"start": 0, "end": 11, "label": "SINGER"}, {"start": 20, "end": 31, "label": "SINGER"}]}
+{"text": "נחמיה גדסי ופינחס וועבר – מחה תמחה לפורים", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "דוד שליסלברג מגיש את 'למה' בגירסת רמיקס", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "שמוליק צ'יזיק מגיש ונהפוך הוא", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "אליעד קורנבליט & אמיתי מור - מחרוזת פורים פארטי", "entities": [{"start": 17, "end": 26, "label": "SINGER"}, {"start": 0, "end": 14, "label": "SINGER"}]}
+{"text": "שחף שמר בסינגל חדש לפורים 'פורימסיבה'", "entities": [{"start": 0, "end": 7, "label": "SINGER"}]}
+{"text": "אבי דויטש בלהיט פורימי אבוא אל המלך", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "דב לוריא - פיש פיש", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "הזמר הלל רדעי שר שוב קומבינה", "entities": [{"start": 5, "end": 13, "label": "SINGER"}]}
+{"text": "שבתאי ישראל מארח את תומר כהן ונמואל לפורימיקס", "entities": [{"start": 0, "end": 11, "label": "SINGER"}, {"start": 20, "end": 28, "label": "SINGER"}]}
+{"text": "מחרוזת שירי פורים מגניבה עם נגן הקלרינט מנשה מרזון", "entities": [{"start": 40, "end": 50, "label": "SINGER"}]}
+{"text": "ינאי סולומון מארח את דניאל גרינוואוד בסינגל פורימי שושנת יעקב", "entities": [{"start": 0, "end": 12, "label": "SINGER"}, {"start": 21, "end": 36, "label": "SINGER"}]}
+{"text": "אלרן ניקולאיב ממשיך עם סינגל שני לקראת פורים - לחיים", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "עזרא כלפה - בשמחה", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "אהרן גרסטל מוכן לפורים 'שנודער אין אדר'  -", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "בנו ציגלר ואוריאל ברקוביץ בסינגל חדש חייב איניש לבסומי", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "עמי בצלאל מגיש ועל הניסים מיוחד לחג הפורים", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "נדב אליהו - ונהפוך הוא", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "ענבר דאי בשירים פורימים טרי ומדליק", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "זרח פינצבסקי ונטע אסף בביצוע חדש למילים ונהפוך הוא", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "קלמי שוורץ פותח את חודש אדר עם מחרוזת פורים מקפיצה", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "מוריס שפינר במחרוזת לפורים 'ריקודיג", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "יותם ליבסקינד ו'אביעד מחפוד' וסבבה מחדשים שושנת יעקב", "entities": [{"start": 16, "end": 27, "label": "SINGER"}, {"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "שושנת יעקב בניה יפרח", "entities": [{"start": 11, "end": 20, "label": "SINGER"}]}
+{"text": "שלמה יעקב וובער עם סינגל חדש לפורים שיר הקורונה", "entities": [{"start": 0, "end": 15, "label": "SINGER"}]}
+{"text": "גדליה גרבר - מחרוזת פורים", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "סימון גשמה בסינגל חדש לקראת פורים נסים ונפלאות~1", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "איליי וייצמן בסינגל חדש לפורים בלילה ההוא", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "יהושע דילר בסינגל אלקטרוני לכבוד פורים יעדער זינגט", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "ריף איצקוביץ, יהל אוסיפוב, שמשון גרובמן, חסידימלעך, דוד דייוויס - לבוש מלכות", "entities": [{"start": 52, "end": 63, "label": "SINGER"}, {"start": 14, "end": 25, "label": "SINGER"}, {"start": 0, "end": 12, "label": "SINGER"}, {"start": 27, "end": 39, "label": "SINGER"}]}
+{"text": "אליסף מור, תור פרדקין, ליאור רובין - קיימו וקיבלו", "entities": [{"start": 11, "end": 21, "label": "SINGER"}, {"start": 0, "end": 9, "label": "SINGER"}, {"start": 23, "end": 34, "label": "SINGER"}]}
+{"text": "דביר מולוקנדוב מארח את ישועה שפירא – להודיע", "entities": [{"start": 23, "end": 34, "label": "SINGER"}, {"start": 0, "end": 14, "label": "SINGER"}]}
+{"text": "זוהר לימואי בשיר חדש לפורים - תמחה", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "סער טדגי מגיש פרוייקט X עם אבי שרון ושלומי בוקשפן - דוגמה", "entities": [{"start": 0, "end": 8, "label": "SINGER"}, {"start": 27, "end": 35, "label": "SINGER"}]}
+{"text": "סיני קטרי ריגש את החתן בגראמען בקבלת פנים לפני חופתו", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "אליהו דיין, קובי אריאלי & בנצי ווברמן - תודה לך השם", "entities": [{"start": 0, "end": 10, "label": "SINGER"}, {"start": 12, "end": 23, "label": "SINGER"}, {"start": 26, "end": 37, "label": "SINGER"}]}
+{"text": "אריק לביא ויוחנן אילוז מחדשים את השיר הנוסטלגי 'ישימך אלוקים'", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "חננאל אשכנזי מגיש סינגל חדש - זינגען צוזאמען", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "רעם אסולין בשיר נעים לי מאוד", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "אלכסנדר ינאי בגראמען שלא הותירו עין יבשה מתוך השבת באירגון HCS", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "סינגל לחתן ''נפתולי'ס שמייכל'' ע''י גיא בנדיקט & צח אשר", "entities": [{"start": 49, "end": 55, "label": "SINGER"}, {"start": 36, "end": 46, "label": "SINGER"}]}
+{"text": "מיקי שטיינר וחברים - חוגגים ט''ו בשבט", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "אביב אלוש בסינגל החדש בניחוח יווני ''דרך הלב''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "ערן קליין באלבום חדש - אשר בחר בנו  - דוגמה", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "ישעיה מייזלס בסינגל חדש ומצמרר במיוחד נופל וקם", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "עירן הבר בוסקילה בסינגל חדש – 'יגדל'", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "יעקב רובין & דיויד חיון - מזמור לתודה", "entities": [{"start": 0, "end": 10, "label": "SINGER"}, {"start": 13, "end": 23, "label": "SINGER"}]}
+{"text": "רפאל גרין מגיש משירי כצל'ה קה ריבון", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "הלל פורת, מבקש ומתחנן - יקיר קנטרוביץ דעבדין רעותך", "entities": [{"start": 24, "end": 37, "label": "SINGER"}, {"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "אלרועי עזיזה בתפילה על פרנסה לפני קריאת פרשת המן", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "הללי לסלאו מרגש בצועדים לחופה", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "שובאל אלקיים שר – אֱלָהָא דִּילֵיהּ", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "אדריאן אלשייך מארח את טלאור שמעי ניגון מיוחד משלו", "entities": [{"start": 0, "end": 13, "label": "SINGER"}, {"start": 22, "end": 32, "label": "SINGER"}]}
+{"text": "ארבל איגר שרים את שירת העשבים של רבי נחמן", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "יקותיאל מיארה בסינגל בכורה לקראת ט''ו בשבט נפשי בשדה", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "מידן מרדכי מארח את אליעזר פלקה 'אם תעירו'", "entities": [{"start": 0, "end": 10, "label": "SINGER"}, {"start": 19, "end": 30, "label": "SINGER"}]}
+{"text": "אליצור ויינברגר וברוך אדרי שרים אם אשכחך", "entities": [{"start": 0, "end": 15, "label": "SINGER"}]}
+{"text": "שרלי מלמן בסינגל חדש ומרגש בלילות", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "לוי פלקוביץ בסינגל חדש – מעזי'בוז", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "יאיר בלשר ומקהלת חסידי צאנז בשיר מיוחד לשבת קודש", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "קלמן סדי בסינגל חדש דער רבי איז דא", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "שגיא פרנק וחנוך דרסלר - ותשועת צדיקים", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "חיים קראוס מארח את כתריאל אלקסלסי - במידה", "entities": [{"start": 0, "end": 10, "label": "SINGER"}, {"start": 19, "end": 33, "label": "SINGER"}]}
+{"text": "שלשלת ג_וניור מארח את מאיר ליון בסינגל חדש 'פיה פתחה'", "entities": [{"start": 22, "end": 31, "label": "SINGER"}, {"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "יקיר אביחצירה ושירה במחרוזת משיריו של ר' שלו בן-סימון ז''ל", "entities": [{"start": 0, "end": 13, "label": "SINGER"}, {"start": 41, "end": 53, "label": "SINGER"}]}
+{"text": "שייע קלר מארח את אלרום יצחק שובו אלי", "entities": [{"start": 0, "end": 8, "label": "SINGER"}, {"start": 17, "end": 27, "label": "SINGER"}]}
+{"text": "'אילון קלופפר & נטע מרדכי' בפנינה מיוחדת בשם 'ווארטן", "entities": [{"start": 1, "end": 13, "label": "SINGER"}, {"start": 16, "end": 25, "label": "SINGER"}]}
+{"text": "ליעם הייזלר לקראת ראש השנה לאילנות במחרוזת ''אילן''", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "משה סילבר בשיר של ראש הישיבה זצ''ל ''והיה כעץ שתול''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "נוה קרומביין בסינגל לט''ו בשבט ''בשבילך בראתי''", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "זלמן קויפמאן בשיר חדש ל''חמישה עשר בשבט''", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "חי רוזנפלד בשיר לט''ו בשבט - אדם", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "דודי שוומנפלד וחברים - במחרוזת חדשה פירותיך מתוקים", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "שגיב בכר - שירת העשבים", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "אסא שוורץ מארח את אלתר המבורגר בלחן חדש אילן במה אברכך", "entities": [{"start": 0, "end": 9, "label": "SINGER"}, {"start": 18, "end": 30, "label": "SINGER"}]}
+{"text": "אדיב בנימיני וליאון סויסה שרים אילן", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "תומר אקרמן שר לכבוד טו בשבט – צל עץ תמר", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "משה דוויק רימון מלמד, ואלעד מנדלוביץ מחרוזת אילן", "entities": [{"start": 10, "end": 20, "label": "SINGER"}, {"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "גרשון שאול עלה על הטרקטור ומגיש את שיר החקלאי", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "האחים נוח פרידמן, ותזמורת 'אורות BAND' – אילן", "entities": [{"start": 6, "end": 16, "label": "SINGER"}]}
+{"text": "לקראת טו בשבט, יקותיאל ירון שר דבר אלי באדמית", "entities": [{"start": 15, "end": 27, "label": "SINGER"}]}
+{"text": "החזן צבי גרינבאום בלחן חדש לטו בשבט 'אשרי האיש", "entities": [{"start": 5, "end": 17, "label": "SINGER"}]}
+{"text": "הדר עמירה בסינגל חדש לקראת ט''ו בשבט 'נטיעות'", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "דוד לוסקי וחברים - אללה אלאלי", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "ברק אקער מגיש זכותו לכבוד ההילולא", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "ארד איאנאו באידיש עם ילד הפלא פיני ברגר אבא איתי", "entities": [{"start": 0, "end": 10, "label": "SINGER"}, {"start": 30, "end": 39, "label": "SINGER"}]}
+{"text": "שלומי חבוב בסינגל 'לך אמר' מאלבומו החדש של רכניץ שי''ר", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "דרור ועקנין בסינגל רווי תקווה ואמונה – כל יכול", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "חנן זילברמן הכוכב הצרפתי בסינגל חדש אהללה", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "אורון פז מארח את יוני ז. אשירה", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "לירן פרבשטין בסינגל חדש שמחתי", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "חיים גורי עם הגירסה האידישאית לשבורי לב", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "ר' רועי טחלוב מגיש שיר 3- דוגמה", "entities": [{"start": 3, "end": 13, "label": "SINGER"}]}
+{"text": "מיכאל סורא ויחיאל לוק במחרוזת שמחה", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "אריאל זיגמן בסינגל חדש עם אחד", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "מיקי רוזנבאום בסינגל חדש 'ותחזינה", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "עזריה אלקובי באלבום משירי יגל יעקב -אערוך מהלל ניבי", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "אילן קניבסקי שר כצל'ה אדון עולם", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "לכבוד הילולת סידנא בבא סאלי ''עתי לביא'' מארחת את גדולי הפייטנים", "entities": [{"start": 30, "end": 38, "label": "SINGER"}]}
+{"text": "להקת פומפודיסא ובנימין טלקר מגישים סינגל חדש - אליך", "entities": [{"start": 0, "end": 14, "label": "SINGER"}]}
+{"text": "יוגב רדה בסינגל חדש הודו להשם", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "עדי גלעד ו'זמירות' בקאבר ליצירה 'האבות הקדושים'", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "מסעוד ישי וניב בירן בשיר חדש אבידת בת מלך", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "מרדכי כהנמן מרטיט כלו עיני", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "ירמיהו דמן ושלום קליינלרר במחרוזת ריקודים", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "אבינועם באומן בסינגל חדש איפה אני", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "הזמר והיוצר יפתח בר בסינגל חדש ומלא תקווה ''אותו היום''", "entities": [{"start": 12, "end": 19, "label": "SINGER"}]}
+{"text": "שעיה רובנשטיין וישעיהו טרבלסי שרים ''די ניגון''", "entities": [{"start": 0, "end": 14, "label": "SINGER"}]}
+{"text": "מודי בקלה מרגש עם היצירה אנא בכוח של שליסקי", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "עמיחי ליבוביץ בסינגל חדש - והיה זרעך", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "יעקב נעמןר, רגב וינוגרדוב, בני מגיד וגילה הנדל בשיר רבינו", "entities": [{"start": 12, "end": 25, "label": "SINGER"}, {"start": 27, "end": 35, "label": "SINGER"}]}
+{"text": "אלון שחר בסינגל מרגש כיסא המלך", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "אליעד ספיר מגיש ניגון 'קול דודי' לרגל הילולת 'בעל התניא'", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "מרגלית אנקורי ו'חסידימלעך' & תזמורתו של נבו איזראילוב, בחצוצרות וקול שופר", "entities": [{"start": 40, "end": 53, "label": "SINGER"}, {"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "רז פריש, מרדכי אנגלרד, לוי לסין - מחרוזת ריקודים", "entities": [{"start": 0, "end": 7, "label": "SINGER"}, {"start": 9, "end": 21, "label": "SINGER"}]}
+{"text": "פריאל גלמן בסינגל בכורה זה הזמן", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "מאיר פרידמן בביצוע לייב לאחד מלהיטיו - ברכת הבנים", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "שניאור יזדי במחרוזת פאנק מתוך המופע ב'לייב פארק'", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "אחיעד לרנר בסינגל חדש ומלהיב ''שיר פשוט''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "טום פיסהה מרגש בסינגל חדש - שמע אותי", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "עקיבא רוט מרגש בגראמען ליתומה", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "אסיף אבישר עם פסח ג'וסף - בראיון על האלבום החדש 'נוגה פרייטג 4 - אמונה ובטחון'", "entities": [{"start": 0, "end": 10, "label": "SINGER"}, {"start": 49, "end": 60, "label": "SINGER"}, {"start": 14, "end": 23, "label": "SINGER"}]}
+{"text": "לאון קלוש שר לכבודו של אביר יעקב", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "ישיבת יצהר ותום בוריה - מזמור לתודה", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "לירן ברין וטוני בובליל מחדשים את היצירה 'יאקאב'", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "עילי גרוס מגיש ממלכת אביחצירא", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "שנהב קלר בסינגל ביכורים, למילות הפיוט המוכר עת דודים כלה", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "אלכסנדר זייד מחדש את השיר המלאך", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "מאור דייויס ואהוד אלמקיס - מתנות קטנות", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "יוחאי שימונוב מגיש סינגל חדש 'עם סגולה'", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "שילה יזראילוב, עומרי שנקמן, אריק קטן מגישים 'משקה'", "entities": [{"start": 15, "end": 26, "label": "SINGER"}, {"start": 28, "end": 36, "label": "SINGER"}, {"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "הורה קדצקה הזמין בגראמן את הרבי מאמשינוב שליטא למצווה טאנץ", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "פנחס וובר, רווה פרגון ועקיבא נוף שרים 'נשמה'", "entities": [{"start": 0, "end": 9, "label": "SINGER"}, {"start": 11, "end": 21, "label": "SINGER"}]}
+{"text": "דניאל טורדזמן ונחמיה דריאל ודביר מסיקה (A Team) בידיים טובות", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "עמיתאי ברזילי בשיר מחזק במיוחד הוֹרֵנִי ה'", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "'רון נשר (דובי) משחרר שיר חדש 'עידן חדש", "entities": [{"start": 1, "end": 8, "label": "SINGER"}]}
+{"text": "ערן גלברט מארחת את ש.-נ. הרשטיק למחרוזת מקפיצה", "entities": [{"start": 19, "end": 31, "label": "SINGER"}, {"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "אברימ'לע פלוטשק מרגש בסינגל חדש - 'מי אדיר'", "entities": [{"start": 0, "end": 15, "label": "SINGER"}]}
+{"text": "מתנאל בולג בסינגל חדש מי אדיר", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "לידור בזזינסקי ואורי ורובל במחרוזת אנרגיה 'ומרקדין ומשמחים'", "entities": [{"start": 0, "end": 14, "label": "SINGER"}]}
+{"text": "ציון שובלי בסינגל חדש - חלום", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "יגאל דוד שטטנר בסינגל חדש לרגל נישואי אחותו 'אחות קטנה'", "entities": [{"start": 0, "end": 14, "label": "SINGER"}]}
+{"text": "סער גמרמן מחדש את הקלאסיקה אלוקים נתן לך במתנה", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "גקי אלקים, מקהלת הילדים זמרה וסבבה במחרוזת ריקודים", "entities": [{"start": 0, "end": 9, "label": "SINGER"}, {"start": 11, "end": 28, "label": "SINGER"}]}
+{"text": "מרדכי גלס בסינגל חדש רק עוד רגע", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "אריק איינשטיין & שמחה אברמציק בביצוע מרגש לשיר 'כשושנה'", "entities": [{"start": 17, "end": 29, "label": "SINGER"}, {"start": 0, "end": 14, "label": "SINGER"}]}
+{"text": "לאה ארצי בסינגל החדש שכתב, הלחין ומגיש מזמור שיר", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "נגב אלוני בסינגל חדש - 'אבינו'", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "יצחק קלפטר ושלום געלב בסינגל החדש ''שליסל''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "אריאל זינו וגולן אריאלי ''מי כעמך - אשרנו''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "יצחק עדן, אלקנה ווייס, תובל אור - שלח אורך & מנורה", "entities": [{"start": 23, "end": 31, "label": "SINGER"}, {"start": 0, "end": 8, "label": "SINGER"}, {"start": 10, "end": 21, "label": "SINGER"}]}
+{"text": "תמר יהלומי & אלרואי גרשטנקורן - לעכטיג", "entities": [{"start": 13, "end": 29, "label": "SINGER"}, {"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "נתנאל אטלן וילד הפלא בשיר לחנוכה ולעמך ישראל", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "מקסים גורש - מחרוזת ניגוני כורדיסטאן", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "השיר החדש של אלן אלדר וחיים בנעט ''בצורת''", "entities": [{"start": 13, "end": 21, "label": "SINGER"}]}
+{"text": "הרב ניתאי הולנדר מגיש ניגון מלאפיץ", "entities": [{"start": 4, "end": 16, "label": "SINGER"}]}
+{"text": "קורן וולמרק, שמואל סלנטר ושלום מרדכי רובשקין במחרוזת שכולה 'תודה'", "entities": [{"start": 0, "end": 11, "label": "SINGER"}, {"start": 13, "end": 24, "label": "SINGER"}]}
+{"text": "ישראל פרנס ודודו טסה בדואט ללהיט ויהיו רחמיך", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "דודי פולק יוסף פרידמן יצחק אלקלעימן - מחרוזת יוונים", "entities": [{"start": 10, "end": 21, "label": "SINGER"}, {"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "רום לנדאו בקאבר לשיר ברכת כהנים של תמיר גרינברג", "entities": [{"start": 0, "end": 9, "label": "SINGER"}, {"start": 35, "end": 47, "label": "SINGER"}]}
+{"text": "עמנואל עמית בסינגל חדש - תאיר נרי", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "אלימלך כהן מגיש מחרוזת שירי הלל", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "קומזיץ חנוכה עם ישיבת מערבא אלעד אברהם והרב שלום רובשקין", "entities": [{"start": 28, "end": 38, "label": "SINGER"}, {"start": 44, "end": 56, "label": "SINGER"}]}
+{"text": "בערל האניג מארח את עמנואל דהאן לסינגל חופה", "entities": [{"start": 19, "end": 30, "label": "SINGER"}]}
+{"text": "עתי שפיר בוסקילה - אחי אל תלך לי", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "אלי ישי - הלל בלייב", "entities": [{"start": 0, "end": 7, "label": "SINGER"}]}
+{"text": "חננאל צ'קול בביצוע הלהיט 'תדליק את האש'", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "ערב של גיבורים ואחדות בחנוכה בירושלים עם האמנים ארנון פטנה ויוחאי עצמון", "entities": [{"start": 48, "end": 58, "label": "SINGER"}]}
+{"text": "גת דנוביץ, בהופעה לייב חנוכה", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "רוי ארז עם 'ניגון חיזוק'", "entities": [{"start": 0, "end": 7, "label": "SINGER"}]}
+{"text": "אלרועי לוונטל וארי בוינגוי בקאבר לאלתר כפיר קול פעמונים", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "רובי בנט ורואי חלפון הניצוץ שבכל יהודי", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "שלומי ברגר במחרוזת משיריו של אליהו קרן", "entities": [{"start": 29, "end": 38, "label": "SINGER"}]}
+{"text": "בועז שר והמנגנים במופע חנוכה מיוחד (שידור חוזר)", "entities": [{"start": 0, "end": 7, "label": "SINGER"}]}
+{"text": "ולרי רזיאל מגיש גרסת רמיקס לשיר של גולן ויינגרטן כמה טוב השם", "entities": [{"start": 35, "end": 48, "label": "SINGER"}, {"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "תולי לעזער ומשה ריינר במחרוזת חנוכה", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "גונן משען מגיש לכבוד חנוכה - אמאל און היינט - כאן ועכשיו (Now & Then)", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "תפילת הלל מוזיקאלית עם שמואל יצחקי", "entities": [{"start": 23, "end": 34, "label": "SINGER"}]}
+{"text": "סלים קרן - תן לי אור (הרמיקס הרשמי)", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "מחרוזת פיטסבורג - אמנון אנקרי, איציק ליפסקר, מלכות, חסידימלעך ואשחר שקד", "entities": [{"start": 18, "end": 29, "label": "SINGER"}, {"start": 31, "end": 43, "label": "SINGER"}]}
+{"text": "דר שפר ועובדיה אלמשעלי מחדשים את 'חשוף' של יאיר חביבי", "entities": [{"start": 0, "end": 6, "label": "SINGER"}, {"start": 43, "end": 53, "label": "SINGER"}]}
+{"text": "ר' מיכאל דורי & אביב שטרלינג - הנרות הללו", "entities": [{"start": 16, "end": 28, "label": "SINGER"}, {"start": 3, "end": 13, "label": "SINGER"}]}
+{"text": "הערשי אורטטנער וארהל'ה סאמט מארחים את אבי מאיירפלד הנרות הללו", "entities": [{"start": 38, "end": 50, "label": "SINGER"}, {"start": 0, "end": 14, "label": "SINGER"}]}
+{"text": "וולוול מרנץ, מרטין וידרקר - אשירה לה' בחיי", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "עופר נון בלהיט חדש לחנוכה יוונים נקבצו עלי", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "רעי פורמן שער - ניגון התחזקות", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "יעקב חי בכור נסים & יוסל לייפר-בזמן הזה-מחרוזת חנוכה", "entities": [{"start": 20, "end": 30, "label": "SINGER"}, {"start": 0, "end": 17, "label": "SINGER"}]}
+{"text": "13 קומזיץ ר' מור חורי", "entities": [{"start": 13, "end": 21, "label": "SINGER"}]}
+{"text": "12 קומזיץ ר' עוזיהו כהנא", "entities": [{"start": 13, "end": 24, "label": "SINGER"}]}
+{"text": "10 קומזיץ ר' קדם לימון", "entities": [{"start": 13, "end": 22, "label": "SINGER"}]}
+{"text": "11 קומזיץ ר' דורי ששון", "entities": [{"start": 13, "end": 22, "label": "SINGER"}]}
+{"text": "יוסי הופמן בשיר לזכרו של מרן הגראי''ל שטיינמן", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "רענן וולפסון אלורו מארח את יוסף הרקדן אשא עיני", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "אביאל קרייב נהוראי ששון וגיל חן, ליבי ובשרי", "entities": [{"start": 0, "end": 11, "label": "SINGER"}, {"start": 12, "end": 23, "label": "SINGER"}]}
+{"text": "אורין האוזר רוקדים ושרים 'חנוכה כאן'", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "אילון הייטנר ואברומי רוזנפלד מרגשים בחופה", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "חנוך גטנך העולמית & קובי ביניאשוילי מארחים את עטר ברגסון - מחרוזת שירי חנוכה", "entities": [{"start": 20, "end": 35, "label": "SINGER"}, {"start": 0, "end": 9, "label": "SINGER"}, {"start": 46, "end": 56, "label": "SINGER"}]}
+{"text": "גולן קצפ & קורן זרבאילוב - ככלות הכל", "entities": [{"start": 11, "end": 24, "label": "SINGER"}, {"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "צבי טוקצינסקי בסינגל חדש להאיר את העולם", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "ראובן שמידט מגיש מחרוזת שירי חנוכה", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "שרוליק הרשטיק בסינגל חופה מרגש- פיה פתחה", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "אייל סעיד מגיש - חשוף", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "רפאל וייסמן וחברים מגישים 'גראמ-זיץ'", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "יששכר גבריאל באלבום חדש מדרגות", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "פנחס בינשטוק וחן רביד מסיום והכנסת ספר התורה לעצירת המגיפה שידור חוזר", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "דעאל לוגסי, נתן שבת ומתניה זנדברג בין קודש לחול", "entities": [{"start": 0, "end": 10, "label": "SINGER"}, {"start": 12, "end": 19, "label": "SINGER"}]}
+{"text": "שמעון ערלוי לקראת חנוכה - חשוף", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "אהרון מרגלית מגיש מחרוזת להיטי חנוכה", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "ניסן טללה עם להיט חדש מתי", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "אסי אלקבץ מגיש להקת שירה 4 - 'אמונה ובטחון' - דוגמה", "entities": [{"start": 15, "end": 24, "label": "SINGER"}, {"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "אילן דרפקין מארח את עובדיה גדז' במופע הצדעה לגיבורים שמאחורי המוגבלות", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "מתן אברגל ונחמיה בראדט מגישים - אמא שלי", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "סיני מעודה ראש ישיבת 'כוכבי אור' בשיר חדש - 'הכוכב' 22 עם אמנים חסידיים", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "אבנר אלוס והזמרים החבדים במופע 'יט כסליו'", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "ר' ניצן למברגר ור' טוביה קנדל מגישים כאייל תערוג - ניגונו של בעל התניא", "entities": [{"start": 3, "end": 14, "label": "SINGER"}, {"start": 19, "end": 29, "label": "SINGER"}]}
+{"text": "הילל סבו בלהיט חדש וקצבי מה טובו", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "יורם מרדכי מגיש לכבוד חנוכה מחרוזת שירי הודיה", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "מתן מלכה והמשמחים במחרוזת קומזיץ לחנוכה", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "פלג הללי וחברים - מחרוזת חנוכה", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "דור שרייר מחדש לחן העתיק - ארוממך", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "אמיתי אדל מבצע יוונים שהלחין לחצר הקודש סאטמר", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "דולב פליגמן מארח את רפי ציון - בזמן הזה (מחרוזת חנוכה)", "entities": [{"start": 0, "end": 11, "label": "SINGER"}, {"start": 20, "end": 28, "label": "SINGER"}]}
+{"text": "אבנר לוין לכבוד ימי ההודאה בסינגל  תגיד תודה", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "אלעזר שובלי וקורן דורי במחרוזת חנוכה אינסטרומנטלית", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "דוד׳ל ווינברג מארח את נחשון רבין-מחרוזת דאנס חנוכה", "entities": [{"start": 0, "end": 13, "label": "SINGER"}, {"start": 22, "end": 32, "label": "SINGER"}]}
+{"text": "דורי אילוז ופרחי הראם, מגישים סינגל חדש לחנוכה  על הניסים", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "רוי ורזגר מחדש את היצירה העתיקה הנרות הללו", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "שירה רגב במאשפ חדש המורכב משירי אש וניסים", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "ישיבת השלמה מועלםאבר ללהיט החנוכה של פרץ אופיר  חשוף", "entities": [{"start": 37, "end": 46, "label": "SINGER"}]}
+{"text": "שמחה יוסקוביץ בסינגל חדש לכבוד חנוכה", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "יוסי שטענדיג ואיתמר פרידמן במחרוזת דאנס חנוכה", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "אלי אדלר וזיו דושינסקי בביצוע לייב ליצירה  חשוף", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "רונית אטד יוצא עם סינגל חדש בשם  לך נפשי", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "איליה שלוש במחרוזת שירי חנוכה מקפיצה", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "אילון אלישע בקאבר ללהיט החנוכה של יותם סעדה  מעוז צור", "entities": [{"start": 34, "end": 43, "label": "SINGER"}, {"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "רוי קלפפיש (Z) - כל יהודי הוא אש ועכשיו הרמיקס של דיג יי יואל דקל", "entities": [{"start": 0, "end": 10, "label": "SINGER"}, {"start": 57, "end": 65, "label": "SINGER"}]}
+{"text": "יעקב אוחיון בשיר שקט לחנוכה הנרות הללו", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "ר  ינקי לנדאו בסינגל חדש לחנוכה  מעוז צור", "entities": [{"start": 3, "end": 13, "label": "SINGER"}]}
+{"text": "זמיר קריב בסינגל חדש  חנוכה הזה", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "בר אלמלח מגיש מחרוזת אינסטרומנטלית לחנוכה", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "לאיו מלול מאיר בסינגל  קומזיצי  חדש  תאיר", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "מתניה עציוני הלחין ושר  יוונים נקבצו עליי", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "עוזי חיטמן, יהודה לב-רן וארבל ממן במחרוזת שכולה תודה", "entities": [{"start": 0, "end": 10, "label": "SINGER"}, {"start": 12, "end": 23, "label": "SINGER"}]}
+{"text": "אפרים מנדלסון, אהר'לע סאמעט, שמואל קרויס, אסיף רוסין, שלום בראדט, יהודית בן-נון - מיין לעכטעלע", "entities": [{"start": 42, "end": 52, "label": "SINGER"}, {"start": 29, "end": 40, "label": "SINGER"}, {"start": 54, "end": 64, "label": "SINGER"}, {"start": 0, "end": 13, "label": "SINGER"}, {"start": 66, "end": 79, "label": "SINGER"}]}
+{"text": "ריף ריקובר מרדכי שפירה - לעכטיג", "entities": [{"start": 11, "end": 22, "label": "SINGER"}, {"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "ברנרד שמידט מגיש לכבוד חנוכה - אמאל און היינט - כאן ועכשיו (Now Then)", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "אסף פריאנטי ורוברט דאנה מחדשים את חשוף של אלעזר אבוחצירא", "entities": [{"start": 0, "end": 11, "label": "SINGER"}, {"start": 42, "end": 56, "label": "SINGER"}]}
+{"text": "ר' אביחי אסקל ראם שפירא - הנרות הללו", "entities": [{"start": 14, "end": 23, "label": "SINGER"}, {"start": 3, "end": 13, "label": "SINGER"}]}
+{"text": "שמחה יסעור אלטר גבאי-בזמן הזה-מחרוזת חנוכה", "entities": [{"start": 0, "end": 10, "label": "SINGER"}, {"start": 11, "end": 20, "label": "SINGER"}]}
+{"text": "מנחם גמליאל רוקדים ושרים חנוכה כא", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "עדיאל פלג בסינגל לחנוכה על הניסים", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "אילי פרי - הנרות הללו", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "גבריאל פאר - אור חנוכיות", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "נתן נפתלי במחרוזת שירי חנוכה", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "ישעיהו אטר בסינגל חנוכה היה אור", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "עקיבא פרנקל - חשוף", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "אברהם לוצקי בסינגל חדש לחנוכה חשוף", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "לב וינד ואבא תומר - על הניסים", "entities": [{"start": 0, "end": 7, "label": "SINGER"}]}
+{"text": "שחק שטינברג והלהקה - על הניסים", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "נחשון אבורמד - מעוז צור", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "חיים פלאם - מחרוזת הדלקת נרות חנוכה", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "יצחק פלקס בסינגל חדש ומקורי לכבוד החנוכה מעוז צור", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "מוישה שימחה ותזמורתו & אדגר קרקוקלי - זיץ חנוכה", "entities": [{"start": 23, "end": 35, "label": "SINGER"}]}
+{"text": "אלקנה נדף - ניגוני חנוכה", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "יעקב שחר, משה גולדמן, גילי סיטנר בוריץ 'קואן, רחמים מהדר - ברען לעכטעלע   הערליכע נייע ניגון לכבוד חנוכה", "entities": [{"start": 46, "end": 56, "label": "SINGER"}, {"start": 22, "end": 32, "label": "SINGER"}, {"start": 10, "end": 20, "label": "SINGER"}, {"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "מאיה אברהם ונאור כהן במחרוזת חנוכה", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "צבי וייס מדליק לכם את חנוכה מעוז צור", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "רוי פאר בשיר חנוכה מרגש - חנוכיית המגיד מקוזניץ", "entities": [{"start": 0, "end": 7, "label": "SINGER"}]}
+{"text": "איציק נוביקוב בלהיט חנוכה חדש – בזמן הזה", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "דייוויד דריימן זוהר עמוס ותזמורת עוזיאל מלמד לקראת חנוכה מעוז צור", "entities": [{"start": 0, "end": 14, "label": "SINGER"}, {"start": 33, "end": 44, "label": "SINGER"}, {"start": 15, "end": 24, "label": "SINGER"}]}
+{"text": "יוני רוס הפעסטר רב לכבוד חנוכה– על הניסים", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "סמי לומברד עם לחן חדש למעוז צור", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "דני גולן בסניגל חדש לחנוכה - חשוף", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "דוי פלדמן ור' שאול והמדרשה בסינגל לכבוד חנוכה יוונים נקבצו עלי", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "אלקנה יצחקוב - חשוף מתוך המעוררים 2", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "זוהר איזנמן ולורן גרוס - חנוכה דאנס תשע''ז", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "ג'ורג' מלטר - די דריידל ניגון", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "מוריס בורט - להדליק", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "יוסי פרימן - סובב את הסביבון", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "נועם פרס - בזמן הזה", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "אורין אגם - הנרות הללו", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "ערן לובל שר באקפלה מעוז צור", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "חשוף זרוע קדשך - אילון קנר, בניה צמח ואברימי קלצקין", "entities": [{"start": 28, "end": 36, "label": "SINGER"}, {"start": 17, "end": 26, "label": "SINGER"}]}
+{"text": "שבתי רוזי ואיתמר שטאובר - חשוף זרוע קדשך", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "הלל פלאי שר מעוז צור בלחן של כמיהה מתוך אלבומו ''מנורת הזהב'", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "שגב ברנס & תזמורת שלהבת - מחרוזת שירי חנוכה", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "רביד קון - מחרוזת חנוכה", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "אלי קליין עם שיר חדש לחנוכה קריגעלע", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "מאט דאב מארח ידידים בסינגל חדש – די חנוכה ניגון", "entities": [{"start": 0, "end": 7, "label": "SINGER"}]}
+{"text": "מורי אשר מרגש עם חשוף", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "לאונרד כהן בסינגל חדש ומקורי 'הנרות הללו'", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "דביר סבג, איצי בלינדנר, בנימין שוקרון ויוסי ליסאוער חנוכה נרקוד נשמח כולנו", "entities": [{"start": 0, "end": 8, "label": "SINGER"}, {"start": 10, "end": 22, "label": "SINGER"}, {"start": 24, "end": 37, "label": "SINGER"}]}
+{"text": "ילד הפלא שני חיון ועירד נוביק העולמית במחרוזת יוונים לכבוד חנוכה ‏", "entities": [{"start": 9, "end": 17, "label": "SINGER"}]}
+{"text": "מיתר מרואני מבקש – קרב קץ הישועה", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "אסא וואלף מגיש הסיפור המרגש של חנוכה בוייטנאם", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "פלג שרביט בסינגל חדש כדי להודות", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "עובד אוסלנדר מגישים 'מחרוזת חנוכה'", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "תאירו לי שלוימי גרטנר ומקהלת הילדים בסינגל לחנוכה", "entities": [{"start": 9, "end": 21, "label": "SINGER"}]}
+{"text": "יואב צדוק, נחשון מרכוס, לידור טוביאנה, דב צייגר - חשוף", "entities": [{"start": 39, "end": 47, "label": "SINGER"}, {"start": 24, "end": 37, "label": "SINGER"}, {"start": 11, "end": 22, "label": "SINGER"}, {"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "אבירם בוטבול - בעט ניסים", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "חשוף זרוע - אהרלה סמט", "entities": [{"start": 12, "end": 21, "label": "SINGER"}]}
+{"text": "עוזיאל זליכה ופ. בורנשטין עם גרסה מקפיצה לעל הניסים", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "עמנואל אברגל עם אחד מניגוני הרגש הגדולים", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "11.יאיר דוד - יוונים נקבצו", "entities": [{"start": 3, "end": 11, "label": "SINGER"}]}
+{"text": "אחיה אריאל' - על הניסים", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "יצחק בן-אהרון מרגש שוב וּבְיָדוֹ הַגְּדוֹלָה", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "ילד הפלא בועז סבן יחד עם בן-אל דנוביץ", "entities": [{"start": 25, "end": 37, "label": "SINGER"}, {"start": 9, "end": 17, "label": "SINGER"}]}
+{"text": "עוזיאל שטרית שר שוובר - מנורת זהב", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "הרצל דהאן ויהודה אהרוני & אלישע בוטראשוילי - חנוכה", "entities": [{"start": 0, "end": 9, "label": "SINGER"}, {"start": 26, "end": 42, "label": "SINGER"}]}
+{"text": "אביהו יוסוב ועילי אברט משחזרים את מעוז צור של אחינו", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "איציק כהן, גד מדר, אדר מרלי ועינב סלע מנורה", "entities": [{"start": 11, "end": 17, "label": "SINGER"}, {"start": 19, "end": 27, "label": "SINGER"}, {"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "יוני סילמן ותזמורתו - מחרוזת חנוכה שמח", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "אלמוג פינחס במחרוזת נוסטלגית ללהיטים הגדולים שהלחין ר' בני דלנוקי", "entities": [{"start": 55, "end": 65, "label": "SINGER"}, {"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "להקת הילדים 'נח כדורי' מחדשת את הלהיט יום שישי הגיע", "entities": [{"start": 13, "end": 21, "label": "SINGER"}]}
+{"text": "ההשקה החגיגית לאלבום החדש של מקהלת זמרה בשם ''מדרגות'", "entities": [{"start": 29, "end": 39, "label": "SINGER"}]}
+{"text": "יהודה גולן משחרר סינגל נוסף לולי תורתך", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "איצי ספינר ואוריה מור ותזמורתו מגישים את ניגון קובליץ", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "תום חזות בשיר חדש ומרגש במיוחד 'אין כאלוקינו'", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "חיים אליעזר הרשטיק ורביב לנדסברג, מרום גמרניק, בארי אבוטבול, חן האוזר, שמואל בלאו - מחרוזת קומזיץ~1", "entities": [{"start": 47, "end": 59, "label": "SINGER"}, {"start": 0, "end": 18, "label": "SINGER"}, {"start": 61, "end": 69, "label": "SINGER"}, {"start": 34, "end": 45, "label": "SINGER"}, {"start": 71, "end": 81, "label": "SINGER"}]}
+{"text": "קלוד איצקוביץ מגיש סינגל רביעי וקצבי העונה לשם מה שלא יהיה", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "יאיר נוסבכר בסינגל בכורה  – תפילה אחת", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "אלכסנדר רופא בסינגל חדש אמר ה' ליעקב", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "אלחנן משמרתי בסינגל חדש אהבת חינם", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "צורי ליבוביץ עם סינגל חדש כל יהודי הוא אש", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "הרב אלכסנדר בן-שבת כהנא יוצא שוב עם קומזיץ 4 מבית לחיים הפקות - דוגמה", "entities": [{"start": 4, "end": 18, "label": "SINGER"}]}
+{"text": "אהוד זוהר וילד הפלא בסינגל הודיה חדש 'הודו לו'", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "ליאור פרנס & עמי הוכמן מקפיצים עם הלהיט לא ימלט", "entities": [{"start": 13, "end": 22, "label": "SINGER"}, {"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "אביהו שפיגל מגיש ללכת בדרך זה - גרסה 2", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "חסד שכטר ואחייניו במחרוזת משיריהם", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "נטע אוחיון ועמוס עוז מארחים את פרחי שלהבת ''עולם הזה עולם הבא''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}, {"start": 31, "end": 41, "label": "SINGER"}]}
+{"text": "אדגר דואק & חן זלינגר בביצוע מיוחד 'האורנה דץיל'", "entities": [{"start": 12, "end": 21, "label": "SINGER"}, {"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "מתן ונטורה בסינגל חדש שכתב והלחין כפירים", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "שלמה וייספיש בסינגל חדש ''לבבות''", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "דביר אביטבול צחי עידו וברק בשארי בסיום מסכת עירובין", "entities": [{"start": 0, "end": 12, "label": "SINGER"}, {"start": 13, "end": 21, "label": "SINGER"}]}
+{"text": "פיני אבין וחנן וורונין במחרוזת להיטים", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "רחמים ויגדורוביץ בהופעה חיה בכינוס השלוחים צמאה לך נפשי", "entities": [{"start": 0, "end": 16, "label": "SINGER"}]}
+{"text": "רפאל פלדמן וארד טשומה בגרסת 'רמיקס' לאליהו הנביא", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "יהודה בן אריה והראל דיגה שרים בדובאי 'שירת הבקשות'", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "מנגינות 1 -יעקב בן-דוד ותזמורתו (נעימות ברצף)", "entities": [{"start": 11, "end": 22, "label": "SINGER"}]}
+{"text": "דני ברינקמן ויוסף משה כהנא וילד הפלא אלון גלבוע בביצוע לשיר ויהי זרעי", "entities": [{"start": 0, "end": 11, "label": "SINGER"}, {"start": 37, "end": 47, "label": "SINGER"}]}
+{"text": "חנניה אריה בביצוע לוהיו למשיסה של קרליבך", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "שלומי גוזני עם סינגל - חדש 'למען אחי'", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "מנדי J בסינגל חבל לע''נ האברך משה יהודה וויינער ע''ה", "entities": [{"start": 0, "end": 6, "label": "SINGER"}]}
+{"text": "ר' גילי שורץ בסינגל חדש ויגדלם", "entities": [{"start": 3, "end": 12, "label": "SINGER"}]}
+{"text": "נתן כורם בקומזיץ סוחף ומרגש & בר רפאילוב", "entities": [{"start": 0, "end": 8, "label": "SINGER"}, {"start": 30, "end": 40, "label": "SINGER"}]}
+{"text": "ניב רוגוב ביטון בסינגל קצבי חדש נגינתי", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "מנחם משען בסינגל סוחף ומרגש, בהשתתפות שמוליק שינדלר ''אדון השמחה והחדוה''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}, {"start": 38, "end": 51, "label": "SINGER"}]}
+{"text": "מריו חקשור הורוביץ, מני פבזנר ונוה שטרן אנא מלך של פיטסבורג", "entities": [{"start": 0, "end": 10, "label": "SINGER"}, {"start": 20, "end": 29, "label": "SINGER"}]}
+{"text": "דייויד פרייד בסינגל בכורה ויקבץ", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "פרוספר שרבי בניגון לכבוד שבת לא תבושי - מודז'יץ", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "ר' תאום מונוסון ור' יעקב מאנע בלהיט חדש 'לעתיד לבוא'", "entities": [{"start": 3, "end": 15, "label": "SINGER"}, {"start": 20, "end": 29, "label": "SINGER"}]}
+{"text": "שלמה וכתר למברגר במחרוזת משירי ר' משה סטורך", "entities": [{"start": 34, "end": 43, "label": "SINGER"}]}
+{"text": "שירן קרמר ודיג'יי נתי אביבי בגרסה מקפיצה ל'אורך ימים' של קרליבך", "entities": [{"start": 18, "end": 27, "label": "SINGER"}, {"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "מתנאל לבון בסינגל חדש - מהמרחקים", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "יוסי אלון & יובל ליבוביץ ואסף נגל בסינגל מיוחד א בית נאמן לטובת ישיבת אורייתא", "entities": [{"start": 12, "end": 24, "label": "SINGER"}, {"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "יזהר בר בביצוע מיוחד ולירושלים עירך", "entities": [{"start": 0, "end": 7, "label": "SINGER"}]}
+{"text": "הזמר אילון עטרי בסינגל חדש - שפיות", "entities": [{"start": 5, "end": 15, "label": "SINGER"}]}
+{"text": "ירון קורן מארחים את יהונתן שרבאני 'כל יום'", "entities": [{"start": 0, "end": 9, "label": "SINGER"}, {"start": 20, "end": 33, "label": "SINGER"}]}
+{"text": "שאול אלתר שר שבורי לב קאבר של יהושע חן", "entities": [{"start": 30, "end": 38, "label": "SINGER"}, {"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "אבירם זינו מארח את יוגב מוזס שבת", "entities": [{"start": 19, "end": 28, "label": "SINGER"}, {"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "סלע עומר בניגון חי השם", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "מוראל מולודצקי ו'ידידים' העולמית 'אני מאמין'", "entities": [{"start": 0, "end": 14, "label": "SINGER"}]}
+{"text": "יעקב גוזמן וטוהר ברונפמן במחרוזת מקפיצה", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "האחים יואלי & אהרן טוסיג בדואט נוסטלגי מרגש 'א ערליכע ברכה'", "entities": [{"start": 14, "end": 24, "label": "SINGER"}]}
+{"text": "יואל רפפורט בסינגל חדש ''חזק''", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "להקת דוראל נדל וארנון אייל בסינגל חדש 'על חיינו'", "entities": [{"start": 5, "end": 14, "label": "SINGER"}]}
+{"text": "14 מחרוזת עימנואל אופולס - ידיד נפש, שוועת עניים, ונקתי, המקום, יברכך, שערי דמעות", "entities": [{"start": 10, "end": 24, "label": "SINGER"}]}
+{"text": "אסף טרומן בגרסת אקפלה מיוחדת לשיר 'מזמור לדוד' של  קרליבך", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "מחרוזת החתונה של קרליבך בביצוע להקת הילדים עודד בן חור", "entities": [{"start": 43, "end": 54, "label": "SINGER"}]}
+{"text": "רחמים וולוך ומשפחתו - שיר המעלות", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "משה עמרן פותח את שערי ליבו הגיע הזמן", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "אריק משעלי מגיש סינגל חדש חסד ומשפט", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "מתן סידגייב כתב והלחין סינגל חדש 'שניה לפני'", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "דרור רוט בסינגל החדש ''השיבנו''", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "שלמה סלצקי מגיש סינגל שכתב והלחין לזכרה של אחותו", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "עוזי קולישר באוסף ניגוני חב''ד", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "אליקים בוטא ונחמן אדמקר בסינגל בכורה – אחת שאלתי", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "יפתח צוקרמן בשירו 'יעדער קיינער' (כל אחד אף אחד)", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "המטפל הרגשי שריאל אבירם מארח את אמן הקלרינט אליהב דוד", "entities": [{"start": 44, "end": 53, "label": "SINGER"}, {"start": 12, "end": 23, "label": "SINGER"}]}
+{"text": "יונה פינקס בסינגל חדש כי לעולם", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "שמחה כץ ואלישע זיו בדואט מקפיץ - 'בר אלעאי'", "entities": [{"start": 0, "end": 7, "label": "SINGER"}]}
+{"text": "איתי תורגמן בקאבר ללהיט השנה נחכה לך של טוהר גברילוב ואברומי דנציגר", "entities": [{"start": 40, "end": 52, "label": "SINGER"}]}
+{"text": "משגב קורדובה ואברומי קאליש מרגשים ריבון כל העולמים ויעלה תחנינו", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "עתי מטיאס & גילי אלון - מעיין כץ - 'קול ברמה נשמע'", "entities": [{"start": 12, "end": 21, "label": "SINGER"}, {"start": 0, "end": 9, "label": "SINGER"}, {"start": 24, "end": 32, "label": "SINGER"}]}
+{"text": "שלמה קרמר בסינגל חדש רחל", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "שמיר קאופמן בסינגל חדש 'בגלל אבות'", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "דוד גרסט אלורו בניגון השמיני ואנחנו עמך וצאן מרעיתך", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "בן ירמייב בסינגל קדש", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "אליאב קריחלי בביצוע מיוחד לשירו נטיעות", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "שעה שעותי בסינגל חדש מרגש ומחזק 'כשרוצין ליכנס'", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "נחמן רייכל וגיל לוגסי הפתיעו לכבוד החתונה שירי דביר וינר ב-5 דקות", "entities": [{"start": 0, "end": 10, "label": "SINGER"}, {"start": 47, "end": 56, "label": "SINGER"}]}
+{"text": "יגאל שורץ מגיש סינגל בכורה אגדלך אלוקי כל הנשמה", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "אראל מרגלית זכה לעלות לארץ ישראל ויוצא באלבומו ה12 Unplugged 3", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "מורי איפראימוב שוורץ מרגש בגראמען בחופת חתן יתום מאמא", "entities": [{"start": 0, "end": 14, "label": "SINGER"}]}
+{"text": "יונה חורש מתחנן ״וברך שנתנו כשנים הטובות״", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "הזמר והיוצר ישי נסימוב בסינגל שני 'רק תבוא'", "entities": [{"start": 12, "end": 22, "label": "SINGER"}]}
+{"text": "מורן מטקובסקי בקאבר ללהיטו של איתן כהנא לא ימלט", "entities": [{"start": 0, "end": 13, "label": "SINGER"}, {"start": 30, "end": 39, "label": "SINGER"}]}
+{"text": "ר' אלקנה חיון ובנו אלעזר שרים במרפסת בואו שעריו", "entities": [{"start": 3, "end": 13, "label": "SINGER"}]}
+{"text": "יצחק אלון ומרדכי אלחרר בפיוט לזכר הצדיק הוד והדרו", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "גור טלל מארח את מקהלת זמירות ''פה אתכם''", "entities": [{"start": 16, "end": 28, "label": "SINGER"}, {"start": 0, "end": 7, "label": "SINGER"}]}
+{"text": "לביא צאירי בשיר על מרן 'חזור אלינו'", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "יותם מאיר מארח את סוזנה קאופמן - 'אליך'", "entities": [{"start": 18, "end": 30, "label": "SINGER"}, {"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "מרדכי קנלסקי בסינגל הודיה חדש הודו לו", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "לוקה ייטב משעשע בגרסת קורונה שיר המשאיות ללהיט שבט אחים ואחיות", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "נחמיה ישראלוב וילדי הפלא חיים ימיני ודובי וינד ''נספר תהלתך''", "entities": [{"start": 25, "end": 35, "label": "SINGER"}, {"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "שיר הנקל הרטיט עם היצירה 'ברכת הבנים' של אורי גרינוולד", "entities": [{"start": 41, "end": 54, "label": "SINGER"}, {"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "שחר מוכטרי בסינגל חדש ומרגש מתוך צמאה 6 'לכה דודי'", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "חנניה ביגון בביצוע מיוחד ''ואנפנהא נהירין''", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "טהר קנטורוביץ בסינגל בכורה מרגש 'ס'זיכער גוט", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "מור מויאל משיק סינגל חדש - מודה אני", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "דן סלומון & אביש בראדט במופע מיוחד", "entities": [{"start": 0, "end": 9, "label": "SINGER"}, {"start": 12, "end": 22, "label": "SINGER"}]}
+{"text": "יואל ברוקמן, חנוך אביטל & ושביט נוי מגישים את היצירה 'עקידה'", "entities": [{"start": 13, "end": 23, "label": "SINGER"}, {"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "יהונתן צח אחרי 3 שנים בשיר חדש  ''כנס ללב''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "רותם אברהם וסמי שוע שרו ודמעו מלחני הרבי מפיטסבורג זצ''ל", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "אביעזר עמרן בסינגל חדש לרגל יום ההילולא של החאורן תורג'מן רבי משה סופר", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "די ג'יי שמשון אסיף בסינגל שלישי ''והוא היה'' עם אריה ברנט", "entities": [{"start": 8, "end": 18, "label": "SINGER"}]}
+{"text": "מקהלת יחד באלבום שני ''מה שלומך ר' איד''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "שגיא זילברמן עם לחן קודש של מרן בעל הסולם זיע - לכה דודי", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "פז ברוכין & יואל אליהו במחרוזת ישראלית", "entities": [{"start": 0, "end": 9, "label": "SINGER"}, {"start": 12, "end": 22, "label": "SINGER"}]}
+{"text": "שניאור אטל מפתיע ביצירה מוזיקלית 'הרש''י הראשון'", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "מוטי שטימנץ הלחין ושר יחד עם סתיו עטר 'מצוא חן בניגונם'", "entities": [{"start": 0, "end": 11, "label": "SINGER"}, {"start": 29, "end": 37, "label": "SINGER"}]}
+{"text": "ועכשיו הרמיקס של יניב אזולאי מקפיץ עם שמחה שלמה", "entities": [{"start": 17, "end": 28, "label": "SINGER"}]}
+{"text": "יגאל אברמוב שוורץ עם סינגל חדש 'בראשית'", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "אהוד גולדמן ואלישיב כהן בקאבר לשיר 'מוכנים'", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "אימרי אבלזון מארח את שבתי סבתו מה טובו", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "נתניאל חליאוה מרגש בסינגל שני מישהו למעלה", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "ר' רוברט וולפנזון עם מדרשת תפארת בחורים - נוסח תפילת גשם", "entities": [{"start": 3, "end": 17, "label": "SINGER"}]}
+{"text": "צורי ינאי ומלכות שרו את קה ריבון של פיטסבורג לפני פטירת האדמור זצ''ל", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "שי גולדשטיין ובניה תורג'מן בליווי הקלידן דובי נייגרטן - שירי הקפות", "entities": [{"start": 0, "end": 12, "label": "SINGER"}, {"start": 41, "end": 53, "label": "SINGER"}]}
+{"text": "נהוראי כגן - הושענא", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "המצעד השנתי של קול ברמה בהגשת נריה אליהו לולו וישראל כהן", "entities": [{"start": 30, "end": 40, "label": "SINGER"}]}
+{"text": "עומרי לבצ'נקו אלורו עם הניגון השישי בסדרה 'הללו את ה", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "דובלה פרידמן נחמן זוננשיין וניסן סבאג יוסי ברגר", "entities": [{"start": 13, "end": 26, "label": "SINGER"}, {"start": 0, "end": 12, "label": "SINGER"}, {"start": 38, "end": 47, "label": "SINGER"}]}
+{"text": "שמחת בית השואבה בשיתוף קופח מאוחדת בהגשת ישראל כהן בהשתתפות נח קוג'מן, אריה ברגר, דיוויד טויב ובליווי אשר גבאי", "entities": [{"start": 60, "end": 69, "label": "SINGER"}, {"start": 71, "end": 80, "label": "SINGER"}]}
+{"text": "שמחת בית השואבה ממגדל דוד עם יגל צברי, להקת אומן וירחמיאל מדר ובהנחיית משה אוסלנדר", "entities": [{"start": 39, "end": 48, "label": "SINGER"}, {"start": 29, "end": 37, "label": "SINGER"}, {"start": 71, "end": 82, "label": "SINGER"}]}
+{"text": "משה בן ארויה ועודד ישראל בשירי תשרי", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "יהודה שטיין, גולן שפר, דובי מייזלעס בליווי מוזיקלית של ניב ברכה ודין רייניץ", "entities": [{"start": 0, "end": 11, "label": "SINGER"}, {"start": 13, "end": 21, "label": "SINGER"}, {"start": 55, "end": 63, "label": "SINGER"}]}
+{"text": "ליאור מלר, ניצנה ברדוגו, רפאל מאיר האלפערט, מנדי סנדי ועילי בלינקי", "entities": [{"start": 11, "end": 23, "label": "SINGER"}, {"start": 0, "end": 9, "label": "SINGER"}, {"start": 44, "end": 53, "label": "SINGER"}, {"start": 25, "end": 42, "label": "SINGER"}]}
+{"text": "מור עמאר - חדו חדו רבנן פיוט לשמחת תורה - נוסח תימן", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "נעמה אברמסון בסינגל שלישי חדש וקצבי - ישראל שלנו", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "שמחת בית השואבה אנשים עם מוגבלות בשיח סוד בלוווי ניסן ואזנה ואלקנה מושקוביץ", "entities": [{"start": 49, "end": 59, "label": "SINGER"}]}
+{"text": "אלישע גלברג בסינגל חדש ושמחת בחייך", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "רפי גילאון בתוכנית חג מיוחדת מלאה בדברי תורה ווארטים ושירים לכבודו של המועד והחג הכי שמח בשנה", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "מ. קוסביצקי מתוך סיום הש''ס של דרשו ''לב טהור'' לקראת שמחת תורה הבעל''ט החג המסמל יותר מכל את אהבת עמ''י לתורה וללימודה", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "שלמה אצ'נפה ונוה שורצברג במחרוזת מיוחדת 20 דקות של ניגוני חב''ד באווירה חסידית, שמחה ומקפיצה", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "נתן רומפלר, יואל הרציג ונמרוד עזר בשמחת חג ישר מהכותל", "entities": [{"start": 0, "end": 10, "label": "SINGER"}, {"start": 12, "end": 22, "label": "SINGER"}]}
+{"text": "אליאור לחצ'קוב מקפיץ בשמחת בית השואבה ביחד עם סימון אלגזי", "entities": [{"start": 46, "end": 57, "label": "SINGER"}, {"start": 0, "end": 14, "label": "SINGER"}]}
+{"text": "רן ברבי בסינגל חדש – משניתנה הרשות", "entities": [{"start": 0, "end": 7, "label": "SINGER"}]}
+{"text": "יועד מילוא מגיש סינגל שני וחגיגי עם מילים מתוך ההלל ברוכים אתם", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "אשר יריב, עמיהוד שניידר ובניהו פאר במופע ממגדל דוד בירושלים", "entities": [{"start": 10, "end": 23, "label": "SINGER"}, {"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "קומזיץ סוכות המסורתי עם ידידיה מאיר בהשתתפות הרב זאנוויל מרעיד, גדי גוטשלק, אלאור עטיה, עברי אריס ואלדר מזוז", "entities": [{"start": 76, "end": 86, "label": "SINGER"}, {"start": 88, "end": 97, "label": "SINGER"}, {"start": 49, "end": 62, "label": "SINGER"}, {"start": 64, "end": 74, "label": "SINGER"}]}
+{"text": "אודי קנר & אבי לנקרי - וְזֹאת הַתּוֹרָה", "entities": [{"start": 0, "end": 8, "label": "SINGER"}, {"start": 11, "end": 20, "label": "SINGER"}]}
+{"text": "מייקל שטרן ובני וילנר - הושע נא", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "אורי בן-ארצי - 'ושמחת'", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "אבריימל פריד ורמי הולנדר יחד עם הקלידן ניסים דרויש בשידור מיוחד של 'שמחת בית השואבה' ב'מוצ''ש חי'", "entities": [{"start": 0, "end": 12, "label": "SINGER"}, {"start": 39, "end": 50, "label": "SINGER"}]}
+{"text": "שמואל טולידאנו בסינגל חדש מרגש עם הילד יוסי מאיער ומשה דויטש ''גשים''", "entities": [{"start": 39, "end": 49, "label": "SINGER"}]}
+{"text": "טירן צ'רנין וחברים - קומזיץ המשמחים", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "מיתר אבדי & ניצן ליסיאנסקי - כיכר השמחה - מחרוזת שמחת בית השואבה עם מיטב הזמרים", "entities": [{"start": 12, "end": 26, "label": "SINGER"}, {"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "לידור גורגי & יוני יעיש - ושמחת בחגיך", "entities": [{"start": 0, "end": 11, "label": "SINGER"}, {"start": 14, "end": 23, "label": "SINGER"}]}
+{"text": "מעיין קארו ואלירן אביב להיט חדש ניגון שמחה על המילים ובכן צדיקים", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "ליעד ניניו & רמי בבאי ושימי עזר - סוכה ולולב", "entities": [{"start": 13, "end": 21, "label": "SINGER"}, {"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "איילון חזות - מחרוזת סוכות שמחה", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "צוריה זוהר שר קחו עמכם מתוך פרוייקט אמנים מחדשים קרליבך", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "עידו קפטן שר מה אשיב במעמד אלפים", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "אביחי סטמפלר ומתניה דריי מקפיצים עם ניגונו של בעל ההילולא ''ניגון נדבורנה''", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "נפתלי פרנקל בביצוע לייב של יעלה תחנוננו & טאטעניו", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "אליאור סמברג מפתיע בסינגל ראשון לֵישֵׁב בַּסֻּכָּה", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "אדוארד זרקה מקפיץ בשיר חדש ''אין עוד מלבדו''", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "​​​בן אייזנשטדט מארחת את ליאון גורגי למחרוזת אנרגטית לחג הסוכות", "entities": [{"start": 25, "end": 36, "label": "SINGER"}]}
+{"text": "שלמה קושמרו הכוכב הצעיר במשאפ תפילה", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "חיים פרז וריי בשן בשיר חדש אור גדול", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "טל-אור קולישר מגישים מחרוזת משירי חג הסוכות", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "אנשיל פרידמן מרגש בסינגל חדש מלך רחמן", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "דרור ליפשיץ & מקהלת אשדוד – קומטס מיט מיר", "entities": [{"start": 14, "end": 25, "label": "SINGER"}, {"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "לידור נחום בסינגל חדש – ממעמקים", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "טים שושני בגירסה משלו ללהיט הנוסטלגי 'עננו'", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "אלעד סמאני במחרוזת קצבית לימים הנוראים ''שרים למלך''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "שמואל שפירו וצא בסינגל חדש ומרתק באווירת הימים, לגלות פניך", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "אשר חלא במחרוזת חב''ד בהופעה חיה", "entities": [{"start": 0, "end": 7, "label": "SINGER"}]}
+{"text": "אפרים נפרין עם עוד סינגל ''קום קרא''", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "מיקי נחמני בגרסהל'סדר העבודה' של חוני גורודצקי", "entities": [{"start": 33, "end": 46, "label": "SINGER"}, {"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "רגב ראובני ובנימין בנשימול ביקשו עם האלפים שעת רחמים", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "יואל פאלקוויטש מארח את הזמרים החבדיים ויני פייגה, ישראל הופמן, לירום סורקיס וים עמוס ''כִּי רֶגַע בְּאַפּוֹ''", "entities": [{"start": 63, "end": 75, "label": "SINGER"}, {"start": 38, "end": 48, "label": "SINGER"}, {"start": 0, "end": 14, "label": "SINGER"}, {"start": 50, "end": 61, "label": "SINGER"}]}
+{"text": "מישאל זהבי בסינגל חדש חנון המרבה לסלוח", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "שוקי & דיוויד מארחים את מרדכי סובול - שירת הנשמה", "entities": [{"start": 24, "end": 35, "label": "SINGER"}]}
+{"text": "תימור גרובר מארח את יעקב ישראל", "entities": [{"start": 20, "end": 30, "label": "SINGER"}, {"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "12 רבי ברוך אברג'ל שושן", "entities": [{"start": 7, "end": 18, "label": "SINGER"}]}
+{"text": "15 רבי עידו מליכוב שושן", "entities": [{"start": 7, "end": 18, "label": "SINGER"}]}
+{"text": "14 רבי רזיאל מישקין שושן", "entities": [{"start": 7, "end": 19, "label": "SINGER"}]}
+{"text": "13 רבי אנטוני זיגלבוים שושן", "entities": [{"start": 7, "end": 22, "label": "SINGER"}]}
+{"text": "שמחת בית השואבה 2 - עידן לישע, יוסי שיק, לאון סובר, אתגר גבאי, אדם גרנות ומנדי וואלד", "entities": [{"start": 31, "end": 39, "label": "SINGER"}, {"start": 63, "end": 72, "label": "SINGER"}, {"start": 20, "end": 29, "label": "SINGER"}, {"start": 41, "end": 50, "label": "SINGER"}, {"start": 52, "end": 61, "label": "SINGER"}]}
+{"text": "שמתחת בית השואבה 1 - נוף גולדשמיד, רזיאל יצחקי, מאיר חג’בי, רותם רחמיאן, יעקב בן אוריה ומוטי פלדמן", "entities": [{"start": 60, "end": 71, "label": "SINGER"}, {"start": 21, "end": 33, "label": "SINGER"}, {"start": 35, "end": 46, "label": "SINGER"}, {"start": 48, "end": 58, "label": "SINGER"}, {"start": 73, "end": 86, "label": "SINGER"}]}
+{"text": "02 - לב טהור - עקיבא וידר", "entities": [{"start": 15, "end": 25, "label": "SINGER"}]}
+{"text": "10 - והגית בו - משה ויינטרוב", "entities": [{"start": 16, "end": 28, "label": "SINGER"}]}
+{"text": "07 - בהתאסף ראשי עם - לי שטיין, עשהאל אוטמזגין", "entities": [{"start": 32, "end": 46, "label": "SINGER"}, {"start": 22, "end": 30, "label": "SINGER"}]}
+{"text": "11 - הבן יקיר לי - לוטם כבל", "entities": [{"start": 19, "end": 27, "label": "SINGER"}]}
+{"text": "08 - הנה ימים באים - אילן רוטמן", "entities": [{"start": 21, "end": 31, "label": "SINGER"}]}
+{"text": "09 - מחרוזת וולסים חסידיים - קולות המלאכים", "entities": [{"start": 29, "end": 42, "label": "SINGER"}]}
+{"text": "03 - מארש אין קצבה - גור - יואל ריסמני", "entities": [{"start": 27, "end": 38, "label": "SINGER"}]}
+{"text": "04 - הדרן - שמחה נתן", "entities": [{"start": 12, "end": 20, "label": "SINGER"}]}
+{"text": "אילור סטפנסקי בביצוע ללחן המרטיט ''היה עם פיפיות''", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "יהושע ויסברג בסינגל חדש תינוקות של בית רבן", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "עוז קליין בסינגל תפילה חדש נושא תפילה", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "דביר קבליירו בלחן המפורסם של החזן בן-אל וינברג הַבֵּן יַקִּיר לִי~1", "entities": [{"start": 34, "end": 46, "label": "SINGER"}, {"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "מרטין וידרקר מארח את אשד יודקובסקי ללחן חדש ''אב הרחמים''", "entities": [{"start": 21, "end": 34, "label": "SINGER"}]}
+{"text": "ניסן חיים מארח את האחים עילאי וניתאי צרפתי ''כאן לפניך''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "ניל בראס במחרוזת לימים הנוראים טאטע קום שוין", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "צפריר אלמליח בסינגל חדש תִּקְעוּ בַחודֶשׁ שׁוֹפָר", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "רמי גוטפרב מרגש בשירו ''שופר'' מתוך אלבומו האחרון ''רעיונות'", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "שלומי אנג׳י מסלסל עם לך אלי", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "אלעזר מסורי בשיר חדש - ותשובה ותפילה וצדקה", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "נפתלי משה בסינגל חדש למילות הפיוט המרגש ''בן אדם מה לך נרדם''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "יוסי גולדשטיין והאמנים מבקשים מהקבה ''זכרנו לחיים''", "entities": [{"start": 0, "end": 14, "label": "SINGER"}]}
+{"text": "דודי לנדאו ואריק דביר מגישים 'ויהי בישורון מלך'", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "אביגדור בן-דוד מארחים את ר' אושרי שטיינברג - גשים", "entities": [{"start": 0, "end": 14, "label": "SINGER"}, {"start": 28, "end": 42, "label": "SINGER"}]}
+{"text": "אביחי חזות מחדש את הביצוע החזני של קרליבך ''כבקרת''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "ילד הפלא איילון לואיס במחרוזת לימים הנוראים", "entities": [{"start": 9, "end": 21, "label": "SINGER"}]}
+{"text": "רני נגר - אשיר שיר שבחה", "entities": [{"start": 0, "end": 7, "label": "SINGER"}]}
+{"text": "זאנוויל, פלג ווקנין ו'חסידימלעך' ''אזכרה''", "entities": [{"start": 9, "end": 19, "label": "SINGER"}]}
+{"text": "ליר גלעדי - לבוחן לבבות", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "אמיר מזרחי & רווה זלצמן ''ארשת שפתינו - מודז'יץ''", "entities": [{"start": 13, "end": 23, "label": "SINGER"}, {"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "יענקי ונבו פסקר מרגשים עם לחנו של ליבנת נהורות - 'ביד היוצר", "entities": [{"start": 34, "end": 46, "label": "SINGER"}]}
+{"text": "ישי לויטה ויגל בר-דוד מכניסים אתכם לאווירת הימים הנוראים", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "כרם פישלר מבצע את ''עשה למען ירושלים''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "נמרוד קרום בשיר אידישאי ללהיט שכבש את הרשת ''בין קודש לחול''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "לב קופרר, שלום בראון, יומי געלב בקומזיץ שירים לימים הנוראים", "entities": [{"start": 10, "end": 20, "label": "SINGER"}]}
+{"text": "כפיר סנדק מגיש לחן מרטיט ומרגש בניחוח של פעם ''השיבנו''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "אלתר קריטי ובנו אבישי ארז זועקים רחמנו טאטע!", "entities": [{"start": 16, "end": 25, "label": "SINGER"}, {"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "אבנר אביטל מגיש סינגל חדש 'סליחה שלא נגמרת", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "בעל התפילה ר' שילה טבקה והפסנתרן שמעיה קורן ''אָתִיתִי לְחַנְּנָךְ''", "entities": [{"start": 33, "end": 43, "label": "SINGER"}, {"start": 14, "end": 23, "label": "SINGER"}]}
+{"text": "ליאם בוכריס בשיר חדש אזא רבי", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "איתן רבני, ליאב משולם, וילד הפלא אילנה רובינא מכניסים לאווירת הימים הנוראים בויז'ניץ", "entities": [{"start": 11, "end": 21, "label": "SINGER"}, {"start": 33, "end": 45, "label": "SINGER"}, {"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "עופר אמונה שר ומרגש ''בקש עבדך''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "החזן חיים גרישטיין & אברהם מלקר חדשה בביצוע מרהיב ומרגש רצה עתירתם", "entities": [{"start": 21, "end": 31, "label": "SINGER"}]}
+{"text": "יגאל צליק וניסן שחר בדואט מרגש השם כל יכול", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "האחים עמירן ושלמה לנדאו & שרולי וינברגר במחרוזת מיוחד לחודש אלול", "entities": [{"start": 26, "end": 39, "label": "SINGER"}]}
+{"text": "עברי פינקל מגיש סינגל חדש מחילה", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "מקהלת ירושלים בסינגל חדש לרגל הימים הנוראים לבקש רחמים", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "דוידי נחשון & צחי נסים ב ''תשובה ותפילה של שמעון סבג", "entities": [{"start": 14, "end": 22, "label": "SINGER"}, {"start": 43, "end": 52, "label": "SINGER"}, {"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "יזהר חי הלחין, כתב ושר, רבי איך בענק (אני מתגעגע)", "entities": [{"start": 0, "end": 7, "label": "SINGER"}]}
+{"text": "יוסף אבירם מגיש מחרוזת ימים נוראים", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "ישעיהו ליברמן מארח את ניצן גבאי בסינגל חדש אבא יקר", "entities": [{"start": 0, "end": 13, "label": "SINGER"}, {"start": 22, "end": 31, "label": "SINGER"}]}
+{"text": "נחמן דדון ויולי אבידן - אל מסתתר", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "הערשי ווייס מבקש ושר ''שתחדש עלינו שנה טובה ומתוקה''", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "שוע ביטון בסינגל חדש יחד עם ילד הפלא ממעמקים", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "אילון פרן & יעקב אסטרייכר ב“אדון הסליחות” ממזרח ומערב", "entities": [{"start": 0, "end": 9, "label": "SINGER"}, {"start": 12, "end": 25, "label": "SINGER"}]}
+{"text": "פאר גימפל ויהושע ירדן במחווה מרגשת לויזניץ ''יתגדל ''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "תזמורת EvanAl בסינגל שכתב, הלחין והפיק בעצמו 'אבקש פניך'", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "האחים מרכוס מגיש את הפיוט ''אוחילה לא-ל'' בביצוע ייחודי ומרגש", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "הוד רודריגז מארח את אלדד אלקובי למחרוזת אנרגטית", "entities": [{"start": 0, "end": 11, "label": "SINGER"}, {"start": 20, "end": 31, "label": "SINGER"}]}
+{"text": "שרגא ויינשטיין בסינגל ביכורים מלא ''שירה כים''", "entities": [{"start": 0, "end": 14, "label": "SINGER"}]}
+{"text": "גיא הלוי שר לכבוד הבן איש חי רבינו זאב אברמוביץ זיע''א", "entities": [{"start": 0, "end": 8, "label": "SINGER"}, {"start": 35, "end": 47, "label": "SINGER"}]}
+{"text": "אילון פיפרמן בדואט עם שוקי ברוך השם אני נושם", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "בניה שטווי מגיש - חלקי השם", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "אברהם גרמייזא - לא יום ולא לילה", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "בן ציון קופוב בסינגל חדש ומרגש לימי הרחמים והסליחות ''נחפשה''", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "עילי אבידני & טוביה גרינשטיין בסינגל חדש והרוח לנו", "entities": [{"start": 14, "end": 29, "label": "SINGER"}, {"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "לירז בוים בסינגל חדש קרע", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "אדיר נחמני בסינגל אלולי חדש ימי רחמים", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "צפריר פייסחוב באלבום חדש איה ביי דיר - דוגמה", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "רוי קריאף מגיש ''וגמלני חסדים טובים''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "אלעזר מאירי אירח את ניק חכם הלפגוט ''רצה'", "entities": [{"start": 0, "end": 11, "label": "SINGER"}, {"start": 20, "end": 27, "label": "SINGER"}]}
+{"text": "מעוז דיגורקר בסינגל בכורה ייחודי ושונה ''מתפלל ושר''", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "פורת נוב מארח את הרצל צ'רנוב - אני אחר", "entities": [{"start": 17, "end": 28, "label": "SINGER"}, {"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "יוסי שטנדיג מגיש ביצוע מיוחד לניגון חב''ד ''קול דודי''", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "יהושע ווידער מבצע בקומזיץ שירים ונוסח של ויז'ניץ", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "ערן וייס מארח את אביו בסינגל חדש ונצעק", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "אבי צליח מתרגש בניגון המרטיט של ר' מיכל מזלוטשוב", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "תומאס חבקין, יהודה סופיר ו'סבבה' בברכת כהנים של עומר ביטון", "entities": [{"start": 48, "end": 58, "label": "SINGER"}, {"start": 0, "end": 11, "label": "SINGER"}, {"start": 13, "end": 24, "label": "SINGER"}]}
+{"text": "עמנואל מזרחי בסינגל חדש כוכבים", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "יניב הרץ פותח את אלול בלחן חדש ''לדוד ה' אורי''", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "בימת 'קול פליי' ניצן שאנאנס וסהר רעות", "entities": [{"start": 16, "end": 27, "label": "SINGER"}]}
+{"text": "יוסי אדלר בסינגל מיוחד לחודש אלול - תמחל לי", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "ישראָלי'ק בש וחסיד שפירא ואריק חדד תשובה תפילה וצדקה", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "אייזיק  ברוינשטיין בסינגל מרגש לחודש אלול - שמעה תפילתי", "entities": [{"start": 0, "end": 18, "label": "SINGER"}]}
+{"text": "ישראל הלוי בלסופסקי מגיש סינגל חדש וקצבי בשם ''מחדש''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "נוף דן במחרוזת קרליבך ''לקראת שבת''", "entities": [{"start": 0, "end": 6, "label": "SINGER"}]}
+{"text": "אושרי ליפשיץ בשיר באווירת חודש אלול ''אין לנו מלך''", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "חיים שולמן מנשה אלבז וחברים בקאבר לשיר''אשא עיני' (אברימי אייזנבך)", "entities": [{"start": 51, "end": 65, "label": "SINGER"}, {"start": 0, "end": 10, "label": "SINGER"}, {"start": 11, "end": 20, "label": "SINGER"}]}
+{"text": "טופז אייכנשטיין בסינגל שישי ''עולם של נגינה''", "entities": [{"start": 0, "end": 15, "label": "SINGER"}]}
+{"text": "מנדל אקולוב מקפיץ עם מחרוזת דיסקו", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "בוריס ג'יראד מארח את אודי פלדמן ''עבודת הלב''", "entities": [{"start": 0, "end": 12, "label": "SINGER"}, {"start": 21, "end": 31, "label": "SINGER"}]}
+{"text": "אבא נאמן משיק סינגל נוסף עם סגנונו הייחודי ''םילימ''", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "הערשי וינברגר בסינגל חדש ''חי על הקצה''", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "אופק גרשוני בסינגל חדש ''התעוררי''", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "שי-שלום ברוך בסינגל חדש ''נפשנו''", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "גיל סלומון במחרוזת חדשה במקאם חיג'אז (זידאן)", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "עמירם חיימזון בסינגל חדש ''סימן''", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "אבינועם משהשווילי ריגש עם ''ותחזינה'' מול אלפים", "entities": [{"start": 0, "end": 17, "label": "SINGER"}]}
+{"text": "נריה בוטה & ליאו חדד מארחים את אוריאל רייכל ב''שיר האמונה''", "entities": [{"start": 12, "end": 20, "label": "SINGER"}, {"start": 31, "end": 43, "label": "SINGER"}, {"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "אביהו מויאל צועד לחופה בסינגל חדש ''צועדים לחופה''", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "נצח שחרור וטל צבח משתפים פעולה בשיר ''היה הווה''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "שקד עהרנרייך בהכרזת חודש אלול תשפ''ג", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "מיתר צפדיה בסינגל חדש קייצי ושמח ''כפיים לשמיים''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "מיילך פויגל בסינגל חדש בשם ''טענצעלע'' (ריקוד)", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "04 יאן דורון - לב חזק", "entities": [{"start": 3, "end": 12, "label": "SINGER"}]}
+{"text": "03 בנאל פנחס - יש בי את הכוחות", "entities": [{"start": 3, "end": 12, "label": "SINGER"}]}
+{"text": "02 ידין שפיצר - אושר אמיתי", "entities": [{"start": 3, "end": 13, "label": "SINGER"}]}
+{"text": "01 רגב רוזנבליט משחרר סינגל נוסף ''רציתי לגדול''", "entities": [{"start": 3, "end": 15, "label": "SINGER"}]}
+{"text": "גולן איתני בשיר ''פתח ליבי'' מוקדש ללומדי ועמלי התורה", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "אבשלום ובנו יגאל חגבי בדואט משותף ''כשושנה''", "entities": [{"start": 12, "end": 21, "label": "SINGER"}]}
+{"text": "דניאל האביאל ''רוצה להתעורר''", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "אמיר פיינטוך מחדש ''ניצחתי ואנצח''", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "אלעד גיל בר במחרוזת עוצמתית משירי רנאל מטוט", "entities": [{"start": 0, "end": 11, "label": "SINGER"}, {"start": 34, "end": 43, "label": "SINGER"}]}
+{"text": "זלמן זלאטאפאלסקי ולישי פומין בסינגל חדש ושונה ''טועמיה''", "entities": [{"start": 0, "end": 16, "label": "SINGER"}]}
+{"text": "אליעזר מונוסון בקאבר עוצמתי לשיר ''עטלף עיוור'' של משולם בינדמן", "entities": [{"start": 0, "end": 14, "label": "SINGER"}, {"start": 51, "end": 63, "label": "SINGER"}]}
+{"text": "אהרן דנין בסינגל חדש עם נערי הגבעות ''תחזיר את השנים''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "משה בלוי במחרוזת שירי אמונה וביטחון", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "עדי עמר בסינגל חדש ''ואילו''", "entities": [{"start": 0, "end": 7, "label": "SINGER"}]}
+{"text": "עמרם רונן בסינגל חדש ''בן פורת יוסף''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "חיים לוק ועמיאל ליבל במחרוזת חסידית ייחודית ''גפן''", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "יוסף ג'ואי ניוקם בסינגל חדש ''משאלות''", "entities": [{"start": 0, "end": 16, "label": "SINGER"}]}
+{"text": "דוד שאמולא ומשה בן זמרא ב''זיץ'' של ישיבת בית מדרש עליון", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "יצחק שדה בסינגל חדש ''וטובה אני בעיניו''", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "שגיא וייס ואבשלום תורג'מן בדואט חדש ומקפיץ ''היי צמאה''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "יהודית שרון משיק סינגל קצבי חדש בשם ''מרגיש אחר''", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "יגל ירושלמי מגיש סינגל חדש פרי יצירתו בשם ''מסע''", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "בנימין אלבז מחדש בביצוע מרגש את הלהיט ''אוחילה לא-ל''", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "סער דהן בסינגל חדש מרים ומרגש ''יורד ועולה''", "entities": [{"start": 0, "end": 7, "label": "SINGER"}]}
+{"text": "משה טישלער חושף את אלבומו הרביעי המקורי ''ליבי''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "חיים פורטל בשיר בעברית לכבוד המלמדים ''תודה לך רבי''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "ערן פוירברגר בשיר רוק מקפיץ ''בית יבנה''", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "אושר אמסלם בגירסה חדשה לשיר הישן ''כשיבוא''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "ישראל שווארץ ואהרון מאיר עם סינגל חדש ''ואהבת''", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "יהל פנקר מחדש ''ניגון לרקוד איתו''", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "מאי דולב בסינגל חדש ועוצמתי ''ידעתי''", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "ערמון אוט בגרסת רמיקס אלקטרונית ללהיט של נמרוד הלל ''אנא השם''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}, {"start": 41, "end": 50, "label": "SINGER"}]}
+{"text": "שיר דוייב ונחמן אייזנבאך בלהיט חב''די חדש ''ניגון ריקוד''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "יערה מליחי מחדש את הניגון הוותיק של עולם הישיבות ''מארש חברון''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "יקיר סלובודקין בסינגל חדש ''אוי ירושלים''", "entities": [{"start": 0, "end": 14, "label": "SINGER"}]}
+{"text": "ריף מקוב בביצוע מחודש לסינגל הראשון ''בין השמשות''", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "דניאל וולדמן מארח את זמרי החתונות המובילים בניו יורק  ''דער רבי איז געזונט''", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "ליעד שולב מקפיץ עם מילים חודרות אמונה ''הכל לטובה''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "רונן דוד בשיר קייצי חדש ''זה הים גדול''", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "ידידיה גוט הראל מויאל ופלג לרר ''והערב נא''", "entities": [{"start": 11, "end": 21, "label": "SINGER"}, {"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "אליה והב במחרוזת שירי קומזיץ חדשה ומרגשת", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "צור ארביב מפנק אתכם ב''דקה של מצב רוח''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "ניב שושני שעיה הבר והרב ישראל גולדווסר סיפור החורבן ''איכה''", "entities": [{"start": 10, "end": 18, "label": "SINGER"}, {"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "איתמר תמרי אמן הקומזיצים והנשמה בסינגל בכורה ''משיח''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "שירה גבאי פותח את בין הזמנים בקאבר אלקטרוני חדש ''קרבני''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "ליעד בסון בסינגל מרגש ומלא תקווה ל''ימים טובים''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "רני עמק מענדי ווייס ומשה ולרשטיין בסינגל אנרגטי ''אויבען אראפ''", "entities": [{"start": 0, "end": 7, "label": "SINGER"}, {"start": 8, "end": 19, "label": "SINGER"}]}
+{"text": "09 סענדר געלב, דב הנדלר, וחגי ברון - נחמה", "entities": [{"start": 15, "end": 23, "label": "SINGER"}]}
+{"text": "08 שי נעים, אביתר יעקב, רובי קדוש - רחם", "entities": [{"start": 3, "end": 10, "label": "SINGER"}, {"start": 24, "end": 33, "label": "SINGER"}, {"start": 12, "end": 22, "label": "SINGER"}]}
+{"text": "05 יובל מישקובסקי הורביץ לקראת שבת נחמו''חמו נחמו עמי''", "entities": [{"start": 3, "end": 17, "label": "SINGER"}]}
+{"text": "02 אלחנן רווה בסינגל חדש ומרגש רחם בחסדך", "entities": [{"start": 3, "end": 13, "label": "SINGER"}]}
+{"text": "04 איתמר רוזן שר כי ניחם לכבוד שבת נחמו", "entities": [{"start": 3, "end": 13, "label": "SINGER"}]}
+{"text": "01 סיני ביטון ורחל המשוררת סוחפים - טאטאלע", "entities": [{"start": 3, "end": 13, "label": "SINGER"}]}
+{"text": "13 זאב בראל זועק בסינגל  חדש ליבי ליבי", "entities": [{"start": 3, "end": 11, "label": "SINGER"}]}
+{"text": "12 מתן בר וילד הפלא זלמן לייב פרידמן נחמו עמי", "entities": [{"start": 3, "end": 9, "label": "SINGER"}]}
+{"text": "06 עברי בן-שושן - רחם בחסדך", "entities": [{"start": 3, "end": 15, "label": "SINGER"}]}
+{"text": "03 זוהר פריינד ודב הומינר במבואות ירושלים העתיקה  נחמו", "entities": [{"start": 3, "end": 14, "label": "SINGER"}]}
+{"text": "11 מאור מאיר ממשיך והפעם ''פרוק'' של יקותיאל קדוש.", "entities": [{"start": 37, "end": 49, "label": "SINGER"}, {"start": 3, "end": 12, "label": "SINGER"}]}
+{"text": "הרב אלעד שעאר שליט''א ליל תשעה באב תשפ''ב - עברית", "entities": [{"start": 4, "end": 13, "label": "SINGER"}]}
+{"text": "עדן חסון וידידיה גולדשטוף בגרסה ווקאלית לשירם ''אבא אוהב''", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "שמואל ובנצי מרקוס (להקת עברי מונסונגו) מציגים גרסה ווקאלית ללהיטם ''בן עמרם''", "entities": [{"start": 24, "end": 37, "label": "SINGER"}]}
+{"text": "אביתר אושה בביצוע ווקאלי ''זוהר השבת''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "יפתח רוזמרין בביצוע ווקאלי לשירו ''הנה גאולה''", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "נתן גורן וריצ'רד אגרנוביץ' בביצוע ווקאלי משותף 'Love your fellow Jew'", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "עזרא גטנו בביצוע ווקאלי ל''ברכת הדיוט'' מאלבומו החדש", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "אוראל פזי במחרוזת ווקאל מרגשת משירי לי-און שידלובסקי ''למענך''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}, {"start": 36, "end": 52, "label": "SINGER"}]}
+{"text": "איתן חזיזה בסינגל ווקאלי חדש ''לכה דודי''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "שלמי יקואל בסינגל ווקאלי מקורי ''לפיכך הרבה להם''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "עקיבא מאנע בגירסה ווקאלית לשירו ''רחם''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "אחיה איגר מגיש גרסה ווקאלית לשירו ''כמו ילד''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "אלירן כהן בגרסה ווקאלית חדשה לשירו ''מתרצה''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "זאב פרנס בביצוע ווקאלי מרגש ''ירושלים''", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "זאבי ויינשטוק בסינגל ווקאלי ''ציון במר תבכה''", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "אייבי רוטנברג משחרר גרסה ווקאלית לשירו ''לא לבד''", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "יעקב לעמער מגיש ביצוע ווקאלי חדש לשירו ''אודך''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "אליהו מולה בחידוש ווקאלי מרהיב ''להתפלל''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "ר' אלימלך ששון בשיר מרגש לכבוד שמחת בר המצווה לבנו ''והאר עיננו בתורתך'''", "entities": [{"start": 3, "end": 14, "label": "SINGER"}]}
+{"text": "עדי זרחיה בביצוע ווקאלי לשיר של להקת יאפצ'יק ''עד אנה''", "entities": [{"start": 32, "end": 44, "label": "SINGER"}, {"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "צורי טננבוים בסינגל ווקאלי - תן לי תפילה", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "נאור עמבר מגיש סינגל ווקאלי ''קומות של תקווה''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "אברהם אריה תורג'מן בגרסה הווקאלית של פרויקט 'מעומקא דליבא' לסינגל ''רבות מחשבות''", "entities": [{"start": 0, "end": 18, "label": "SINGER"}]}
+{"text": "אייזיק טל ואריק סיני בביצוע ווקאלי ''שפכי''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "רחמים אסלאן & עמיחי זוטא ז''ל ''מיכאל'ס ברכה''", "entities": [{"start": 0, "end": 11, "label": "SINGER"}, {"start": 14, "end": 24, "label": "SINGER"}]}
+{"text": "עילי אוחנה ואהרן יוני זינגלבוים מרגשים 'די רייע' (ההמתנה בתור)", "entities": [{"start": 17, "end": 31, "label": "SINGER"}, {"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "ישראל משיח ווורן אונגר בביצוע מ'פרויקט ניגון' ''מי האיש''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "מיכל ניר בסינגל בכורה ''ידיד נפש''", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "אביחי רוזנבלט בסינגל חדש ''מתוך הלב''", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "טוביה שטראוס מגיש הניגון שהולחן לחג הגאולה י''ב – י''ג תמוז", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "נבו לוי ביצע לרגל שמחת הבר המצווה היצירה ''מיינע תפילין''", "entities": [{"start": 0, "end": 7, "label": "SINGER"}]}
+{"text": "נועם רמתי מארח את אחים שלו בסינגל בכורה לקראת בין המיצרים ''רחם''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "צבי בלומנפלד מגיש ביצוע לייב ''מחרוזת זיץ''", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "יהוידע עמר משחרר סינגל מרגש ''אימתי''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "יאיא כהן אהרונוב ופאר טרוגמן זל מרגשים ''יאסעלע''", "entities": [{"start": 0, "end": 16, "label": "SINGER"}]}
+{"text": "לילך דגן & מורן עבו - ירושלים שלי", "entities": [{"start": 11, "end": 19, "label": "SINGER"}, {"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "שאול ברין מגיש סינגל חדש לזכרו של הנרצח ''נחם צאן מרעיתך''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "רועי הרוש משחרר לקראת שבת ''כי אשמרה שבת''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "שקד בר-און בסינגל חדש ''נכון ליבי''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "דובי מייזליס ודוד ביתן ''במחרוזת להיטים''", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "ברי מסיקה בשיר מקורי ומעניין ''כמו ילד''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "עברי כחלון והרב נאור פישמן בסינגל חדש ''למחר''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}, {"start": 16, "end": 26, "label": "SINGER"}]}
+{"text": "בן זאבי צ. יוסטמן חושן גרינר נטע לוין ומנדי ברנדויין במחרוזת ''ציון וירושלים''", "entities": [{"start": 8, "end": 17, "label": "SINGER"}, {"start": 0, "end": 7, "label": "SINGER"}, {"start": 18, "end": 28, "label": "SINGER"}, {"start": 29, "end": 37, "label": "SINGER"}]}
+{"text": "אחיה חזן בביצוע לייב ותוסס ''אשרי העם''", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "שני רויטמן משחרר סינגל ראשון ''הריני מקבל''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "מוטי הלר בסינגל חדש ''רוצה לעוף''", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "ישראל קרמר אוהד וקסמן ותזמורתו במחרוזת ריקודים", "entities": [{"start": 0, "end": 10, "label": "SINGER"}, {"start": 11, "end": 21, "label": "SINGER"}]}
+{"text": "עידו שופט בסינגל חדש ''כי לא יטוש''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "ענהאל ינקלביץ משחרר מתוך אלבומו הבכורה שיר נוסף ''מלאכי השלום''", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "מישל שבח איציק אייזנשטט ופנחס דוד בביצוע תוסס ''ברודער'ס''", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "יוחאי שורץ ומקהלת צלילי תקווה העולמית בשיר חדש טעמו וראו", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "עברי לידר בהופעה ''נחמה כזו''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "11 רונאל קנטור הרשי מושקוביץ ושירה ומונה ''לא ישא''", "entities": [{"start": 15, "end": 28, "label": "SINGER"}, {"start": 3, "end": 14, "label": "SINGER"}]}
+{"text": "06 גיא פדר עם אדם יגודייב ולוי וילהלם בארגון מסילה ''אם השם''", "entities": [{"start": 14, "end": 25, "label": "SINGER"}, {"start": 3, "end": 10, "label": "SINGER"}]}
+{"text": "08 רחמים הנדל בסינגל חדש ''יעלה ויבוא''", "entities": [{"start": 3, "end": 13, "label": "SINGER"}]}
+{"text": "10 ''אלון דוד וחי אוסטייב צבי הרשלר ''בואי כלה", "entities": [{"start": 5, "end": 13, "label": "SINGER"}, {"start": 26, "end": 35, "label": "SINGER"}]}
+{"text": "09 לידור פינצי אלחנן זיס ומונה ויהורם אדריאן ''נכספה''", "entities": [{"start": 3, "end": 14, "label": "SINGER"}, {"start": 15, "end": 24, "label": "SINGER"}]}
+{"text": "16 - רועי שגיא ועידן אלטמן - ונתנה תוקף", "entities": [{"start": 5, "end": 14, "label": "SINGER"}]}
+{"text": "14 אליעזר בן יהודה בביצוע ''מן השמים'' לעיני אלפי המסיימים", "entities": [{"start": 3, "end": 18, "label": "SINGER"}]}
+{"text": "12 עדי ביטי ושמואל אחרק עם היצירה של מונה ''עיקר לימוד האדם''", "entities": [{"start": 3, "end": 11, "label": "SINGER"}]}
+{"text": "13 שלומי גרנטר שר הרחמן, מונה ניצח ו'חיים וייס' השלימה את ההרמוניה", "entities": [{"start": 37, "end": 46, "label": "SINGER"}]}
+{"text": "04 מלאכי קלינברג יונתן ויניק רוני קלסקי בביצוע נדיר ''הדרן''", "entities": [{"start": 17, "end": 28, "label": "SINGER"}, {"start": 3, "end": 16, "label": "SINGER"}, {"start": 29, "end": 39, "label": "SINGER"}]}
+{"text": "03 טל חזן מארח את חנוך זנו ויהב פרבשטין בשיר חדש ''כדאי''", "entities": [{"start": 18, "end": 26, "label": "SINGER"}, {"start": 3, "end": 9, "label": "SINGER"}]}
+{"text": "01 לוי פאלקאוויטש ומנדל ליפשיץ שרים 'הוי דן' של מיקי יאסו", "entities": [{"start": 48, "end": 57, "label": "SINGER"}]}
+{"text": "לביא שוורץ בסינגל חדש לשבת ''לכו נרננה''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "דור גולדובסקי מרגש שוב ומוציא שיר על הילד המיוחד ''אנדערש''", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "הרב ברוך ליבוביץ מתכבד להגיש ''ניגון התוועדות לר׳ אהרון הנדל''", "entities": [{"start": 4, "end": 16, "label": "SINGER"}, {"start": 50, "end": 60, "label": "SINGER"}]}
+{"text": "נהוראי רביזדה בשיר חדש ''שיר חדש''", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "אריה שפילמן מפתיע שוב ב''קומזיץ עם החברים''", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "צוריאל גולדשמידט בסינגל חדש ''אתה שמציל''", "entities": [{"start": 0, "end": 16, "label": "SINGER"}]}
+{"text": "שימי מרציאנו, עזריאל שבתאי ומקהלת ניגון הלב בסינגל חדש ''מזמור לתודה''", "entities": [{"start": 14, "end": 26, "label": "SINGER"}, {"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "תמיר מנדלסון בסינגל חדש''מצפים לישועה''", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "ליעד בוטרמן בשיתוף שיינר בסינגל חדש מיוחד ובועט ''מהתחלה''", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "ארי בלוזנשטיין מגיש ומרגש ''זמן חופה'' בהפקה ייחודית ומושקעת", "entities": [{"start": 0, "end": 14, "label": "SINGER"}]}
+{"text": "ערן למפרט בסינגל חדש ה''לונה פארק'' של החיים", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "ניצן בלטה ו'ארגון תודה לך השם' מגישים סינגל חדש ''בדרך''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "מקהלת נשמחה ודוד יצחק במחרוזת עם מיטב שירי אלבומי ''לחיים''", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "שלומי ימין בסינגל חדש ''הקב''ה בלבד''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "יהונתן ליבוביץ בתוכנית 'מוצ''ש חי' עם אלקנה טואף מספר על השיר המרגש החדש 'רק מאהבה'", "entities": [{"start": 38, "end": 48, "label": "SINGER"}, {"start": 0, "end": 14, "label": "SINGER"}]}
+{"text": "פז אשרוב מבצע את היצירה של אבנר עמדי ''אמר רבי יוחנן''", "entities": [{"start": 27, "end": 36, "label": "SINGER"}, {"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "יונתן היל מבצע עם הגיטרה את ''ויכולו'' של יידל ואמיל שרביט", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "כפיר רוטמן מברך ''חודש טוב'' עם סינגל חדש ואנרגטי", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "יואל כהן מגיש סינגל בכורה חגיגי ''מקימי''", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "קורן צרפתי בסינגל חדש בשם ''קלי אתה ואודך''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "דוד אמאדו בדואט מרגש שהקליט עם אסף משיח ז''ל ''מה אשיב להשם''", "entities": [{"start": 31, "end": 39, "label": "SINGER"}, {"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "לורן ווסרמן וילד הפלא נתן קריטי עם היצירה הויז'ניצאית ''מה אשיב''", "entities": [{"start": 0, "end": 11, "label": "SINGER"}, {"start": 22, "end": 31, "label": "SINGER"}]}
+{"text": "שרון מחלב שר מרטין וידרקר ''ברכי נפשי''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "שחר עבד עם ''אודך'' מתוך ההלל", "entities": [{"start": 0, "end": 7, "label": "SINGER"}]}
+{"text": "מאיר גלבר מחדשים את 'מה אשיב לך'", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "03 עלי הירש שר מה אשיב במעמד אלפים", "entities": [{"start": 3, "end": 11, "label": "SINGER"}]}
+{"text": "שבתאי גיל סחף עם 'ברכי נפשי'", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "אלדד עסיס וירדן חסון במחרוזת א טאנץ מיט יודעל'ע", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "חיים קריגר משיק סינגל חדש ''למה לי ליפול''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "יותם מיכאל בביצוע לייב ''הגבול זה השמיים & מאן דעביד לטב''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "שלומי ברנשטיין בסינגל מקורי ומרגש ''אלוקי נשמה''", "entities": [{"start": 0, "end": 14, "label": "SINGER"}]}
+{"text": "שמואל הודסמן ודין מטלון בביצוע לייב ייחודי ''הלב שלי''", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "ליעוז רם בסינגל חדש ומרענן ''מה אני אגידך''", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "אייל כהן גל מלמד וזינגערליך ומנדי ברנדויין מגישים ''פינקי'ס ניגונים''", "entities": [{"start": 9, "end": 16, "label": "SINGER"}, {"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "בארי לבב משחרר שיר חופה חדש ''בואי כלה''", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "רפי יעקבי ושרוליק שטיין ''רק תודה''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "מקהלת וויזניץ בית שמש בניגון חדש ''אהבת עולם'' שחיבר ר' שמעון קוגל לסיצין", "entities": [{"start": 56, "end": 66, "label": "SINGER"}]}
+{"text": "רגב אמסלם דב דגן ויהודה לנגר במחרוזת ריקודים מקפיצה", "entities": [{"start": 10, "end": 16, "label": "SINGER"}, {"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "גבי טיקוצקי לוי עצבני ולייזר הרשקוביץ במחרוזת ניגוני חב''ד", "entities": [{"start": 12, "end": 21, "label": "SINGER"}, {"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "איתן כ״ץ מבצע שיר מרוקאי פופולרי ''הייא הייא''", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "נטע שפריי (עילוי הגיטרה הצעיר) מארח הפעם את אביו בביצוע מרגש ''הבט''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "דוד פדר באלבום חדש בשם ''דוגמא'' ומשחרר הסינגל ''קול צהלה''", "entities": [{"start": 0, "end": 7, "label": "SINGER"}]}
+{"text": "אליהו זילברמן ואליאס חסון בדואט לוהט של הקיץ ''שבילים''", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "אסיף סיגאוי משיק סינגל חדש בשם ''טועמיה''", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "מאיר ישראל דדון והאלפים שרו במופע ''גרש את העצבות''", "entities": [{"start": 0, "end": 15, "label": "SINGER"}]}
+{"text": "מיכאל ניסנוב בסינגל חדש ''פתחו לי''", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "אודי מוזיקנט ודי ג'יי פארברענג בסינגל מקפיץ ''האפי קלאפי''", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "סהר ממן בסינגל חדש ''תקח איתך''", "entities": [{"start": 0, "end": 7, "label": "SINGER"}]}
+{"text": "אלישי סורקיס פותח את קיץ עם סינגל חדש וממכר ''מרגיש לי טוב''", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "פז יונגר בסינגל חדש ''תן לי את הלב''", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "ארז דלג'ו בסינגל חדש ומפתיע ''לא מאוחר''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "צבי גרינולד וחברים בחופה לייב מיוחדת ומרגשת", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "עודד מינשרי בביצוע מיוחד  ''האדרת והאמונה'' (מארש חבד)", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "אלירן נגל בסינגל חדש ''מעלי''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "מנחם לוק בקאבר חסידי ניגון ''התבוננות'' - ויז'ניץ", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "יפעת טל בסינגל חדש ''מגולה לגאולה''", "entities": [{"start": 0, "end": 7, "label": "SINGER"}]}
+{"text": "ניב סקאג מגיש סינגל חדש ''מזמור לתודה''", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "יהודה גלאנץ באלבום חדש בשם ''דוגמא''", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "רועי סטולרו משחרר סינגל חדש בשם ''אתה חסר''", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "שמחה הכהן בשיר חדש ומפתיע ''בוקר טוב רבש''ע''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "נתנאל שצקי דב אזולאי וויצמן בודרהם במחרוזת ''אבות על בנים''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}, {"start": 11, "end": 20, "label": "SINGER"}]}
+{"text": "נחום ברנשטיין וטום שושן בלחן חדש לחתונת גור ''באור פניך''", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "הרצל נחמני בסינגל חדש ''מחכה בבית''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "סימן פרדה בלהיט וויראלי חדש בשם ''העולם הבא''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "איציק מימרן בסינגל מרענן לקראת הקיץ ''מסיבה''", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "רזיאל עובדיה בביצוע לייב ''ימה''", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "עמירם גולדנשטיין שר עם תלמידי הישיבה ''אל תיפול''", "entities": [{"start": 0, "end": 16, "label": "SINGER"}]}
+{"text": "אביעד סינוואני ועמרם בר-אשר מקפיצים בשיר ''זה הקטן'' מתןף האלבום 'לב חדש'", "entities": [{"start": 0, "end": 14, "label": "SINGER"}]}
+{"text": "הדר פרנצי (Z) משיק להיט קיץ ''הכל לטובה'' שנכתב כהודיה להשם לאחר תאונה", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "אלי מרכוס באלבום בכורה ''לחיים מיט משה דוד''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "ר' ניר קפטן הלחין ושר ''א-ל אדון''", "entities": [{"start": 3, "end": 11, "label": "SINGER"}]}
+{"text": "טבע קויפמן - הופעה חיה בירושלים 3 -דוגמה", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "רוני אמסלם בשיר לזכרו של שלוימי קאופמן 'ביוטיפול פיפול' (אנשים יפים)", "entities": [{"start": 0, "end": 10, "label": "SINGER"}, {"start": 25, "end": 38, "label": "SINGER"}]}
+{"text": "עומרי רזומני מגיש ניגון השביעי מתוך פרוייקט ניגוני הינוקא ''אדיר איום''", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "ניתאי עיש ונחמן אורן בלהיט חדש ''אדרבה''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "ורן אשרוביץ אפרים זינדאני ואלקנה ברנדויין  ב''מחרוזת דאנס 2''", "entities": [{"start": 0, "end": 11, "label": "SINGER"}, {"start": 12, "end": 25, "label": "SINGER"}]}
+{"text": "חננאל בייטש משחרר להיט אנרגטי ''היום הזה''", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "רום פלוטקין ופרחי רעים בדואט ''מודה אני''", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "חמי פלרמן בסינגל חדש ''תראה אותי''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "פינחס דמארי וישיבת נווה בשירת המונים ''בלבב שלם''", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "אוריה יניב כתב הלחין ושר ''מסיבה בכל העיר''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "רוני נסים בסינגל מקפיץ לקיץ ז''ה הרגע שלך''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "מירון זכריה מגיש להיט החתונות הבא ''אחת שאלתי''", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "רביד זיגמן מארח את אפי פוטולסקי בסינגל חדש ''אלוקים שלי''", "entities": [{"start": 19, "end": 31, "label": "SINGER"}, {"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "עופרי גרינהולץ משיק אלבום בכורה ''ביכורים''", "entities": [{"start": 0, "end": 14, "label": "SINGER"}]}
+{"text": "יונדב פרץ שימי שובקס וברוך גולן במחרוזת 20 שירי ''אני מאמין''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "יואל דוד גולדשטייןוואג ויוחנן גיבל בדואט חדש ''כבודו''", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "יוני בסון משיק מחרוזת חתונה אנרגטית עם כל הלהיטים", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "אלדד קריבוס בקאבר נוסטלגי ''ירושלים הבית שלנו''", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "אופיר סלמון משחרר להיט חדש וסוחף בשם ''ימים טובים''", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "חיים ישכיל מגיש סינגל חדש פרי יצירתו ''מנגינת הנשמה''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "רביד גלבוע עם סינגל חדש ''עוד לא מאוחר''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "יאיר אטיאס ותזמורתו של בני קטן במחרוזת חופה", "entities": [{"start": 0, "end": 10, "label": "SINGER"}, {"start": 23, "end": 30, "label": "SINGER"}]}
+{"text": "גלעד כהנא בסינגל חדש ''פָארוֺיְס''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "הרב זאב שרוני הלחין לאביו שיר על הפסוק 'אפתח בכינור חידתי'", "entities": [{"start": 4, "end": 13, "label": "SINGER"}]}
+{"text": "יצחק וינברג בסינגל חדש ''רק מאהבה''", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "הרב ריי הורוביץ בלחן נפלא ''בן מלך''", "entities": [{"start": 4, "end": 15, "label": "SINGER"}]}
+{"text": "אימרי זיאת בסינגל חמישי ''ביום ההוא''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "אריה דנינו בסינגל חדש ''לבנות בית'' בדרך לאלבום שני", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "סטיבן נדב בסינגל בכורה ''הדרך חזרה''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "ג'רמי גימפל מדליק את הקיץ עם סינגל חדש ''בלב שמח''", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "הרב עוזיאל סויסה בשיר ''התחזקות'' חדש", "entities": [{"start": 4, "end": 16, "label": "SINGER"}]}
+{"text": "תאום רחמיאלוביץ ויהושע דיטשר בביצוע נוסטלגי ''רצה הקב''ה''", "entities": [{"start": 0, "end": 15, "label": "SINGER"}]}
+{"text": "דוד פולק וחברים מחדשים ''מעל פסגת הר הצופים''", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "שיראל קורקוס, יואלי יורוביץ ואברומי פלאם בלהיט הבא ''אל תיפול''", "entities": [{"start": 0, "end": 12, "label": "SINGER"}, {"start": 14, "end": 27, "label": "SINGER"}]}
+{"text": "אל קופר מבצע את היצירה של מיכה מדר ''בריך שמיה''", "entities": [{"start": 0, "end": 7, "label": "SINGER"}, {"start": 26, "end": 34, "label": "SINGER"}]}
+{"text": "אליעד לבנברג ומקהלת ''נשמה'' - ''מחרוזת הכנה למתן תורה''", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "רפאל בוסקוביץ ויוני Z לקראת חג השבועות ''כבוד לתורה''", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "אפק לשם ואליי האלטר עם היצירה ''והאר עינינו''", "entities": [{"start": 0, "end": 7, "label": "SINGER"}]}
+{"text": "אייל עובד בסינגל חדש ''כל הנשמה תהלל י-ה''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "עזר מאירוביץ וחיים ישעי' ווייל בביצוע כובש ''רצוננו''", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "דניאל ישי בסינגל חדש ''שטייגען''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "איציק ויינגרטן בסינגל חדש ''ואתם תהיו לי''", "entities": [{"start": 0, "end": 14, "label": "SINGER"}]}
+{"text": "שי רבייב תמיר מוריוסף ויואלי בשיר לכבוד שבועות ''מן השמיים''", "entities": [{"start": 0, "end": 8, "label": "SINGER"}, {"start": 9, "end": 21, "label": "SINGER"}]}
+{"text": "ישראל שאר תומר קורקידי ופריילך עם היצירה של מונה ''בקולות וברקים''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}, {"start": 10, "end": 22, "label": "SINGER"}]}
+{"text": "בנג'מין צבאג בסינגל חדש לשבועות ''איכא בשוקא''", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "יובל מירום בסינגל חדש ''יומם וליל''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "יוסף קורדונר ובני הישיבות בסינגל חדש לכבוד לומדי התורה ''מקום בגן עדן''", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "אביה דויטש ואדר כהנוביץ בדואט מרגש ליצירה ''והאר עינינו'' (פיטסבורג)", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "מאור אלון אורין מאס עינב פרידלנדר ו'מלכות' ב10 ניגוני תורה מתוך קפיטל קי''ט", "entities": [{"start": 10, "end": 19, "label": "SINGER"}, {"start": 0, "end": 9, "label": "SINGER"}, {"start": 20, "end": 33, "label": "SINGER"}]}
+{"text": "איתן עמיהוד מלכות ובנצי במחרוזת הכנה לקבלת התורה (ווקאלי)", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "גולן שכנר בביצוע ווקאלי מרהיב ''שירה זינגט שירה''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "שילו מיליס אפרים חדוות עמוס רייס רז פוזאילוב יעקב גיפטרן במחרוזת 'ל''ג תשפג'", "entities": [{"start": 0, "end": 10, "label": "SINGER"}, {"start": 33, "end": 44, "label": "SINGER"}, {"start": 11, "end": 22, "label": "SINGER"}, {"start": 23, "end": 32, "label": "SINGER"}]}
+{"text": "אוריה הרוש - בהילולא דבר יוחאי (מחרוזת שירי לג בעומר)", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "עובדיה ארנולד עם להיט חדש לל''ג בעומר ''רבי שמעון לכל''", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "ריף שפיצר בסינגל חדש ומקורי טנקיו השם", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "צפריר יפרח משחרר ''זרעא חיא'' עם עמית גוטמן מתוך אלבומו ווקאלי חדש", "entities": [{"start": 33, "end": 43, "label": "SINGER"}, {"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "ארז קוזי בגירסה ווקאלית לשירו ''להודות''", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "אפק נוימרק בגרסה ווקאלית לשיר ''תדע''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "גיל נמר בשיר ווקאלי ''יהיו לרצון''", "entities": [{"start": 0, "end": 7, "label": "SINGER"}]}
+{"text": "דור ברנדנבורג וחברים בגרסה ווקאלית ל''שיר הצדקה''", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "יקותיאל מלול בקאבר ווקאלי ללהיט של מקהלת כיסופין ''כמה טוב השם''", "entities": [{"start": 35, "end": 48, "label": "SINGER"}, {"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "עדן עמירב בגרסה ווקאלית לשירו ''להודות''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "ארז גולומבק מגישה ''אין כאלוקינו'' (בעלזא) ווקאלי", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "גרשון פפרני בסינגל חדש ''ובאותו הזמן''", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "יהל שולץ עם גירסה ווקאלית ללהיט ''לחי העולמים''", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "מעוז רוזן ומאור מזרחי בליווי עודד סיני במחרוזת מרגשת ווקאלית ''מיכאל'ס פלאם''", "entities": [{"start": 29, "end": 38, "label": "SINGER"}, {"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "להב שבץ מגיש ''אשרי האיש'' בגרסה ווקאלית", "entities": [{"start": 0, "end": 7, "label": "SINGER"}]}
+{"text": "סאן שטינברג מגיש גרסה ווקאלית לשירו ''המרחם''", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "יואלי פולצ'ק שרה שטיינמן ושילה שוורצבורד ''בני חיי מזוני''", "entities": [{"start": 13, "end": 24, "label": "SINGER"}]}
+{"text": "מנחם פיין באלבום שלישי בסדרת ''לחישות הלב 3''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "אסף ילין ואורן ברג - סיום הרמבם (ווקאלי)", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "רותם זהבי ואיציק בלעדי בביצוע ווקאלי ללהיט המצליח ''בוא לפה''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "אופיר כהן בביצוע ווקאלי ללהיט של נוה אזר ''תכף יפתח''", "entities": [{"start": 33, "end": 40, "label": "SINGER"}, {"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "יחזקאל קצב בגרסה ווקאלית במיוחד לימי ספירת העומר ''השוכן איתם בתוך טומאתם''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "אלישיב שניידר בגרסה ווקאלית לימי ספירת העומר ''חלומות''", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "רולי אזרחי ומקהלת ויז'ניץ בביצוע ווקאלי ''טוב להודות''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "אברמי רוט ויחיאל ברש אומני הווקאל מחדשים את ''לחי עולמים'' (סטיבן סיגל)", "entities": [{"start": 60, "end": 70, "label": "SINGER"}, {"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "אליעד נחום משחרר גרסה ווקאלית לשירו ''שמע ישראל''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "נחום יוליש בראיון לאחר פטירת בעל המנגן ר' שוהם שמחי ז''ל", "entities": [{"start": 0, "end": 10, "label": "SINGER"}, {"start": 42, "end": 51, "label": "SINGER"}]}
+{"text": "מוישי בורגר בקול בוכים מספיד את ליאור יוסופוב ז''ל", "entities": [{"start": 32, "end": 45, "label": "SINGER"}, {"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "פרחי טורונטו בגרסה ווקאלית משובחת לשירו ''אבל באמת''", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "לוטן אברס מגיש גרסה ווקאלית לשירו ''תנסה להיות''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "חגי אלפסי בביצוע ווקאלי מרגש לשיר ''איפה כולם''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "ר' פנחס מרדכי (פינקי) וועבער בראיון מצמרר לאחר פטירת ר' אבנר רוזנברג זל", "entities": [{"start": 56, "end": 68, "label": "SINGER"}]}
+{"text": "מאור אהרון מספיד בבכיות ובגראמען את ר' נחמי גלויבער ז''ל", "entities": [{"start": 39, "end": 51, "label": "SINGER"}, {"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "זליג מלכה מפתיע בסינגל ווקאלי ''קול אחד''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "נועם בורוכוב עם הגרסה הווקאלית ''אל תשיבני ריקם''", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "אודי ואליה גרסון בגירסה ווקאלית לשיר של יוסי קקון ''דוד המלך''", "entities": [{"start": 40, "end": 49, "label": "SINGER"}]}
+{"text": "רואי עמור סימן טוב לייזרוביץ ו'פריילך' במחרוזת שלומי ועקנין", "entities": [{"start": 10, "end": 28, "label": "SINGER"}, {"start": 0, "end": 9, "label": "SINGER"}, {"start": 47, "end": 59, "label": "SINGER"}]}
+{"text": "אבי מאירפלד מגיש ''והיא שעמדה'' קאבר פסנתר", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "ירון לנדאו ואיציק בוזגלו בדואט ביתי ''והיא שעמדה''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "נדב קומרובסקי בשיר שכתב והלחין לחג הפסח", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "אלקנה נינו מחדשת את ''בצאת ישראל''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "אביתר גלבוע בראיון מיוחד עם רועי לביא בתכנית ''זמן שמחתנו'' (קול חי)", "entities": [{"start": 28, "end": 37, "label": "SINGER"}, {"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "טלמור פייג ומיכה שטרית בקאבר חדש 'קדש ורחץ'", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "להקת מברוק בקאבר ללהיט ''והיא שעמדה'' של שוואקי", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "שי וגנר בסינגל שלישי מתוך סדרת 'מיינלידל' ''נרצה''", "entities": [{"start": 0, "end": 7, "label": "SINGER"}]}
+{"text": "אבישי שולץ בקאבר לשיר של פינקי ''לעכטיג''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "מבשר בקמן ובראל קץ בסינגל חדש ''מזמור לתודה''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "גיל קפטן בסינגל חדש ''הלילה הזה''", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "שלמה טויטו מגיש שיר נוסף של הינוקא ''תאמין ותנצח''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "בן שיר מבצע את השיר הישן של אלימלך זינגער ''קדוש''", "entities": [{"start": 0, "end": 6, "label": "SINGER"}, {"start": 28, "end": 41, "label": "SINGER"}]}
+{"text": "ניצן רויטמן וליאב פישבין עם היצירה של מונה ''עיקר לימוד האדם''", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "יעקב פרידמן אמן הגיטרה הצעיר במחרוזת מיוחדת לכבוד חג הפסח", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "זבולון דאלל, יואל נפחא וחברים בשמחת חג (קול חי)", "entities": [{"start": 0, "end": 11, "label": "SINGER"}, {"start": 13, "end": 22, "label": "SINGER"}]}
+{"text": "דורון וינד עם היצירה ''א מצה אין אויוון''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "יואלי דוידוביץ בקאבר לשוואקי ''והיא שעמדה''", "entities": [{"start": 0, "end": 14, "label": "SINGER"}]}
+{"text": "נתן גושן בסינגל חדש ''לראות את עצמו''", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "עמרם וידס שר ''מיין קרבן'' (הקרבן שלי)", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "מני דיסקינד שר פרץ חן ''והיא שעמדה''", "entities": [{"start": 15, "end": 21, "label": "SINGER"}]}
+{"text": "יונה בגה ודן טננבוים בדואט חדש ''יבנה ביתו''", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "שון אמבר מבצע הלחן של שנקר ''בצאת ישראל''", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "דני פינקל ותלי יס בביצוע לשיר ''רבי שמעון''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "ישי שטראוס משחרר קאבר לקראת פסח ''והיא שעמדה''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "דנאל לביא בביצוע של מארש שמחה", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "צפניה קריף מגיש מחרוזת פסח", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "דביר עמר ואלמוג זוהר מרגשים עם ''והיא שעמדה'' של חב''ד", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "אריאל דרור במחרוזת פסח מרגשת", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "שמחה אברמצ׳יק מסלסל בתפילת טל של עילאי טלבי", "entities": [{"start": 33, "end": 43, "label": "SINGER"}, {"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "ניצן רבינוביץ מגיש ''חסל סידור פסח''", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "אליסף רביבו במחרוזת פאנקי", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "משה אביגדור מפתיע בשיר חדש מלהיב ומרגש ''אני שייך לעם''", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "אור עמרמי ברוקמן ונתנאל כרמל במחרוזת ''ליל שימורים''", "entities": [{"start": 0, "end": 16, "label": "SINGER"}]}
+{"text": "ליאל קורלנסקי מגיש מחרוזת משירי חג הפסח", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "ר' נח הויזמן בביצוע מיוחד ''והראנו''", "entities": [{"start": 3, "end": 12, "label": "SINGER"}]}
+{"text": "נתנאל גלזר וילדי הפלא בלחן חדש ל''חד גדיא''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "שמוליק סוכות רוני בלום ובני הישיבות שרים ''בצאת ישראל''", "entities": [{"start": 13, "end": 22, "label": "SINGER"}, {"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "מוטי אילאוויטש עם סינגל אופטימי ומרגש ''אחים''", "entities": [{"start": 0, "end": 14, "label": "SINGER"}]}
+{"text": "חגי מזרחי מארח את מקהלת שפתותינו נרננה - שחור ולבן (הינוקא בבית השלישי)", "entities": [{"start": 18, "end": 38, "label": "SINGER"}, {"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "עומרי שקורי בסינגל חדש ''איך בין א שטיק תפילה''", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "נועם שמואלי בשיר תקווה ''ירושלים''", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "שמוליק ישורון בביצוע מיוחד ל''בְּצֵאת יִשְׂרָאֵל'' בלחנו של ר' יעקב תלמוד", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "עתי אורנשטיין מחדש ''הללו את השם''", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "שמואל ויגודה וחיים דוב וולף ''איש ימינך''", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "מ. ב. & הלל פולק בסינגל חדש ''גאולה''", "entities": [{"start": 8, "end": 16, "label": "SINGER"}]}
+{"text": "יותם רענן בנצי ועמוס דלבריאן במחרוזת שירי שבת בלייב", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "אגם הוז בשיר מרגש לזכר נשמת אמו ''רפאינו''", "entities": [{"start": 0, "end": 7, "label": "SINGER"}]}
+{"text": "יוני גנוט משחרר מחרוזת שירים לחג הפסח", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "שראל רונן בבייב מגיש מחרוזת קלידים ''מחרוזת פסח''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "תום איתן בשיר עוצמתי למילותיו של החזון איש זיע''א ''שתרחם על בני''", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "חי סבאג וילדי הת''ת נתיבות משה בשירת המונים ''מי אנכי''", "entities": [{"start": 0, "end": 7, "label": "SINGER"}]}
+{"text": "רם קאופמן בשיר השני בסדרה ‘מיינלידל’ ''ווארעמקייט''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "עילי נובק בשיר המחאה החדש ''אני יהודי!''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "יובל פרנקל ר' צחי אלמקיס אברהם סאמעט ''קדש ורחץ''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}, {"start": 14, "end": 24, "label": "SINGER"}, {"start": 25, "end": 36, "label": "SINGER"}]}
+{"text": "קאי מלק מגיש גרסת רמיקס לשיר ''מנגינה'' של זאבי וולס", "entities": [{"start": 43, "end": 52, "label": "SINGER"}, {"start": 0, "end": 7, "label": "SINGER"}]}
+{"text": "זאב בוכניק ויעקב למר ''יבשה שלי''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "דיג'יי פארברנגן איתי חלפון ואבירן אהרון ''אפ-מיקס פסח''", "entities": [{"start": 16, "end": 26, "label": "SINGER"}]}
+{"text": "לייבי מאשקאוויטש, יונה פרלשטין, ראובן וייסמן מרגשים בחופה", "entities": [{"start": 18, "end": 30, "label": "SINGER"}, {"start": 32, "end": 44, "label": "SINGER"}]}
+{"text": "מנשה סגל בניגון ''אשריך'' לקראת הכנסייה הגדולה", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "יצחק איתן מזרחי, אדר קמחי, ישיבת בני עקיבא מטה בנימין - אדיר במלוכה", "entities": [{"start": 17, "end": 25, "label": "SINGER"}, {"start": 0, "end": 15, "label": "SINGER"}]}
+{"text": "גבע קצבמן בביצוע מרגש ''שערי דמעות'' של פריד", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "יגאל אורן בסינגל חדש ''למצוא את הדרך''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "נועם סרור ואופק אסא בקאבר נוסטלגי ''בלבבי''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "יהודה זיסאפל מגיש סינגל חדש בשם ''מלאכי עליון''", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "נחשון רחמים ויוסי ורסאנו בביצוע לייב ''אמר רבי יוסי''", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "אלי יפרח וליאור פנחסוב במחרוזת שירי פסח תשפ''ג", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "יעקב טלכינר ועומר לוקצקי בשיר חדש ''חתן כלה - מזל טוב''", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "שמואל טרקו ותזמורתו של יהושע קלר במארש ''לכה דודי''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "יהורם יצחקי ויואל לויטוב בסינגל חדש ''שירה עמי''", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "מיכה נגר מגיש סינגל חדש לקראת חג הפסח ''לאבותינו ולנו''", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "אוריאל לוי ונבות דוניצה מגישים סינגל משותף ''מתפלל אני''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "אושר הראל עובדיה אילן יוגב שוורץ שבת לייו", "entities": [{"start": 0, "end": 9, "label": "SINGER"}, {"start": 22, "end": 32, "label": "SINGER"}, {"start": 10, "end": 21, "label": "SINGER"}]}
+{"text": "אלה לי לא מביט לאחור ויוצא בסינגל ''התחלה חדשה''", "entities": [{"start": 0, "end": 6, "label": "SINGER"}]}
+{"text": "אוריון יצחק בסינגל ייחודי ''משה נביאך''", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "ארי סאמט ומאיר צ'ורטקוב בקטע מרהיב ''שהחיינו''", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "ליאור קלמר ניצן חדאד ותזמורת פול שמחה ''מודים''", "entities": [{"start": 11, "end": 20, "label": "SINGER"}, {"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "הראל סעייד ''יבואו ימים''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "ילד הפלא ישראל אלטמן שר על מרן שר התורה זצ''ל ''למה''", "entities": [{"start": 9, "end": 20, "label": "SINGER"}]}
+{"text": "גלי לנג בקאבר נוסטלגי ''שמח תשמח''", "entities": [{"start": 0, "end": 7, "label": "SINGER"}]}
+{"text": "מימון זנזורי משיק סינגל חדש ''על גגות העיר''", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "יוס'לה רוזנבלט במחרוזת תפילה מרגשת לנחת יהודית", "entities": [{"start": 0, "end": 14, "label": "SINGER"}]}
+{"text": "הרב אלי לאופר שר לזכר האחים שנרצחו ''מנחם ישראל''", "entities": [{"start": 4, "end": 13, "label": "SINGER"}]}
+{"text": "מוטי פיקסלר מגיש - מקהלת אשר אשכנזי ''ויקרא''", "entities": [{"start": 0, "end": 11, "label": "SINGER"}, {"start": 25, "end": 35, "label": "SINGER"}]}
+{"text": "פייבל גרינבערג בסינגל מקפיץ ''אמת''", "entities": [{"start": 0, "end": 14, "label": "SINGER"}]}
+{"text": "צביקה אברס בסינגל חדש ''כמה טוב השם''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "''אחיה מוגס באלבום חדש עתיקא קדישא 6 - ''פסח אינדערהיים", "entities": [{"start": 2, "end": 11, "label": "SINGER"}]}
+{"text": "חיים ג'רביטבוים & גיל קקון - בלדת השמש והירח", "entities": [{"start": 18, "end": 26, "label": "SINGER"}]}
+{"text": "כרם שפרינגר בסינגל ציפייה לגאולה ''משיח''", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "משה שטראך בסינגל חדש ''סנהדרין''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "חצק'לה דוד באלבום חדש ''א עהרליכע ליד'' - שירי ר׳ יום טוב עהרליך זצ''ל", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "דוראל כלף בסינגל חדש ''ותן בנו''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "תמיר סגל בביצוע כובש ''מי שעשה ניסים''", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "אורון הלל פרץ בבכי בפורים במהלך שיר התפילה ''מתי תמלוך בציון''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "שלו בדש בסינגל חדש ''נקודות''", "entities": [{"start": 0, "end": 7, "label": "SINGER"}]}
+{"text": "מרדכי יצהר בוימל ופסח שניידר בביצוע מחודש לניגון חב''ד עתיק ומלא רגש", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "ריי אלבז כתב הלחין ושר ''אני היהלום''", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "טלאור סספורטס מפתיע בסינגל רביעי ''סימן טוב''", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "דוד רגב בקאבר מקורי לשיר של איציק אורלב ''הלילה''", "entities": [{"start": 28, "end": 39, "label": "SINGER"}, {"start": 0, "end": 7, "label": "SINGER"}]}
+{"text": "יניב ואנונו בדואט מרגש מהאלבום החדש ''אמר רבי יוחנן''", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "טל גור משחרר סינגל רביעי עם מסר מיוחד בסינגל חדש ''מנגינה''", "entities": [{"start": 0, "end": 6, "label": "SINGER"}]}
+{"text": "אוראל ברון סחף במחרוזת ''בן מלך''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "אביעד שמעון בסינגל חדש ''והאר עינינו''", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "שאול מרטין מרגש בסינגל חדש ''תפילת הרופא''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "אוראל ינקלביץ (אפי' בהסתרה) בסינגל חדש ''אראפ און ארויף' (למעלה ולמטה)", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "יומי לוואי בסינגל חדש ומקורי ''עולם של אהבה''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "דוד רויטמן מגיש את ''אני חי'' מתוך אלבומו החדש", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "מרים לוי בסינגל חדש ''לולי השם''", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "אורן שקדי בלחן חדש ליצירה השבתית ''קה ריבון''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "יואב אהרן מוטי אוזן תמר אביב ומאי גכמן ''מתנה טובה!''", "entities": [{"start": 20, "end": 28, "label": "SINGER"}, {"start": 10, "end": 19, "label": "SINGER"}, {"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "אמיתי פורת בשיר חדש ''בשורה הראשונה''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "ירחמיאל דגן חוזר באלבום חדש ''קידוש השם''", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "עמית בן בביצוע לייב ''כי קל מלך - אלול ניגון''", "entities": [{"start": 0, "end": 7, "label": "SINGER"}]}
+{"text": "און תגר וניתאי קליין ''תבנה חומות ירושלים''", "entities": [{"start": 0, "end": 7, "label": "SINGER"}]}
+{"text": "בר נסים בסינגל השני של פרויקט 'מעומקא דליבא' ''רבות מחשבות''", "entities": [{"start": 0, "end": 7, "label": "SINGER"}]}
+{"text": "ישראל שכטר עם הלהיט ''אידן אין אמריקע''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "פולג זלינגר ושרגא שלי בדואט חדש ''עיני תמיד''", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "יוסל'ה קרישבסקי חוזר בסינגל חדש ''לא לפחד כלל''", "entities": [{"start": 0, "end": 15, "label": "SINGER"}]}
+{"text": "נתן שוורצברג בסינגל חדש לע''נ חברו ''מתגעגעים כל הזמן''", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "שימי דיאי בלסופסקי מגיש סינגל ''אתהלך''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "יובל שחר באלבום עשירי - ''לב חדש''", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "גיל לי מונטיפיורי מבצע את הלחן של אביו ''אודה השם''", "entities": [{"start": 0, "end": 17, "label": "SINGER"}]}
+{"text": "גדעון זיתון מכניס לרחבה ומקפיץ עם ''חתונה לייב #2''", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "חיים פיסגוס בשיר נפלא בשם 'צפת' מהאלבום שבת'דיג", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "מנשה בדור מבצע בלייב את היצירה המוכרת ''נאך איין שבת''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "שלמה קרלין מחדש את שירו ''תכלית 2.0''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "סעדיה מלכה בשיר געגועים מרטיט ''יש בידינו''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "ליפא אלפנדרי באלבום חדש ומושקע ''יחיד במלוכה''", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "ישי שין לא עוצר ומגיש סינגל מושקע וחדש ''חלומות''", "entities": [{"start": 0, "end": 7, "label": "SINGER"}]}
+{"text": "אהרי ברוין נתי ארגאו סטיב פלגי במסיבת אולפן סוערת", "entities": [{"start": 0, "end": 10, "label": "SINGER"}, {"start": 11, "end": 20, "label": "SINGER"}, {"start": 21, "end": 30, "label": "SINGER"}]}
+{"text": "ארי רייך בסינגל חדש לפורים ''א עיניים איד''", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "עילי חדד מגיש משירי חג הפורים", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "שאול אייזיקס בסינגל לפורים - חייב איניש לבסומי", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "רובי אהרוני במחרוזת פורים מקפיצה", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "אלי אטיאס לכבוד פורים במחרוזת קצבית מקפיצה", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "רווה בוחנה, בניהו אפרתי, אור ארז ''פורים כפורים בקאריביים''", "entities": [{"start": 12, "end": 23, "label": "SINGER"}, {"start": 25, "end": 32, "label": "SINGER"}, {"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "יואל דיין מארחת יקיר סורוג'ון וה'פעסטער רבי' במחרוזת פורים סוערת", "entities": [{"start": 16, "end": 29, "label": "SINGER"}, {"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "בנצי מויאל בסינגל חדש ''מאמע קוק'' (אמא תראי)", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "הערשי לנגסאם מארח את אברומי הולצר ו'שירה' - ''א-ברידערס חתונה''", "entities": [{"start": 21, "end": 33, "label": "SINGER"}]}
+{"text": "שון טרוסמן שר ''ותוסף אסתר'' בלחן קרלין", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "ארי דותן בסינגל חדש ''טאטע''", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "עדיאל ברון בשיר חדש לפורים ''ליהודים היתה''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "הרי ריבי מפתיע שוב ''רוצה להיות צדיק''", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "לביא ולץ ב''סינגל'' חדש לקראת פורים", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "ויקטור רטה בסינגל חדש לפורים ''עדי עדי''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "להקת קורנבלו מציגים ר' נתן אביעד במחרוזת ריקודים לכבוד פורים אין די גיסטע", "entities": [{"start": 23, "end": 32, "label": "SINGER"}]}
+{"text": "רון צונדק בביצוע מרגש ''מי יודע''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "אחיה שטרית ויוסי געווירץ מגישים מחרוזת פורים תשפ''ג", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "ישעיהו בונדרצ'וק במחרוזת להיטי פורים", "entities": [{"start": 0, "end": 16, "label": "SINGER"}]}
+{"text": "עמית סגל בסינגל פורימי ''א פריילעכן פורים''", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "בצלאל בלקין מגיש ''איך בין א איד'' מיינלידל #1", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "אור חזקיה, שקד עידאן וגבעול צונדק בסינגל פורימי ''לך אל המלך''", "entities": [{"start": 11, "end": 20, "label": "SINGER"}, {"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "תומר חתוכה במחרוזת שירי תורה לכבוד ז' אדר הילולת משה רבנו", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "אהרן גפני עם אביהו מדינה ומירון מלכה מחדשים את להיט העבר של הרב אלימלך בידרמן", "entities": [{"start": 13, "end": 24, "label": "SINGER"}, {"start": 0, "end": 9, "label": "SINGER"}, {"start": 64, "end": 77, "label": "SINGER"}]}
+{"text": "ארן שוסטר מארחת אברימי גולדשטיין ומקהלת מזמרים במחרוזת פאנק לייב", "entities": [{"start": 16, "end": 32, "label": "SINGER"}, {"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "הרב אבירם דירנפלד ותלמידיו בסינגל ''משנכנס אדר''", "entities": [{"start": 4, "end": 17, "label": "SINGER"}]}
+{"text": "יוסף מסגדיאן מגיש מחרוזת להיטי פורים קצבית וסוחפת.", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "אלירן אורדן חוזר שוב עם ''שמחת החיים 11''! - דוגמה", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "אלחנן עמיר בסינגל לפורים ''ומרדכי לא יכרע ולא ישתחוה''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "נורית גלרון מנחם אליש ואבנר דניאל ריגשו ''נפשי בשאלתי''", "entities": [{"start": 0, "end": 11, "label": "SINGER"}, {"start": 12, "end": 21, "label": "SINGER"}]}
+{"text": "מידן מתנה מקפיץ בשיר לכבוד פורים ''נִיֶע זשוּרִיצִי כְלאָפְּצִי''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "אלעאי שמאי, ודים קרינסקי, יששכר מרשה בירסת רמיקס ''לבוא אל המלך''", "entities": [{"start": 26, "end": 36, "label": "SINGER"}, {"start": 12, "end": 24, "label": "SINGER"}, {"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "יאיר פיצ'חדזה מגיש מחרוזת פורים עד דלא ידע", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "עירא כחלון משחרר סינגל נוסף בשם ''חיברתי מנגינות''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "אברימי קירשנבוים בסינגל מקפיץ לקראת ''פורים''", "entities": [{"start": 0, "end": 16, "label": "SINGER"}]}
+{"text": "ניסים וכניש והלל שפילמן מקפיצים בשיר ''ואני אבטח בך''", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "רבקה רוזנברג חוזר (16 שנים מהאלבום האחרון) בשיר חדש ''ושננתם''", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "שרה שטרן משיק סינגל חדש ''אל גליל''", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "אהרן ויצברגר משחרר שיר נוסף מתוך האלבום ''ממזרח שמש''", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "אליהו קוגן פותח את אלבומו השני ''בלי להודיע''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "יוסי ממן מוציא סינגל חדש בשם ''יהודי אף פעם לא לבד''", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "שמוליק רוזובסקי משחרר ''הושענות לפורים''", "entities": [{"start": 0, "end": 15, "label": "SINGER"}]}
+{"text": "ברי נחמיה בבייב משחרר לכבוד חג הפורים מחרוזת פורימית בסגנון חסידי", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "ליאם בוחבוט מארח את עם ישראל ל ''יום שכולו שבת''", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "אלחנן שאו מרגש עם ביצוע מיוחד לשירו של יהודית רביץ ''אייכה''", "entities": [{"start": 39, "end": 50, "label": "SINGER"}, {"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "תום טובין במחרוזת מרגשת של שירי תפילה על הילדים ''לעכטיגע קינדער''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "אלמוג דערי ודי ג'יי אלירן דרעי מכניסים אתכם לאווירת חודש אדר", "entities": [{"start": 20, "end": 30, "label": "SINGER"}, {"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "נוה רוזנצוויג ואגם רוזנברג ב25 דקות של מחרוזת ריקודים לייב-דאנס", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "מנדל גולדמן מתכונן לפורים ''מי שעשה ניסים והכרזת חודש אדר''", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "מאור בסין ומשה שטעקל לקראת פורים והשנה ''שיר הביטחון''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "יואב סגל ודי ג'יי פאברעגן מגישים סינגל חדש ''פורים כל השנה''", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "מקהלת 'אהרן ברק' מגישה שיר חדש ומרגש בשם ''משמחה ליגון''", "entities": [{"start": 7, "end": 15, "label": "SINGER"}]}
+{"text": "ר' הערשל ובנו יודי רוזענבערג, יהודה קנדל, בארי קפואנו, מוישי קרויס, יולי גרטי, דוד מנחם", "entities": [{"start": 79, "end": 87, "label": "SINGER"}, {"start": 30, "end": 40, "label": "SINGER"}, {"start": 42, "end": 53, "label": "SINGER"}, {"start": 68, "end": 77, "label": "SINGER"}]}
+{"text": "הנרי גרוסברג מארח את י'ה ריבון לדואט חדש ''קרן אורה''", "entities": [{"start": 0, "end": 12, "label": "SINGER"}, {"start": 21, "end": 30, "label": "SINGER"}]}
+{"text": "כרמי אוזן בסינגל חדש ''מזמור לתודה''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "אביחי גילה ומנחם ליפשיץ - מחרוזת דאנס 2023", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "ריי ספרין משחרר סינגל חדש וממכר ''אשרי העם''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "ישי שיפרין בשיר מטלטל ''ארץ אל תכסי דמם''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "יעקב עממי ומרק מירב בסינגל חדש ''לא לבד''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "חנן נאורי בסינגל חדש ומקפיץ ''אני מאמין''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "יצחק ויינגרטן בסינגל מרגש וסוחף ''הרוצה בתשובה''", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "יוסף זכאי אדי בוסקילה מעוז סורוצקי יונה סולומון רן שולמן מוטי וויזל מקבלים שבת בצפת!", "entities": [{"start": 57, "end": 67, "label": "SINGER"}, {"start": 48, "end": 56, "label": "SINGER"}, {"start": 35, "end": 47, "label": "SINGER"}, {"start": 22, "end": 34, "label": "SINGER"}, {"start": 10, "end": 21, "label": "SINGER"}, {"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "אליאב צחי בסינגל קצבי חדש ''עושים שמח''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "עירד אליאס בביצוע לשיר 'האפ קוזאק' של חבד", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "אליעזר בוצר, ר' איטן עלמו ובנו יודי שרים ''והשיב''", "entities": [{"start": 0, "end": 11, "label": "SINGER"}, {"start": 16, "end": 25, "label": "SINGER"}]}
+{"text": "יועד ממן מרגש בסינגל חדש ''מאמעלע''", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "יוחאי לוין במחרוזת שירי שמעון זיסמן", "entities": [{"start": 24, "end": 35, "label": "SINGER"}, {"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "אביעד פרוינד בשיר חדש שכתב והלחין ''מעצמי באתי''", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "נתיב יאנובסקי משיק סינגל שלישי ''פרק שירה''", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "שלומי וורצברגר מגיש סינגל חדש בשם ''לך לך''", "entities": [{"start": 0, "end": 14, "label": "SINGER"}]}
+{"text": "אילון גולומב בסינגל חדש ''וקם'", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "ליעד פרץ ויקיר יאיר בסינגל חדש ''העבר עיני''", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "מורן ברקן בסינגל חדש ''בקרוב ממש''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "הרב גרשי אורי ואלי גרשטנר בדואט ''כי השם''", "entities": [{"start": 4, "end": 13, "label": "SINGER"}]}
+{"text": "עמית ליסטוונד ודובי מייזלעס בסינגל ''אידן אין אמעריקע''", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "מורד זיו משחרר כעת סינגל חורפי ומרגש ''חיזוקים''", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "אביאל ביללוב ומשפחתו בח''י דקות של מחרוזת זמירות שבת קודש", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "רעי יפרח משחרר סינגל ''מזל טוב''", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "מיקלוש גפני ואלימלך שבת בדואט חדש ''יגעתי ולא מצאתי''", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "הגר לופט ויהושע חביב וחסידימלע'ך במחרוזת ''ירא שמים''", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "דוד ראזנפעלד משחרר סינגל נוסף אישי ונוגע ''עולם גדול''", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "צור הוכמן & אביאל פריידקין בדואט מרענן ''אבא אוהב''", "entities": [{"start": 12, "end": 26, "label": "SINGER"}, {"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "שימי פריד בלחן חדש לזמר ''אשת חיל''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "פייר פינצ'יק כתב, הלחין ושר ''אין סוף''", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "אילי מנצור מוציא אלבום שניה ''במסתרים'' - דוגמה", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "זאב חדד מגיש סינגל חדש בשם ''אלוף''", "entities": [{"start": 0, "end": 7, "label": "SINGER"}]}
+{"text": "פנחס בטיטו ועירא קנתן בסינגל חדש ''קל מסתתר''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "אלירן קקון בסינגל חדש ומרגש לכבוד יו''ד שבט ''מתגברים''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "מקהלת נוער והילדים בשירת המונים בקולעוילם ''ממלכת כהנים''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "מבשר אמארה בשיר לרגל המצב ''אל תירא''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "דב לוינגר בסינגל חדש ''נגיע אליך''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "אביעזר נחמיה וחושן רכבי בגרסת הרמיקס ''ישמח חתני''", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "חיים מרדכי פייערווערקער ודוד שירו במחרוזת שירי ר' עירן רובינשטיין", "entities": [{"start": 50, "end": 65, "label": "SINGER"}]}
+{"text": "דוד שטרית משחרר סינגל חדש לקראת האלבום ''אבל באמת''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "שגיא דויטש מפתיע עם סינגל סוחף ''הכל טוב אחי''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "גדי סטון בניגון נוסף מניגוני הינוקא ''ניגון חזק ואמץ''", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "אברהם אהרן אזולאי וזאבי שוורץ בשיר חדש מבית תודה לך ה' ''ישמח משה''", "entities": [{"start": 0, "end": 17, "label": "SINGER"}]}
+{"text": "יונתן חן מארח את יונתן צ_רצ_י, הערשי רוטענברג ולי אביקסיס לריקוד סוחף ''העושה גדולות''", "entities": [{"start": 0, "end": 8, "label": "SINGER"}, {"start": 31, "end": 45, "label": "SINGER"}, {"start": 17, "end": 29, "label": "SINGER"}]}
+{"text": "יגאל מלכה בלחן מרגש על ''מזמור לתודה''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "קאי לנצמן בקאבר ללהיט ''השיבנו' של כון בוכבינדר", "entities": [{"start": 35, "end": 47, "label": "SINGER"}, {"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "מאטי אטיאס מגיש סינגל חדש ''אור בעיני''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "להקת 'אורי בן ציון' בסינגל חדש 'בן עמרם'", "entities": [{"start": 6, "end": 18, "label": "SINGER"}]}
+{"text": "ערן טוריאנסקי ואיצי ברי בסינגל חדש הרים יכולים לזוז", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "שמואל גנזל והילדים בסינגל חדש בשובך לציון ברחמים", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "ראובן גרימברג מגיש שיר חדש - ''ארץ ישראל''", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "שניאור דוקן בסינגל חדש ''טרערן אויף פאפיר - דמעות על נייר''", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "מנדי ג'י וילד הפלא חיים נחמן ''מתי''", "entities": [{"start": 19, "end": 28, "label": "SINGER"}, {"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "שעיה אליוביץ חוזר בסינגל חדש ''ומשפע''", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "שרגא לוי ויחזקאל חייט & תזמורת 'בלו מלודי' במחרוזת ריקודים", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "ראובן ורטהיימר בביצוע לייב לשיר ''כף זכות''", "entities": [{"start": 0, "end": 14, "label": "SINGER"}]}
+{"text": "ליאל ספנסר בסינגל עם מסר חד ''אף אחד לא יעזור''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "אביחי לוי חוגג את יום הולדתו ומשחרר סינגל חדש ''תכלת ולבן''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "עמוס פיינגולד בסינגל מיוחד לכבוד השמחה במוסדות 'תפארת ישראל' ''מודים''", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "עילאי ירקוני ודי ג'י גידי דבוש ברמיקס מקפיץ ''טאטאל''ע''", "entities": [{"start": 21, "end": 30, "label": "SINGER"}, {"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "אביב גבאי ושילו וורטהיימר בביצוע משותף ''לכה דודי''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "משה רוזנבאום בסינגל חדש ומרגש ''לעולם לא תעזבני''", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "אפיק מנוח לרגל ההילולא עם הניגון של האדמוה''ז ''קלי אתה''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "ניסן שלזינגר ולהקתו, בביצוע מרטיט במופע 'צמאה' לניגון ''ארבע בבות''", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "ויקטור דלנוקי לא מפסיק להפתיע ומגיש את ''הכל כאן''", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "ברקת בראונשטיין מחדש את קרליבך ''מזמור שיר''", "entities": [{"start": 0, "end": 15, "label": "SINGER"}]}
+{"text": "הרב ישורון ברורמן בניגון לר' דב מויסייב מקרמנצ'וג", "entities": [{"start": 4, "end": 17, "label": "SINGER"}]}
+{"text": "מאיר אטיאס בסינגל חדש ''מזמור לתודה''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "שי דוידזון שר ''אתה השם''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "עדיאל דיין יוצא בסינגל אלקטרוני חדש ומסקרן ''2000''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "ר' דוד טליסמן כהנא מגיש אלבום מופת ''א גאלדענע ליד''", "entities": [{"start": 3, "end": 13, "label": "SINGER"}]}
+{"text": "ר' רחל קיציס בלחן חדש ''טהרינו''", "entities": [{"start": 3, "end": 12, "label": "SINGER"}]}
+{"text": "אשר בן דוד בסינגל חדש מתוך אלבום הבכורה ''חייב לשרוד''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "צמד רעים על הגיטרה מבצע מחרוזת מניגוני קרליבך", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "הארי רייכנבאך ומשה דדון בהלחמה חדשה ''ממקומך''", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "קובי ברי, מיקי מוקטון, צהל לינר, וחסידימלעך ''כולם אהובים'' מ''החתונה של שמחל'ה''", "entities": [{"start": 10, "end": 21, "label": "SINGER"}, {"start": 0, "end": 8, "label": "SINGER"}, {"start": 23, "end": 31, "label": "SINGER"}]}
+{"text": "תמיר פרץ בסינגל חדש ''אתפאר''", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "כפיר אדוט, ויצמן יוספי ונועם ויצמן מרגשים ''כד יתבון''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}, {"start": 11, "end": 22, "label": "SINGER"}]}
+{"text": "עופר יחזקיא ועמרם נעים בסינגל חדש ''הילדים הם משימתנו''", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "איליה וולס משחרר ממתק נוסף & אבי משה ''הלב והמעיין''", "entities": [{"start": 29, "end": 36, "label": "SINGER"}, {"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "נתנאל ששון בקאבר ליצירה של טום ניסים ''אנא בכח''", "entities": [{"start": 27, "end": 36, "label": "SINGER"}]}
+{"text": "איציק שרקי מוציא סינגל שני ''הנה זה בא''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "גד קאהן & ת''ת חפץ חיים בקולולם חדש ''טוב להודות''", "entities": [{"start": 0, "end": 7, "label": "SINGER"}]}
+{"text": "עובד ברודי בסינגל חדש ''להיות שלם'' (אפשרי להיות שלם גם בלי להיות מושלם)", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "צבי גרינהיים ופינקי ובר בסינגל חדש ''אנא''", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "ליאן שוקר בביצוע שקט ראשון בשיר מיוחד לשנת ''הקהל''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "אורון חימוביץ מגיש 'הסוד הגדול של חסידות גור'", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "ירין ספיר סחף את הציבור עם 'ואני בחסדך' של קרליבך", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "ארנון ליברזון בביצוע משלו לניגון ברדיטשוב המרטיט", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "שי פיודורוב בשיר מרגש ''רפואה''", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "שמעון אלקבץ & יהודה רוזן בסינגל חדש ''אנא''", "entities": [{"start": 0, "end": 11, "label": "SINGER"}, {"start": 14, "end": 24, "label": "SINGER"}]}
+{"text": "שלום וויס סוחף במחרוזת שנייה בסדרה מחרוזת משירי הלל זכאי", "entities": [{"start": 0, "end": 9, "label": "SINGER"}, {"start": 48, "end": 56, "label": "SINGER"}]}
+{"text": "משה לאופר בסינגל בכורה ''ים של דמעות''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "יובל עובדיה מפתיע שוב ''זה לא בידים שלך''", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "חיים בלומפלד בסינגל מרגש לקראת עשרה בטבת ''ולירושלים עירך''", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "יוסי בלומבערג במחרוזת שרים ל''אמא''", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "גיא אסף, לוי סבן ואלחנן רון ביצירה המרטיטה ''מתי יתוודע''", "entities": [{"start": 0, "end": 7, "label": "SINGER"}, {"start": 9, "end": 16, "label": "SINGER"}]}
+{"text": "החזן שניר חבה מבצע את היצירה הנודעת רזא דשבת", "entities": [{"start": 5, "end": 13, "label": "SINGER"}]}
+{"text": "עיליי גרינבוים מנגן ומתחזן בליווי יותם משה ''רזא דשבת''", "entities": [{"start": 34, "end": 42, "label": "SINGER"}, {"start": 0, "end": 14, "label": "SINGER"}]}
+{"text": "יום טוב ערליך בסינגל חדש ''הינאי פזרקאריל''", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "שמעיה מנחם בסינגל חדש ומרגש ''זכיתי''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "נירן אלחנתי בסינגל שלישי חדש ''מחשבות של חורף''", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "חזקי מנדלוביץ בסינגל חדש ''הנה זה בא''", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "אושרי ישעיהו מרגש בביצוע מלטף ''טיהר'' לכבוד בר המצווה שלו", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "שלומי וילמן & מנחם מנבי'ץ במחרוזת ריקודים", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "ארנון בס בביצוע לייב את שירו ''שנשתוקק''", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "יחיאל זוהר ומנדי וור'ץ בסינגל חדש ''לא אירא''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "גבריאל רייכמן חוזרבסינגל חדש ''אש תמיד''", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "אברהם מרדכי שוורץ ושעיה חיטמן בסינגל חדש ''כי יעמוד''", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "יהל דדוש במחרוזת חדשה - 'מחרוזת חתונה'", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "יהודאי בורמן ודוד פליישמאן ב''שיר החופה''", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "אהוד איסאקוב הלחין ושר את ''כי הם חיינו''", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "נחום זילברברג מקהלת שבח ומלכות בסינגל חדש ''שא שטיל''", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "טוהר רוטלוי סחף את האלפים ''אחת שאלתי''", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "להקת הילדים ''רונן טואיטו'' בביצוע מרגש ''שירים של השטעטעל''", "entities": [{"start": 14, "end": 25, "label": "SINGER"}]}
+{"text": "התפילה שיצאה מהלב של עזריה קלצקו ''סוד הגאולה''", "entities": [{"start": 21, "end": 32, "label": "SINGER"}]}
+{"text": "משה קרויס מקפיץ את החורף ''מחרוזת גלביה''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "רביד אללוף משחרר סינגל חדש וחמישי ''אתה טוב''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "אריה פוקס - Light Up the Night", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "אמרי גבאי בקטע מרגש לחנוכה ''ברענט לעכטעלעך''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "החזן ינאי גלעדי מגיש שילוב מנגינת חנוכה בקבלת שבת", "entities": [{"start": 5, "end": 15, "label": "SINGER"}]}
+{"text": "ג'ואל חיימוביץ, שמעון דוב דאווידאוויטש ודביר ששון שרים ''יומם''", "entities": [{"start": 0, "end": 14, "label": "SINGER"}]}
+{"text": "אריה מירילשוילי, יששכר גוטטמאן & ר' ירמי' דמן - נאסטלגיה (תקציר האלבום)", "entities": [{"start": 0, "end": 15, "label": "SINGER"}]}
+{"text": "ארתור רוז'נסקי מגיש לחן חדש לפיוט החנוכה ''מעוז צור''", "entities": [{"start": 0, "end": 14, "label": "SINGER"}]}
+{"text": "אביבה אבידן מגיש מעוז צור בעיבוד פילהרמוני", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "אבישי לוי, יעקב קובלן ןמשה קליין, אופיר אלבז ותזמורתו ''דאנקען''", "entities": [{"start": 34, "end": 44, "label": "SINGER"}, {"start": 11, "end": 21, "label": "SINGER"}, {"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "איציק דדיה מחדש ''הנרות הללו''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "ארגמן רייכר מרגש ליצירה ''הודו להשם'' מתוך האלבום 'שבתדיג'", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "איתן פרידמן בסינגל חדש של הודיה והלל ''בואו שעריו''", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "דקל גניש וחברים בסינגל חדש ''מעוז צור''", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "היצירה העתיקה של ר' צחוק תינוקי ''מזמור שיר חנכת''", "entities": [{"start": 20, "end": 31, "label": "SINGER"}]}
+{"text": "הרב אלתר סרגוסטי ותלמידיו בסינגל חדש ''מעוז צור''", "entities": [{"start": 4, "end": 16, "label": "SINGER"}]}
+{"text": "שייע ברקו בסיפור מוזיקלי שני חנוכה בעמק פורג'", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "אביב סימון מגיש ''מחרוזת שירי צח גל''", "entities": [{"start": 30, "end": 35, "label": "SINGER"}, {"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "צחי-יצחק גרינברג, אסא השאש ולהקתו במחרוזת שירי חנוכה", "entities": [{"start": 18, "end": 26, "label": "SINGER"}, {"start": 0, "end": 16, "label": "SINGER"}]}
+{"text": "ישראל כץ ואיתיאל אסטמקר בביצוע סוחף לחנוכה ''יוונים נקבצו''", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "רן אושרי בסיפור מרגש ''כוחה הנצחי של החנוכייה'' (אידיש)", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "ישראל צוברי ויונה חכמיגרי בביצוע לחנוכה ''הנרות הללו''", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "אודי ובנו אופק גליק בשיר הודאה לכבוד חנוכה ''מזמור לתודה''", "entities": [{"start": 10, "end": 19, "label": "SINGER"}]}
+{"text": "דוד ורדיגר & מוישי ריינר - א הויכער חנוכה", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "גיל יוליש בסינגל חדש לחנוכה ''המסר של הנרות''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "ידידיה טהר, מטע הימלבלאו וחננאל טייכמן & נחל לייבוביץ בקאבר ללהיט ממלכת כהנים", "entities": [{"start": 41, "end": 53, "label": "SINGER"}, {"start": 12, "end": 24, "label": "SINGER"}, {"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "נורי ברלין, נתן אוחיון, ושרה קרליבך ועילם מלכה במחרוזת ''אבות ובנים''", "entities": [{"start": 12, "end": 22, "label": "SINGER"}, {"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "תומר מלכא בניצוחו של מנור פינסקי ב''מחרוזת חנוכה''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}, {"start": 21, "end": 32, "label": "SINGER"}]}
+{"text": "גדי שכטר בסינגל חדש ''מיין טייערע לעכטעלע''", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "אבי פודלינסקי שר ''מעוז צור'' של ברסלב", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "ליאור שמעון ויענקי גרין בשיר חדש לחנוכה ''ניסים''", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "'דיויד איטח בסינגל חדש ''ר' אליאב יוסף'' מבית 'תודה לך השם'", "entities": [{"start": 28, "end": 38, "label": "SINGER"}, {"start": 1, "end": 11, "label": "SINGER"}]}
+{"text": "זכריה ישר בסינגל מיוחד לחג החנוכה ''הנרות הללו''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "אליאב שבו, דביר כהן והתזמורת במחרוזת חנוכה בלייב", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "און רופא ממשיך עם סינגל חדש במיוחד לחורף ''סופות''", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "מאור מויאל שוואקי בסינגל חדש ''תוותר - תרוויח יותר''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "ירון רוטנברג בסינגל הביכורים אותו כתב והלחין ''שלח גאולה''", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "שוע פריד מוציאים כעת סינגל חדש בשם ''פתחו לי''", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "יואלי ברוין בסינגל בכורה מרגש לחנוכה ללחן שלו ''אור''", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "איליי סגל ודילן מיכלשווילי בחידוש מרגש ''מעוז צור''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "יצחק גינסבערג, הרשי סגל , עילם גלאון, לביא לבקוב & גיורא קפלן ב''מזמור שיר - מחרוזת חנוכה''", "entities": [{"start": 51, "end": 61, "label": "SINGER"}, {"start": 0, "end": 13, "label": "SINGER"}, {"start": 38, "end": 48, "label": "SINGER"}, {"start": 26, "end": 36, "label": "SINGER"}, {"start": 15, "end": 23, "label": "SINGER"}]}
+{"text": "ברוך אקשטיין במחרוזת שירי ברסלב לחג החנוכה", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "אביעד דפנה בשיר ''תודה'' אחרי לידת התאומים", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "שדה מנצור & יהב גרין במחרוזת חג הגאולה לכ' י''ט כסליו", "entities": [{"start": 0, "end": 9, "label": "SINGER"}, {"start": 12, "end": 20, "label": "SINGER"}]}
+{"text": "עוזי חלף מחדש את הניגון העתיק ''להודות ולהלל''", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "ישראל אדרי מגיש סינגל ''אהבת עולם אהבתנו''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "עוזי ליפקין ושמשי קראוש בלהיט חדש ומקפיץ ''שיטה הקדושה''", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "שמולי שניידר מבצע ''המצוות הקטנות שלנו''", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "עמיר קהרמני וגיורא לווטה בגרסת רמיקס לשיר ''זה הזמן''", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "סתיו רבינוביץ מגיש ''מחרוזת חנוכה''", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "הרב אייל עלימה מחדש את ''פליאה'' לרגל י''ט כסלו", "entities": [{"start": 4, "end": 14, "label": "SINGER"}]}
+{"text": "זיו נחום מחרוזת ''צמאה'' בלייב", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "דני עמרם באלבום שלישי ''אני חי''", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "רון סרויה משחרר שיר חדש לרגל הולדת בתו ''טוהר''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "עומר גלילי מגיש סינל חדש רבי תגיד לי (Rebbe Tell Me) מבית 'תודה לך השם' TYH", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "ר' שלו מלכי בסינגל ''אני לא לבד'' - ''איך בין נישט אליין''", "entities": [{"start": 3, "end": 11, "label": "SINGER"}]}
+{"text": "יאיר עיני פותח את החורף עם שיר אנרגטי מקפיץ וסוחף ''הולך להיות שמח''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "ירון רז מגיש את ניגוני הינוקא ''ניגון קווה אל השם''", "entities": [{"start": 0, "end": 7, "label": "SINGER"}]}
+{"text": "ליאם לוין מגיש לקראת פרשת וישב את שירו המרגש מלא מסר ''עוד יוסף חי'' מאלבומו ''קרבן''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "א. פריד בסינגל חדש ''אני לומד תורה''", "entities": [{"start": 0, "end": 7, "label": "SINGER"}]}
+{"text": "אלדן איתן בסינגל חדש ללחן גנוז של קרליבך ''מה ידידות''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "הראל טל, שמילי לייפער, שעי' גרוס ויורם גלוסקינוס ''די תפארת שלמה ניגון''", "entities": [{"start": 0, "end": 7, "label": "SINGER"}, {"start": 9, "end": 21, "label": "SINGER"}]}
+{"text": "איתי פישר ו'עקב' בשיר חופות חדש ''בואי כלה''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "בנימין קטן שר ''פדה בשלום'' - ברסלב וחב''ד נפגשים מתוך פרויקט 'צמאה", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "עידן אבירם, סער דוד ודן שני במחרוזת שירי ''שלו זינגר''", "entities": [{"start": 12, "end": 19, "label": "SINGER"}, {"start": 43, "end": 52, "label": "SINGER"}, {"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "שלמה שוורץ שר ''פדה בשלום'' - ברסלב וחב''ד נפגשים מתוך פרויקט 'צמאה'", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "צפריר רזניק וילד הפלא זאבי ורצברגר מבצעים בלייב סינגל חדש ''אחותנו''", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "טובי וובה בסינגל חדש ''תדבר איתו", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "יידל וורדיגר & גדי טייטלמן - קל מלא רחמים", "entities": [{"start": 15, "end": 26, "label": "SINGER"}, {"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "אדי בר ויואל דיקמן בביצוע 'קולולם' מדהים לשיר ''גרש את העצבות''", "entities": [{"start": 0, "end": 6, "label": "SINGER"}]}
+{"text": "אסי בדין בסינגל חדש וייחודי ''מקום לחלום''", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "יעקב ענבר ומקהלת הילדים החדשה 'זינגערליך' בסינגל חדש ''הושיענו''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "יהודה שקד בקאבר ללהיט של יואל שוורץ ''ויהיו זרעי''", "entities": [{"start": 25, "end": 35, "label": "SINGER"}]}
+{"text": "אליהו מישקובסקי בסינגל בכורה מקפיץ ''קול ששון''", "entities": [{"start": 0, "end": 15, "label": "SINGER"}]}
+{"text": "מקהלת פריילאך בסינגל ''עין טובה''", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "ר' טל סקלי בלחן חדש ''מי יתן מציון'' לכבוד החתונה בסערט ויז'ניץ", "entities": [{"start": 3, "end": 10, "label": "SINGER"}]}
+{"text": "שריה שמול יוצא בסינגל העשירי ''רגע לפני לילה''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "שלמה הלשטוק & נחלא ויואל זיו - יפה ותמה", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "שלמה ליפמן עם סינגל חדש שיכניס אתכם לאווירת השבת ''זהר השבת''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "אלכסנדר שמחון בסינגל חמישי חדש ''עוצו עצה''", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "דוד דקס החתן הצעיר מודה להוריו בשיר חדש ''הרחמן''", "entities": [{"start": 0, "end": 7, "label": "SINGER"}]}
+{"text": "רפאל יעקב הלחין ''אשרי עין'' לרגל החתונה הערב בחצה''ק באיאן", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "יגאל אילני בסינגל חדש ''עבודת השמחה''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "ברני אייזנמן בדרך לאלבום בכורה בסינגל חדש ''אין בי קול''", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "רחמים רבינוביץ עם בנו אלעזר (לוזי) בסינגל חדש ''ויתן לך''", "entities": [{"start": 0, "end": 14, "label": "SINGER"}]}
+{"text": "בניהו גאון בסינגל באווירה חורפית מרענן ''השיר שלי''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "און מור ביצירה חדשה ''מעלת ריבוי הלימוד''", "entities": [{"start": 0, "end": 7, "label": "SINGER"}]}
+{"text": "3,000 בחורי הישיבות ב'קולולם' בניצוחו של עוזיאל סבח ''ולבקר בהיכלו''", "entities": [{"start": 41, "end": 51, "label": "SINGER"}]}
+{"text": "ארבל אבזוב בסינגל חדש ''לא לבד''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "מוטי בוקסבוים בשיר קצבי מלא אמונה ''תודה על החיים''", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "יוגב בלוך בקאבר נוסטלגי לייב ''קדש את שמך''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "פרוייקט ''קפיצת הדרך'' חוגג שנה ומוציא ''יש לנו יומולדת'' של יריב דרדיק", "entities": [{"start": 61, "end": 71, "label": "SINGER"}]}
+{"text": "עודד בלאי ואליהו משענייה ובנימין יפת ''גם ציפור''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "רם אמסלם מחדש את קרליבך ''בגלל אבות''", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "להקת הילדים 'תומר דר' בשיר ''תפילין''", "entities": [{"start": 13, "end": 20, "label": "SINGER"}]}
+{"text": "אלירן כהנא בקאמבק מפתיע עם בלדת חורף מרגשת ''על האבן''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "צח שפירא, רם אופנהיימר ועמית ליסטונד שרים ''אביסלע משקה'' של ליפא", "entities": [{"start": 0, "end": 8, "label": "SINGER"}, {"start": 10, "end": 22, "label": "SINGER"}]}
+{"text": "רון גליק באלבום חדש בהפקתו של אלעד מאור '''תתחדש''", "entities": [{"start": 0, "end": 8, "label": "SINGER"}, {"start": 30, "end": 39, "label": "SINGER"}]}
+{"text": "עדן ממוקה בסינגל חדש פרי יצירתו ''מזמור לאסף''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "מקהלת נופי הגליל בסינגל חדש ''תצא מזה''", "entities": [{"start": 0, "end": 16, "label": "SINGER"}]}
+{"text": "ירוחם אברהמסון, נבו כחילה, מיכאל נועם ויגל רחמילביץ ב'שיר הסטנדר'", "entities": [{"start": 16, "end": 25, "label": "SINGER"}, {"start": 27, "end": 37, "label": "SINGER"}, {"start": 0, "end": 14, "label": "SINGER"}]}
+{"text": "מלכיאל אוחנה ומימון אוזנה במחרוזות שבת סוחפות ''א שאבעס טיש''", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "תומר סגל משחרר סינגל חופות חדש ''תפילה לחופה''", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "הלל אייזנמן בסינגל חדש ''אתה שם''", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "יצחק מזרחי ג'יי ושרגא נעים במחרוזת 'הדבר הבא' Next Level", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "ישראל רון בסינגל חדש ''חצות''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "הרב מורן איסקוב מגיש את הסינגל השמח הראשון מתוך אלבום געגועים 7", "entities": [{"start": 4, "end": 15, "label": "SINGER"}]}
+{"text": "עמיחי אברה מפציע בסינגל בכורה ''דיבור עוקר סלעים''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "שלומי ברקן בסינגל ביכורים ''יברכך''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "להקת 'נהוראי חממי' בסינגל חדש ''לא נרפה ממך''", "entities": [{"start": 6, "end": 17, "label": "SINGER"}]}
+{"text": "מנשה אברמוביץ והילד אלי וקסלר בשחזור היסטורי לשיר ''אליהו הנביא''", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "ישורון מלול בסינגל תפילה חדש ''שמעה תפילתי''", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "ישיבת רמת גן בסינגל חדש ''אני מאמין''", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "סער מרדכי משיק את אלבומו השני 'יוניטי' האזינו לשיר אחדות", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "האחים אזולאי מקדיש לאחיו חתן בר המצווה ''תפילין''", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "בצלאל מור בגראמען מרגשים בהכנסת ס''ת לע''נ הב' אליעזר בריל ז''ל", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "אוהד לדר ורפי פינקס בן סעדון שרים קרליבך ''ניגון זושא''", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "יחזקאל קלמן והילדים בסינגל חדש ''אלו דברים''", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "בנציון גל בסינגל הביכורים ''עומדים כמלאכים''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "אוריאל ישראלוף משיק את אלבומו השני 'יוניטי' UNITY‏ - אחדות", "entities": [{"start": 0, "end": 14, "label": "SINGER"}]}
+{"text": "עמי מטאטוב בשיר החמישי ''אהיים קיין ירושלים'' (הביתה לירושלים)", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "שחר רוקח בסינגל חדש ומרגש ''רגעי חופה''", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "עזרא שניידר וילד הפלא אבידן סינדורי ריגשו בחופה ''שערי שמים''", "entities": [{"start": 0, "end": 11, "label": "SINGER"}, {"start": 22, "end": 35, "label": "SINGER"}]}
+{"text": "דוד קאופמן נותן 'סיכוי' בסינגל חדש", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "סוקי ברי בסינגל חדש עם מסר עוצמתי ''זכות לעולם''", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "אדם פרץ עם לחן חדש ''שנשמע ונתבשר'' לכ' 6 שנים לר' ג'ון שחק ז''ל", "entities": [{"start": 0, "end": 7, "label": "SINGER"}, {"start": 51, "end": 59, "label": "SINGER"}]}
+{"text": "28 שנים לפטירתו של ר' שמשון ווייט - שידור מיוחד (חוזר) זמרים בוחרים קרליבך", "entities": [{"start": 22, "end": 33, "label": "SINGER"}]}
+{"text": "נתן בראונר בביצוע מבית קרליבך ''ממקומך''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "איתן כהן מחדש את הלהיט של קרליבך ''כאשר דיברת''", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "צבי זילברשטיין מחדש את קרליבך - 'עוד ישמע'", "entities": [{"start": 0, "end": 14, "label": "SINGER"}]}
+{"text": "''הרב איתן ז'וקובסקי בסינגל חדש ''יגדל", "entities": [{"start": 6, "end": 20, "label": "SINGER"}]}
+{"text": "גולן כהן סוחף בסינגל חדש ''עד שלא אמצא מקום''", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "דקל דגני ומיכאל הדר בגרסת רמיקס - ''לנסות''", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "בן ציון שנקר ואלחנן שטיינמץ בדואט - 'אדרבה'", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "שלום חמו ודוד ילין מרגשים 'חופה'", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "יוחנן אלקובי מחדש את שירו של עמיר רייס ''תשמח''", "entities": [{"start": 29, "end": 38, "label": "SINGER"}, {"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "אביגדור רוט ועופר לוי מגישים 'מחרוזת להיטים באנגלית של מב''ד", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "נועה אדרי חוזר אל שכונת ילדותו ׳נחלאות׳ ומפתיע בסגנונו עם שיר חדש '׳אל תחשוב על המחר׳'", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "נועם אלעזר בבלדת תפילה מרגשת ''שערי שמיים''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "בר גרינברג בסינגל בכורה ''ואתה צדיק''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "אראל רבינוביץ ונחמן הלל מרגשים בשיר ''הדלקת הנרות''", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "עדי ברקאי ואדר רזי במחרוזת ''קול ברמה''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "משה סטרוך שר לכבוד רחל אימנו בביצוע מיוחד", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "עמיחי שפיר בסינגל מרגש חדש ''תן יד''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "יוסף טרומפלדור בלהיט חדש ''שיר למעלות''", "entities": [{"start": 0, "end": 14, "label": "SINGER"}]}
+{"text": "ארהל׳ה סאמעט חיים דבש & יענקי דסקל במחרוזת מאמע רחל", "entities": [{"start": 13, "end": 21, "label": "SINGER"}, {"start": 24, "end": 34, "label": "SINGER"}]}
+{"text": "אודי ברוך מוציא לכב' הילולא ה-28 של קרליבך 'יתברך שמך'", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "ניב בביוף על הגיטרה בקאבר למרדכי בלויא ''הלב שלי''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "בראל בנימיני בסינגל חדש לכבוד ההילולא ''אמא רחל''", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "אליעזר גומס מאנגליה שרים ''אדון עולם''", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "להקת 'ניר אנשל' בשיר ''אן א מעסער''", "entities": [{"start": 6, "end": 14, "label": "SINGER"}]}
+{"text": "דוד שמש עם ניגון שלישי מהינוקא ''בדרך אל האור''", "entities": [{"start": 0, "end": 7, "label": "SINGER"}]}
+{"text": "ישעי'ה זאב טאבאק בסינגל חדש כולו תקווה ''קצת ממך''", "entities": [{"start": 0, "end": 16, "label": "SINGER"}]}
+{"text": "ינון סטפנסקי בקאבר לצור וקנין ''לכו למים''", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "טום מרגי מארחים את 'זושא' ''יודע תעלומות''", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "לוי יצחק בסינגל שני חדש ''הנס שלי''", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "רחמים שניידר & מיכאל עובד בסינגל בכורה ''האמנתי''", "entities": [{"start": 15, "end": 25, "label": "SINGER"}, {"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "ברוך רוזנטל ואורי משה ב10 דקות של שירה חסידית", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "ים ברמן בשיר חופות החדש ''בואי כלה''", "entities": [{"start": 0, "end": 7, "label": "SINGER"}]}
+{"text": "אברומי דערמער בסינגל נוסף ''עד מתי'' מתוך אלבומו ''זכות''", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "ראם אלבז בסינגל חדש לרגל הילולת הרב עובדיה זצוקל ''רבנו עובדיה''", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "אשל אלמוגי ושאול רוזן בליווי מקהלת איתמר כחלון בלהיט חדש ''רפואה שלמה''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}, {"start": 35, "end": 46, "label": "SINGER"}]}
+{"text": "מאיר ראזענבערג מציג את סינגל הבכורה שלו ''הודאה''", "entities": [{"start": 0, "end": 14, "label": "SINGER"}]}
+{"text": "מרדכי זיידמן ועוזי שושני בקאבר נוסטלגי ''אדון עולם''", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "יודאלע מנדלסון מגיש סינגל חדש בשם ''צעקה''", "entities": [{"start": 0, "end": 14, "label": "SINGER"}]}
+{"text": "יזהר מדר ולייב כנפו & אורי עמוק - שופר", "entities": [{"start": 0, "end": 8, "label": "SINGER"}, {"start": 22, "end": 31, "label": "SINGER"}]}
+{"text": "זוריק עוזרי בסינגל חדש ''לעולם לא רחוק מידי'' - Never Too Far", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "יונתן לידור מפתיע שוב בסינגל חדש קצבי וסוחף ''מה הם מרקדין''", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "גיל רבי ומנדי ברוין במחרוזת ''מארש וואלס''", "entities": [{"start": 0, "end": 7, "label": "SINGER"}]}
+{"text": "שלו קופר בסינגל נוסף ''משוך'' מתוך האלבום ''זכות''", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "שמוליק גנץ מארח את נחום ברנע ''קה ריבון''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}, {"start": 19, "end": 28, "label": "SINGER"}]}
+{"text": "אחישי אייזנשטדט באלבום חדש וייחודי ''ניגוני רבי בעריש ווישאווער''", "entities": [{"start": 0, "end": 15, "label": "SINGER"}]}
+{"text": "שרון נהון חוגג 33 בסינגל חדש ''נתראה בשמחות''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "מיכאל כהן בליווי אלימלך קליגר ותזמורתו המורחבת של נחמן דרייער מרגש עם 'חמול על מעשיך'", "entities": [{"start": 50, "end": 61, "label": "SINGER"}, {"start": 17, "end": 29, "label": "SINGER"}, {"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "אמרי נשיא בוכה פשוטו כמשמעו בעת שירת היצירה הויז'ניצאית ''חמול''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "צ'רלי עזרא בלחנו של וידרקר ''ששון ושמחה''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "איתן יולזרי מפציע עם סינגל בכורה ''ואתה ברחמיך''", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "אהרן וייס בסינגל חדש ''כיסופים''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "נפתלי קיסר בביצוע לייב לשירו ''אביס'ל'", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "שליו חניה בסינגל חדש לרגל 'שבת בראשית ''בראשית''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "שמחה כספי ממשיך עם סינגל שני - פנס באפילה", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "שמעון פרס בלחנו של הרב יהושע קנל ''נספר תהילתך''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "זבולון מושיאשווילי מארח את מושיקו אבלגון ''טאטע''", "entities": [{"start": 27, "end": 40, "label": "SINGER"}]}
+{"text": "24 אריה וינמן – תן לי תפילה", "entities": [{"start": 3, "end": 13, "label": "SINGER"}]}
+{"text": "11 מקהלת לחיים – קדוש", "entities": [{"start": 3, "end": 14, "label": "SINGER"}]}
+{"text": "14 יוני ולביא גנוט מארחים את ישעי שולקין – אולי ירחם", "entities": [{"start": 29, "end": 40, "label": "SINGER"}]}
+{"text": "10 מירון מעלם – מחרוזת יפה ותמה", "entities": [{"start": 3, "end": 13, "label": "SINGER"}]}
+{"text": "19 זאב בריהון ויובל פרל – אין דבר רע", "entities": [{"start": 3, "end": 13, "label": "SINGER"}]}
+{"text": "17 טל אלקיים – רגעים", "entities": [{"start": 3, "end": 12, "label": "SINGER"}]}
+{"text": "18 אילן כלפון – קול דודי דופק", "entities": [{"start": 3, "end": 13, "label": "SINGER"}]}
+{"text": "22 עופר עדיין – מקום לטעויות", "entities": [{"start": 3, "end": 13, "label": "SINGER"}]}
+{"text": "13 מאיר בן דוד – אלף צעיפים", "entities": [{"start": 3, "end": 14, "label": "SINGER"}]}
+{"text": "12 גדיאל קראוס – אבטיח", "entities": [{"start": 3, "end": 14, "label": "SINGER"}]}
+{"text": "15 עודד שמואל – מהגר", "entities": [{"start": 3, "end": 13, "label": "SINGER"}]}
+{"text": "23  ניסים סאלם - לכה דודי", "entities": [{"start": 4, "end": 14, "label": "SINGER"}]}
+{"text": "21 ניסן אלמו – מישהו יקרא לך אמא", "entities": [{"start": 3, "end": 12, "label": "SINGER"}]}
+{"text": "20 פנחס עקיבא – ומתקדש", "entities": [{"start": 3, "end": 13, "label": "SINGER"}]}
+{"text": "16 מיכאל פרזונסקי – זוכר", "entities": [{"start": 3, "end": 17, "label": "SINGER"}]}
+{"text": "04 ברק ליבוביץ – עולם חדש", "entities": [{"start": 3, "end": 14, "label": "SINGER"}]}
+{"text": "08 שלמה לוי – המרחם", "entities": [{"start": 3, "end": 11, "label": "SINGER"}]}
+{"text": "02 גבע בדיחי ופסח מוריה – שמע ישראל", "entities": [{"start": 3, "end": 12, "label": "SINGER"}]}
+{"text": "01 גבע שובה ויגיל גוזלן – כשאנחנו מנגנים", "entities": [{"start": 3, "end": 11, "label": "SINGER"}]}
+{"text": "03 שקד צברי – אל-קנה", "entities": [{"start": 3, "end": 11, "label": "SINGER"}]}
+{"text": "06 סולומון שכטר – קדם", "entities": [{"start": 3, "end": 15, "label": "SINGER"}]}
+{"text": "07 חי דניסוב – ימה", "entities": [{"start": 3, "end": 12, "label": "SINGER"}]}
+{"text": "05 הוד רומם – תאמין בעצמך", "entities": [{"start": 3, "end": 11, "label": "SINGER"}]}
+{"text": "09 אופרי חיון – לכו למים", "entities": [{"start": 3, "end": 13, "label": "SINGER"}]}
+{"text": "מקהלת הילדים סגיב כהן בסינגל ''מה גדלו מעשיך''", "entities": [{"start": 13, "end": 21, "label": "SINGER"}]}
+{"text": "מידע טסה בסינגל חדש ''ברכת הבית''", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "רוי ריאר בסינגל חדש ''היטן שבת''", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "מתניה מחלוף בשיר ''לנצח כל מכשול''", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "גדליה זנגר פותח את החורף ''מרקד לפניהם''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "נפתלי קסוטו ביטון בסינגל קצבי חדש ''זכיתי בחיים''", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "מעיין סלומון מפתיע בסינגל שני ''מיתרי הלב''", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "יואל רביבו, ליאל הורוביץ, תזמורת המנגנים ו''טיהר ר' חיים עצמו'' וניגון מרן שר התורה", "entities": [{"start": 12, "end": 24, "label": "SINGER"}, {"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "שולי הופשטיין ועקיבא קאליש בגרסה רישמית ללהיט ''מודים''", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "עידן רז ממשיך עם הפרויקט החסידי ומשלב מילים משלו ללחן המוכר", "entities": [{"start": 0, "end": 7, "label": "SINGER"}]}
+{"text": "יואב אמיתי מגיש סינגל חדש ''רוממו''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "משה מנדלסון ויהורם גאון במחרוזת ריקודים", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "אילון ענטר ואליאור מרום בסינגל חדש בביצוע משותף - ''הקהל''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "אלון מזרחי בסינגל חדש ''אחת שאלתי''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "אבי מילר ודודו אהרן בדואט חדש לכבוד הרבי 'זה יום גדול'", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "טוביה אייזנר שר בני שינפלד ''גשם''", "entities": [{"start": 16, "end": 26, "label": "SINGER"}, {"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "יעקב גולדברג מגיש סינגל חדש ''יעלה ויבוא''", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "שיר קרליבך בסינגל קצבי לחג ''הרחמן''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "אלירוי ברילנט בקאבר חדש לקראת החג ''ולקחתם''", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "מקהלת נעימות בית הכנסת, יהוידע גיטלמן, אבי לוי - ניגון ר' יענק'ל דוקשיצער", "entities": [{"start": 39, "end": 46, "label": "SINGER"}, {"start": 0, "end": 12, "label": "SINGER"}, {"start": 24, "end": 37, "label": "SINGER"}]}
+{"text": "רביד וינר בסינגל מרגש לחג הסוכות ''דער סוכה''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "חזקי גליק מגיש מחרוזת מקפיצה לשמחת בית השואבה", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "יזהר סיגמן במחרוזת מקפיצה ''זמן שמחתנו''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "יהודה ישראליוויטש ושניאור לוצקר בדואט אווירה מיוחד לחג ''7''", "entities": [{"start": 0, "end": 17, "label": "SINGER"}]}
+{"text": "אשר אפרתי בביצוע חדשני ל'ניגון גור' המפורסם", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "עמיאל צציק, דוד פלדמן, דוד קדוש, יהל אשטיוקר ושאול דנציגר עם מחרוזת עליה לרגל ''נעלה ונראה''", "entities": [{"start": 23, "end": 31, "label": "SINGER"}, {"start": 0, "end": 10, "label": "SINGER"}, {"start": 33, "end": 44, "label": "SINGER"}, {"start": 12, "end": 21, "label": "SINGER"}]}
+{"text": "בנימין אונגר בלהיט חדש ''אני לא יודע''", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "אמוץ רואימי & ג_קי קוגן מגישים ''אתה בחרתנו''", "entities": [{"start": 0, "end": 11, "label": "SINGER"}, {"start": 14, "end": 23, "label": "SINGER"}]}
+{"text": "חמי כץ ומיכאל בן יוסף - הקהל את העם", "entities": [{"start": 0, "end": 6, "label": "SINGER"}]}
+{"text": "יהודה הראל שר אלמוג זינדאני 'ונחה' בלייב", "entities": [{"start": 14, "end": 27, "label": "SINGER"}, {"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "שניאור מוניס מתחנן בסינגל חדש ''בטל מעלינו''", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "אנדור לנדוואי הלחין ושר ''סוכת לוויתן''", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "אודי אלקיים - אלוקי עד שלא נוצרתי", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "נחמן ברגמן מכניס אתכם לאווירת חג הסוכות עם ''הושע נא'' (גנשוף)", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "אוריה סאסי עם מקהלת ’זמרו’ בביצוע מרטיט של ’שמע קולנו’", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "מתן ויצמן בסינגל שני ''תמיד שומר''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "נמרוד נהרי שר על נסיעה לאומן למרות המלחמה ''מניעות''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "אבי חיון בביצוע לייב ליצירה הויז'ניצאית - ''ויאתיו''", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "'טוהר אמרון' מארח את יצחק מחפודה ומוישי שוורץ - שערי סליחות", "entities": [{"start": 1, "end": 11, "label": "SINGER"}, {"start": 21, "end": 32, "label": "SINGER"}]}
+{"text": "קורן ווינברג בסינגל מרגש ''כסא רחמים''", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "רענן אסיאו בלחן של מאיר ברמן ''פדה היום''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "מנדי ג'יי בסינגל בכורה קצבי ''ביום ההוא''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "אסנת וישינסקי ואפי סמט מגישים מחרוזת ימים נוראים", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "בר שימרון מארח את שרגא אליסיאן בסינגל חדש ''אהבתי''", "entities": [{"start": 18, "end": 30, "label": "SINGER"}, {"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "חזקי קליין שר בצלאל שניאור ''קווה אל השם''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}, {"start": 14, "end": 26, "label": "SINGER"}]}
+{"text": "מאיר אריאל מארח את אלברט צ'רטוק ''קול דודי''", "entities": [{"start": 19, "end": 31, "label": "SINGER"}, {"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "פרץ הראל סלסל קוורטין ''טיהר רבי ישמעאל''", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "אדיב טוקר & לירן סבן בדואט ''אחת שאלתי''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}, {"start": 12, "end": 20, "label": "SINGER"}]}
+{"text": "יפתח וינברגר חיים בלומנפלד המורחבת ושיר טולדנו בהרכב מוסיקלי רחב ''מחרוזת ימים נוראים''", "entities": [{"start": 13, "end": 26, "label": "SINGER"}, {"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "אבירן וקנין מגיש ''מחרוזת ניגוני הַקְהֵל''", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "שמואל גרשוני בשיר ''סליחה'' מקורי", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "בנצי קלצקין בביצוע מרגש ''כי הנה כחומר''", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "להקת SIX13-סיקס13 שר האחים קוסביצקי ''חמול על מעשך''", "entities": [{"start": 21, "end": 35, "label": "SINGER"}, {"start": 0, "end": 17, "label": "SINGER"}]}
+{"text": "תומר שילוני באלבום חדש בסדרת 'נשמה פלאם' בשם ''שבתון''", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "אהרון וינטרוב בסינגל חדש ''לטב עביד''", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "מנחם שטינמן בסינגל מרגש ''דער קעניג פון דער וועלט''", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "עזרי סורוקר ומקהלת ''שיר ושבח'' בסינגל מרגש על 'סדר העבודה' ביום הכיפורים!", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "בלדת הרגש של סמואל ברנס ''אבאל'ה''", "entities": [{"start": 13, "end": 23, "label": "SINGER"}]}
+{"text": "אביחי צנעני, פלג פיגה ושמואל בן יאיר במחרוזת מרגשת אחרי סליחות", "entities": [{"start": 0, "end": 11, "label": "SINGER"}, {"start": 13, "end": 21, "label": "SINGER"}]}
+{"text": "עדי וולקן בקלאסיקה חדשה עם נועם פנחסוב ''מחול וסלח''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}, {"start": 27, "end": 38, "label": "SINGER"}]}
+{"text": "יהונתן באור בניה ברוכים ולוי כהן בביצוע מרגש ''זכרנו לחיים''", "entities": [{"start": 12, "end": 23, "label": "SINGER"}, {"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "יונתן ברזילי מבצע משולם גרינבור ''שבורי לב''", "entities": [{"start": 18, "end": 31, "label": "SINGER"}, {"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "פסח דניאלי מכניס אתכם לאווירת הימים הנוראים", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "עמוס ספיר והמלחין אלישע זכאי במחרוזת ''תשרי נחת''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}, {"start": 18, "end": 28, "label": "SINGER"}]}
+{"text": "מוטל חשין ואבא פרייברג בדואט מרגש ''וידע כל פעול''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "דולב ברלוביץ & מראה הנגינה בשיר 'מלכיות זכרונות שופרות'", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "אליאור קרקליס עם נגיעות מהתפילות בויז'ניץ 'הייליגע מינוטן'", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "מאיר בלוי תומר דביר בסינגל חדש ''ואני קרבת''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}, {"start": 10, "end": 19, "label": "SINGER"}]}
+{"text": "יונגע יארן בסינגל חדש אמונה, ביטחון, גאולה", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "אבידן להב מגיש לחן מקורי לפיוט ''כי אשמרה שבת''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "ר' שמחה אזולאי לקראת ימי הרחמים בלחן החדש ל'אתיתי לחננך'", "entities": [{"start": 3, "end": 14, "label": "SINGER"}]}
+{"text": "גרשון כהנמן בסינגל חדש ''נורא אתה''", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "יונה פסח וליאור ביטון בסינגל חדש לראש השנה ''כתר מלוכה''", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "יגיל הופמן בסינגל חדש ''חסדי השם'' לרגל 3 שנים לתאומים", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "מקהלת מלכות וילדי אהרן קעסלער ''ידע כל פעול''", "entities": [{"start": 18, "end": 29, "label": "SINGER"}, {"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "כפיר גל בסינגל חדש ''מן המיצר''", "entities": [{"start": 0, "end": 7, "label": "SINGER"}]}
+{"text": "רות נצר ושמילי לייפר בסליחות מכניסי רחמים", "entities": [{"start": 0, "end": 7, "label": "SINGER"}]}
+{"text": "גורי מנהיימר בביצוע מרגש לימים הנוראים ועשרת ימי תשובה ''אבינו מלכנו''", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "יגאל שבתאי, ירוחם מן ומקהלת פריילך, עודד ורבין ושי ברק 'עננו רחום וחנון' לימים הנוראים תשפ''ג", "entities": [{"start": 12, "end": 20, "label": "SINGER"}, {"start": 36, "end": 46, "label": "SINGER"}, {"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "רוסלן זילברשלג ואלרואי אורצקי בסינגל חדש ''שיר הרפואה''", "entities": [{"start": 0, "end": 14, "label": "SINGER"}]}
+{"text": "מטר קירזנר עם סינגל בכורה 'לטב עביד'", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "פסח קגן חותם את השנה בסינגל חדש סגנון קומזיצי ''אשרי האיש''", "entities": [{"start": 0, "end": 7, "label": "SINGER"}]}
+{"text": "לישי גרבי בביצוע לייב ליצירה של פינקי ''שערי דמעות''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "אלקנה מרציאנו בסינגל חדש ''השיבנו''", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "דורי רומי מחדש את היצירה ''צדיק השם''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "דן שמריהו בסינגל החדש ''אומן אמונה''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "אבישי חדיף מגיש סינגל חדש ''אם תחנה'' של כצל'ה", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "לייזר שטיינמץ במחרוזת משירי הימים הנוראים", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "אחיה ספוז'ניקוב בביצוע פסנתר לניגון ''אדון הסליחות''", "entities": [{"start": 0, "end": 15, "label": "SINGER"}]}
+{"text": "עזריה נבון בביצוע לייב מחרוזת נוסטלגית ''אוצרות יהודים''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "מיכאל רוזן הלחין ושר ''מקווים'' מתוך הסליחות", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "מעגן למפרט & שמשון חזן - הבן יקיר לי", "entities": [{"start": 0, "end": 10, "label": "SINGER"}, {"start": 13, "end": 22, "label": "SINGER"}]}
+{"text": "הנס ליפשיץ בסינגל חדש לרגל המעמד ''תורת אמך''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "לני הנדלר בשיר חדש ומשמח ''אוטוטו בקרוב בימינו''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "ויקטור הרשקוביץ מכלוף קסטון רגב פינקל אליאור עופר ומנחם שוקרון עם מחרוזת ''מוסף ראש השנה''", "entities": [{"start": 38, "end": 49, "label": "SINGER"}, {"start": 16, "end": 27, "label": "SINGER"}, {"start": 0, "end": 15, "label": "SINGER"}, {"start": 28, "end": 37, "label": "SINGER"}]}
+{"text": "נועם זלצר בסינגל חדש ''בשעה אחת''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "נחשון סיבהט מאחל ''לשנה טובה''", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "אליאב סברסקי בסינגל מרגש לימים הנוראים ''הבן יקיר לי''", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "מוטי עופר בסינגל חדש לחודש אלול ''אבקש''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "שקד חזן מכניס לאווירת הסליחות ''קום בן אדם''", "entities": [{"start": 0, "end": 7, "label": "SINGER"}]}
+{"text": "יקיר כהן במחרוזת משירי ר' משה יחזקי’ ווייס", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "עידן שהרבני הלחין ומגיש סינגל חדש ''ותערב''", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "יוסף לימן בביצוע לפיוט המרטיט ''אחות קטנה''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "יואלי קליין בסינגל חדש ''קול דודי דופק''", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "אילי ווקנין במופע להקה מיוחד לרגל השנה החדשה ''הנה ימים באים''", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "יובל שגיב ותלמידי ישיבת ''אש התלמוד'' שרים ''אהבת תורה''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "לידור אסור יואל גליק ולהקת הווקאל 'רבותי' במחרוזת ''גוטליב ימים נוראים''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}, {"start": 11, "end": 20, "label": "SINGER"}]}
+{"text": "שאול קיפניס בקאבר משובח ללחנו של רכניץ ''אחת ואחת''", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "מאור נוף בלחן מרגש לחודש אלול ''שובו אלי''", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "אהרן יצחקי מרטיט בסינגל חדש ''מרן דבשמיא''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "תמיר הירש בסינגל חדש וייחודי ''די לבנה'ס דין תורה'' (דין התורה של הלבנה).", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "אורי אליאב בסינגל חדש וקצבי ''ניגון המדבר''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "מוטי כץ מארח את אושר ביטון לשירו ''אלול''", "entities": [{"start": 16, "end": 26, "label": "SINGER"}, {"start": 0, "end": 7, "label": "SINGER"}]}
+{"text": "נתנאל דוניצה בסינגל שני ''תן לי תפילה''", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "שגיא חייט בשיר מרגש לאלול ''סלחתי''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "קלמי שווארטץ בגרסה מקפיצה ''הולך רק איתך''", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "יוני ולביא גנוט & יגל יפלח - אולי ירחם", "entities": [{"start": 18, "end": 26, "label": "SINGER"}]}
+{"text": "דותן יוחפז בלחן מרגש לקראת הימים הנוראים ''השיבנו''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "שרון מונדני עם תלמידי ישיבת 'תורת החיים' 'עוקד והנעקד'", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "דן שעיו בסינגל חדש ''ניגון ריקוד''", "entities": [{"start": 0, "end": 7, "label": "SINGER"}]}
+{"text": "שלום פרנקל בסינגל מרגש ''אלף פעמים ריבונו של עולם''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "עמירם נחמיאס עם די ג'י שני בן-יהודה בפיוט הסליחות 'אדון הסליחות'", "entities": [{"start": 23, "end": 35, "label": "SINGER"}, {"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "ניסים דוד משחרר סינגל חדש ’תשרת’ שמו", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "איציק סנדרוי משיק סינגל שני ''ביום דין וחשבון''", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "ירוחם שרדר ממשיך לסלסל ולרגש בדרך לאלבום נוסף ''מלאכים קטנים''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "תום עברון בביצוע אינסטרומנטלי ''ניגון קבלת שבת ברסלב''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "רואי אלון משיק אלבום רביעי", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "אהר'לע סמט עם סינגל מהאלבום ''כבן המתגעגע''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "אשר ברוצקי מגיש סינגל חדש לקראת הימים הנוראים ''ימים באים''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "גבע ללוש שר ''אני איתך''", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "דני שביט בביצוע נוסטלגי ומרגש מכניסי רחמים", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "'מראה הנגינה & דר אדהנני' מגישים השיר ''אמרו לפני מלכיות זכרונות שופרות''", "entities": [{"start": 15, "end": 24, "label": "SINGER"}]}
+{"text": "עקיבא המניק בסינגל חדש ''אבינו מלכנו''", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "רונן שמש מרגש בסינגל חדש ''מלך''", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "מידד זגרון יוצא בסינגל הבכורה ''למה נגרע''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "צבי פלדר בסינגל חדש ''לבד אבל איתך''", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "יותם זלזניק בסינגל חדש ''אלול - אני לדודי ודודי לי''", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "מיקי פובידלו נכנס לאולפן ויצא עם שיר חדש ''הלב''", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "מרום סלוני מרגש בסינגל חדש ונוגע ''גם אם כרגע''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "אשר קרישבסקי ולאונרדו וייס בליווי תזמורתו של גדעון אסיאג ויהל אפשטיין ''לב טהור - מיין הארץ''", "entities": [{"start": 45, "end": 56, "label": "SINGER"}, {"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "שחק עזרי וילד הפלא מיתר מצא ''ארשת שפתינו - באבוב''", "entities": [{"start": 19, "end": 27, "label": "SINGER"}, {"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "עמית מרסיאנו מארחים את שובל בקרמן ''ברכך''", "entities": [{"start": 0, "end": 12, "label": "SINGER"}, {"start": 23, "end": 33, "label": "SINGER"}]}
+{"text": "הרב טדי מילצקי, תשעה באב תשע''ט עברית", "entities": [{"start": 4, "end": 14, "label": "SINGER"}]}
+{"text": "יוני זיגמונד - אליך (ווקאלי)", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "ישי גרין ווקאלי הריני", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "הזמר איתי יהושע בביצוע ווקאלי נשיר שוב", "entities": [{"start": 5, "end": 15, "label": "SINGER"}]}
+{"text": "רועי דוד וחברים מגישים מחרוזת ירושלים", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "עופר שמיר מגיש 'שאבעס טיש - ווקאלי'", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "נחמן קלינשטיין ומשה קונסטלר 'בקש עבדך' - ווקאלי", "entities": [{"start": 0, "end": 14, "label": "SINGER"}]}
+{"text": "ליר חזן בביצוע ווקאלי מאמין בניסים", "entities": [{"start": 0, "end": 7, "label": "SINGER"}]}
+{"text": "רפי ברידס, ליאל צרפתי, ניסן פטמן, דויד חזיזה, בובי - בר יוחאי - רמיקס", "entities": [{"start": 11, "end": 21, "label": "SINGER"}]}
+{"text": "מקהלת פיסטבורג - געגועים למירון", "entities": [{"start": 0, "end": 14, "label": "SINGER"}]}
+{"text": "עוזי שמעוני בסינגל חדש דייייי", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "מורן אלי & יהודה בר-טל (עיריית בני ברק) - כדאי הוא רבי שמעון", "entities": [{"start": 0, "end": 8, "label": "SINGER"}, {"start": 11, "end": 22, "label": "SINGER"}]}
+{"text": "שאול בוסקילה - מלך עוזר", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "קובי שלזינגר והזמר דגן אוזן עם מחרוזת לג בעומר", "entities": [{"start": 0, "end": 12, "label": "SINGER"}, {"start": 19, "end": 27, "label": "SINGER"}]}
+{"text": "אבי פודולינסקי מבקש מרבי שמעון העלפ אונז שוין", "entities": [{"start": 0, "end": 14, "label": "SINGER"}]}
+{"text": "אמנון שטינברג לכבוד לג בעומר - עולו בנים קדישין", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "אברהם גולדשטיין מגיש סינגל בכורה בזכות הצדיק", "entities": [{"start": 0, "end": 15, "label": "SINGER"}]}
+{"text": "עופרי קורן, מנדלסון ובלטי עם מיטב שירי מירון", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "ליאו טבח, תמי פרץ, אלי תמיר - הייליגער רבי שמעון", "entities": [{"start": 0, "end": 8, "label": "SINGER"}, {"start": 19, "end": 27, "label": "SINGER"}, {"start": 10, "end": 17, "label": "SINGER"}]}
+{"text": "יעקב בראון - פון מיין הייל צו דיין הייל", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "שידור חוזר מההדלקה המרכזית הילולת התנא האלוקי רבי שון אביטן זיע''א ל''ג בעומר במירון תשע''ח", "entities": [{"start": 50, "end": 59, "label": "SINGER"}]}
+{"text": "מופע הוקרה חמישים שנה לגדול הזמר פייר פולונסקי", "entities": [{"start": 33, "end": 46, "label": "SINGER"}]}
+{"text": "ספיר בר-לב בתחינה לבורא עולמים הַשְׁקִיפָה מִמְּעוֹן קָדְשְׁךָ  -", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "שרון פרוינד שר ניגון אלול של אבירם שאשא", "entities": [{"start": 0, "end": 11, "label": "SINGER"}, {"start": 29, "end": 39, "label": "SINGER"}]}
+{"text": "יפתח כפיר מארח את דני ממן - נכספה", "entities": [{"start": 18, "end": 25, "label": "SINGER"}, {"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "מקהלת 'אחיה כהן' ו'שירה' בביצוע מרגש למחרוזת סקולען", "entities": [{"start": 7, "end": 15, "label": "SINGER"}]}
+{"text": "תמיר שוורץ זועק עם רבבות 'שערי שמים פתח'", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "שגיב אביטבול בסינגל רביעי הכל בסדר", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "גדעון גילאור ריגש בקמפ ללהיט שלו ''לעכטעלע''", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "מישל בויקו מארח את יצחק בן ארזה ויוסי לויבער בסדרת ''קיץ חי''", "entities": [{"start": 19, "end": 31, "label": "SINGER"}, {"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "רוי פרץ בקומזיץ ליל שישי סוף זמן קיץ תש''פ לבחורי הקיבוץ בדושינסקיא", "entities": [{"start": 0, "end": 7, "label": "SINGER"}]}
+{"text": "עוזי בך בסינגל חדש מתנות החיים", "entities": [{"start": 0, "end": 7, "label": "SINGER"}]}
+{"text": "אייל עמרם על במת קיץ חי במופע סוחף ומרגש", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "עדן בן-ציון ויוסף-חיים אלסטר על בימת קול פליי עם רינת בר", "entities": [{"start": 0, "end": 11, "label": "SINGER"}, {"start": 49, "end": 56, "label": "SINGER"}]}
+{"text": "קסם שוקן מקפיץ בסינגל חדש אשרינו", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "יוסף אסייג בלהיט חדש יום זה לישראל", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "כלב ויינשטוק, דור הפנר,שרולי וייס ושבתאי מניס - ה' הוא האלוקים", "entities": [{"start": 14, "end": 22, "label": "SINGER"}, {"start": 23, "end": 33, "label": "SINGER"}, {"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "סול פוזננסקי מרגש ביצירה מרטיטה ''אלוקי נשמה''", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "אלימלך דודסון בסינגל חמישי מפרויקט ה-40 ''אומן''", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "מופע הצדעה לציון 40 שנות יצירה לר' אורון רון מסדרת קיץ חי", "entities": [{"start": 35, "end": 44, "label": "SINGER"}]}
+{"text": "רותם מזור בלהיט קיץ חדש רק לתת", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "נבו טל בסינגל חדש - כמה טוב ה'", "entities": [{"start": 0, "end": 6, "label": "SINGER"}]}
+{"text": "רם זילברשטיין בסינגל חדש נושם שלמות", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "סעדיה גולני מגיש סינגל מתוך אלבום חסידי חדש אוטוטו!", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "ר' יוסף הצדיק בשיר עוצמתי הטוב שבך", "entities": [{"start": 3, "end": 13, "label": "SINGER"}]}
+{"text": "ירמיהו עוזרי, אבשלום פיינגולד, גור שחר, מילך פרנק ווולטר קולישר. שיריו של אילי ברנדוין.", "entities": [{"start": 40, "end": 49, "label": "SINGER"}, {"start": 74, "end": 86, "label": "SINGER"}, {"start": 0, "end": 12, "label": "SINGER"}, {"start": 31, "end": 38, "label": "SINGER"}, {"start": 14, "end": 29, "label": "SINGER"}]}
+{"text": "שמעון לובוביץ במחרוזת פיוטים חדשה 'אנא אלי'", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "אריאל בנדור ויששכר לבאן מחרוזת אליהו הנביא", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "האחים דסקל ולהקתו - מחרוזת חתונה ענקית", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "מופע ענק של אבישי וינברגר ופתיחה של להקת אלמוג דיין", "entities": [{"start": 41, "end": 51, "label": "SINGER"}, {"start": 12, "end": 25, "label": "SINGER"}]}
+{"text": "יונתן וניב עוזרי במופע מרתק & ילד הפלא ינון לרר", "entities": [{"start": 39, "end": 47, "label": "SINGER"}]}
+{"text": "'משאלות' מחדשת את 'תחשוב טוב' של תמיר ביטון בגרסה שקטה", "entities": [{"start": 33, "end": 43, "label": "SINGER"}]}
+{"text": "ליבי שלומוביץ בשיר געגועים על הדור שאינו ימים יפים", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "עופר דזאנאשוילי, איציק קלה, ועידו מרגולין לרגל סיום מסכת שבת 'הדרן'", "entities": [{"start": 17, "end": 26, "label": "SINGER"}, {"start": 0, "end": 15, "label": "SINGER"}]}
+{"text": "ליאב מלמד מגיש יצירה חדשה ''שיר ציון''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "עדין נווה במופע השקה לאלבומו השני 'אנה אלך'", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "מתניה כהן חוזר בשיר נוסף מתוך הסדרה ישמחו", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "עידו כהן בסינגל חדש מהפטרות הנחמה 'ואנכי לא אשכחך'", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "מתן פאר & אריה דדון - שיר השמחה", "entities": [{"start": 0, "end": 7, "label": "SINGER"}, {"start": 10, "end": 19, "label": "SINGER"}]}
+{"text": "יהושע בן-ארי ריגש בסעודת ההודיה לסבא והסבתא - רגש'דיג", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "אלדר פסט עם סינגל ראשון שכתב והלחין בעצמו ''נעשה שמח''", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "אלכסנדר ווייס בביצוע אינסטרומנטלי ל'נפשי' של פאלקאוויטש", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "שמעון רויכר ותזמורתו & עדי גורי - מחרוזת להיטים", "entities": [{"start": 23, "end": 31, "label": "SINGER"}, {"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "חנניה רידלר עם רולי וטום סעדי בשידור חוזר מקול פליי", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "גד פישמן - במחרוזת פאנקי קצבי", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "נועם דר בסינגל שני ''להודות''", "entities": [{"start": 0, "end": 7, "label": "SINGER"}]}
+{"text": "אילן לבל באלבום חדש ''רעיונות''", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "זוהב שטראשון ואלימלך פקר מגישים מתנות קטנות", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "ישראל קובי יוצא בריקוד לצלילי סינגל חדש ''סול מי''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "קובי בלטה בביצוע עצמתי ללהיט בין קודש לחול", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "אורן גולדשטיין מחדש את 'יהיו לרצון'", "entities": [{"start": 0, "end": 14, "label": "SINGER"}]}
+{"text": "השלום זכר של לי נחשון עם דייויד טויב", "entities": [{"start": 13, "end": 21, "label": "SINGER"}, {"start": 25, "end": 36, "label": "SINGER"}]}
+{"text": "צחי פרנקל - תן לי אור", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "ירמיהו מאירי ומתיסיהו בביצוע מיוחד", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "בנצי אלחננוביץ וניר באזוב מגישים מחרוזת אנרגטית", "entities": [{"start": 0, "end": 14, "label": "SINGER"}]}
+{"text": "מופע הקיץ של קול פליי עם מקהלת 'יחד', פיני גולדמן וניתאי שרעבי ותזמורתו", "entities": [{"start": 38, "end": 49, "label": "SINGER"}]}
+{"text": "אפרים דוד בסינגל חדש – שמח תמיד", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "רמיקס חדש לשירו של הראל סממה - חיבור חזק", "entities": [{"start": 19, "end": 28, "label": "SINGER"}]}
+{"text": "מתן רבינוביץ שר בליבי", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "שמחה לוונשטיין מארח את עמנואל פנחס איך בין דיינס", "entities": [{"start": 0, "end": 14, "label": "SINGER"}, {"start": 23, "end": 34, "label": "SINGER"}]}
+{"text": "דודי הראל מארח את גדולי הזמר למחרוזת אנרגיה", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "ימין סגל ותזמורתו מארחים את כוכבי הזמר החסידי במחרוזת חדשה", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "דותן שריג בסינגל קצבי חדש נחמו עמי", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "טומי וויליאמס - בואי בשלום", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "ישראל מאיר שוויד מגיש נחמה – ווי ביסטו", "entities": [{"start": 0, "end": 16, "label": "SINGER"}]}
+{"text": "נוה קיים ואלכס קלייר מגישים 'חראשו' בגרסת רמיקס", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "יעקב אורטנר מארח את סער דושי לדואט מרגש אחותינו את", "entities": [{"start": 0, "end": 11, "label": "SINGER"}, {"start": 20, "end": 28, "label": "SINGER"}]}
+{"text": "28 אליאל שלי", "entities": [{"start": 3, "end": 12, "label": "SINGER"}]}
+{"text": "30 קלמי שווארץ", "entities": [{"start": 3, "end": 14, "label": "SINGER"}]}
+{"text": "26 צח אבני", "entities": [{"start": 3, "end": 10, "label": "SINGER"}]}
+{"text": "29 לירם כרפסי", "entities": [{"start": 3, "end": 13, "label": "SINGER"}]}
+{"text": "27 אריק בר", "entities": [{"start": 3, "end": 10, "label": "SINGER"}]}
+{"text": "23 שלום לעמר", "entities": [{"start": 3, "end": 12, "label": "SINGER"}]}
+{"text": "24 לוי דרויאן", "entities": [{"start": 3, "end": 13, "label": "SINGER"}]}
+{"text": "25 אנדי פרידמן", "entities": [{"start": 3, "end": 14, "label": "SINGER"}]}
+{"text": "06 רבי מתן פז שושן", "entities": [{"start": 7, "end": 13, "label": "SINGER"}]}
+{"text": "עופרי שימשלביץ בביצוע ווקאלי אהבת חינם", "entities": [{"start": 0, "end": 14, "label": "SINGER"}]}
+{"text": "גדליה בנישתי ומשפחתו 'ומפני חטאנו' - ווקאלי", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "אבי וינברג מגיש סינגל שני בביצוע וואקלי נחם השם", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "מנחם מנדל ור' אליאב ורטנשטיין 'תיקון חצות' (ווקאלי)", "entities": [{"start": 14, "end": 29, "label": "SINGER"}, {"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "עמיר מנגסטו שנוצרה בבידוד ''אליהו הנביא זכור לטוב''", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "רוני פריד ובן הזקונים בלהיט שעבר ''אין ערוך'' ווקאלי", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "הרב עומרי פרי, צום י''ז בתמוז וימי בין המצרים, וחיזוק לימי הקורונה - עברית", "entities": [{"start": 4, "end": 13, "label": "SINGER"}]}
+{"text": "קובי מרנקו עם מחרוזת שפכי כמים ווקאלי", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "ר' שלומי גפן שליטא יום צום י''ז בתמוז ה' פנחס תש''פ", "entities": [{"start": 3, "end": 12, "label": "SINGER"}]}
+{"text": "ישראל גברא ור' יוט עהרליך 'קנא לשמך'", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "מוטי פוקס & פליקס גיספן - י-ה ריבון", "entities": [{"start": 12, "end": 23, "label": "SINGER"}, {"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "דודי סתר בן 17 ניצח בתחרות הקלידנים  תקשיבו לשידור חוזר מאת רדיו קול חי", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "רגע לפני בין המיצרים יובל כרמל - 'נחם השם'", "entities": [{"start": 21, "end": 30, "label": "SINGER"}]}
+{"text": "אלברט איינשטיין ואברימי גוטסמן א גוט וואך ב'סיום השס'", "entities": [{"start": 0, "end": 15, "label": "SINGER"}]}
+{"text": "עמנואל ביתן, שלומי לעווי - ''מושי'ס תנועה''", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "אתי באבאיאן & שלו מרגולין - שיר המקווה", "entities": [{"start": 0, "end": 11, "label": "SINGER"}, {"start": 14, "end": 25, "label": "SINGER"}]}
+{"text": "ר' רוי עופר - טאטע טאטע", "entities": [{"start": 3, "end": 11, "label": "SINGER"}]}
+{"text": "ישעיהו קאפח בסינגל שלישי (מתוך 40)  הריני", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "מתנאל קורגן ועופרי אשרי - יום שישי הגיע", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "חושן יששכר ושרה לוי בדואט חדש ''אשרי תלמיד חכם''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "אליעזר מרדכי שווארץ וטוביה בולטון אבינו אב הרחמן", "entities": [{"start": 0, "end": 19, "label": "SINGER"}]}
+{"text": "קובי לביא, סיני שרייבר ו'שירה' במחרוזת קלאסית", "entities": [{"start": 0, "end": 9, "label": "SINGER"}, {"start": 11, "end": 22, "label": "SINGER"}]}
+{"text": "ארי גולד בביצוע מיוחד ואנרגטי ללהיט המנגן", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "מרדכי-מוטי פרטוש & ניצן שוקרון - מטאפורה", "entities": [{"start": 19, "end": 30, "label": "SINGER"}, {"start": 0, "end": 16, "label": "SINGER"}]}
+{"text": "סינגל לחתן בנימין - שירה ע''י חיים ארלנגר", "entities": [{"start": 30, "end": 41, "label": "SINGER"}]}
+{"text": "מתנאל פריד ורפאל סופר במחרוזת שירי הלל", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "רום זינצ'נקו מגיש גרסת קאבר הלב שלי", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "מעיין הכהן עם עוד שיר חדש ישמחו במלכותך", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "התכנית החדשה 'אזור התעשייה' עם הזמר שבתאי אלבז", "entities": [{"start": 36, "end": 46, "label": "SINGER"}]}
+{"text": "עמיאל קוטנר - פותח את ידך", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "פלג דנוך בפייטן מרוקאי, לחן טוניסאי, עיבוד פלמנקו ספרדי חביבי", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "עמיחי אשכנזי משחרר סינגל רביעי - צועד קדימה", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "שמואל אלחדד בנסמיאן מגיש בסינגל בכורה הרבי הבטיח", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "יפת שוסטר בשיר חדש עושה שלום", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "עמוס גרשון & אפרים בצלאל בסינגל חתונה", "entities": [{"start": 0, "end": 10, "label": "SINGER"}, {"start": 13, "end": 24, "label": "SINGER"}]}
+{"text": "אליאל ראזנבוים במחרוזת להיטים בהופעה מיוחדת", "entities": [{"start": 0, "end": 14, "label": "SINGER"}]}
+{"text": "ילד הפלא שקד אמויאל וליבי קקורייב 'גערוישן אין הימל'", "entities": [{"start": 9, "end": 19, "label": "SINGER"}]}
+{"text": "מענדי וואלד ונר אדם בסינגל חדש בינתיים השמיים", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "אמוץ דבי בקאבר לשיר של שוואקי 'תפילת כלה'", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "צור אטיאס ויהל בדר שרים בעת ההיא", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "ברק פסקין ושניאור טורס - קרבה אל נפשי גאלה", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "איילון מילס - מה לכם להתבייש", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "ודים צוקרמן & אהרן טסלר & ינאי גמליאל מקפיצים עם 'יאבאביי'", "entities": [{"start": 14, "end": 23, "label": "SINGER"}, {"start": 0, "end": 11, "label": "SINGER"}, {"start": 26, "end": 37, "label": "SINGER"}]}
+{"text": "עובדיה רוט מארח ילד הפלא פנחס רעטעק לאהבה", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "לכבוד היארצייט חזנים בקברו של ר' מיכל גרינברג ז''ל", "entities": [{"start": 33, "end": 45, "label": "SINGER"}]}
+{"text": "דניס אדרי ודן איסחקוב 'לא לנו - דאווענען'", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "מקסים קסלמן בסינגל חדש רגעים", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "עודד אביטן - מחרוזת שירי שבת - מתוך המופע שרים ביקב", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "אפי מושייב בלהיט גאולתי מקפיץ ''ותמהר לגאול''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "רונאל סבאג וישראל ג'רופי במחרוזת שבתי ''נשמה יתירה''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "זאבי דניאל מגיש את ''להודות'' ברוח התקופה", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "קאפי עלנבויגן במחרוזת ניגוני חבד אינסטרומנטלית", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "אורי רוזנבלום בביצוע מרגש ''אני מאמין''", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "שרון מזור בפיוט יפה ותמה", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "סלמן קריאף ובניו שרים ומפני חטאינו", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "גלי רון באלבום חדש - מודה אני", "entities": [{"start": 0, "end": 7, "label": "SINGER"}]}
+{"text": "מרדכי יפרח מחדש גרסה מרעננת ועיבוד חדש ללהיט I CAN BE", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "שמוליק ברגר ואסיף בלקין - לכו נרננה", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "ישראל אורני והרשי וינברגר מגישים ולזבולון לזכרו של ר' רפאל זבולון וויכלנדר ז''ל", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "שידור חוזר מוצש חי עם שמואלי הורביץ והשבוע עם שלוימל'ה קרישבסקי", "entities": [{"start": 22, "end": 35, "label": "SINGER"}, {"start": 46, "end": 63, "label": "SINGER"}]}
+{"text": "רותם חמרי ובנו בסינגל חדש יא אדער ניין ביי אתה חונן", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "גדעון שירי מגיש סינגל חדש ומיוחד ''ניפול נקום''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "גור ימליאנוב ממשיך בסינגל חדש אלוקים", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "שלומי אגמון מרגש 'אודך השם' & 'שערי דמעות' בחופה", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "לוי מונד בגרסה אלקטרונית והריקותי", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "מורן שיף בסינגל חדש – אברכה", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "אוהד גראשי וגבריאל גואטה וואלס דז'יקוב", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "הרצל שמרלר באלבום חדש - ''געפיל'' - דוגמה", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "שלום דוידוביץ מחדש עמנו ישראל", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "רנה שמעי והחברים רוקדים – כי טוב השם", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "מייקל טובול קונופניצקי בסינגל חדש 'לך ידיד נפשינו", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "יהונתן מרגוליס בסינגל חדש שוכן עד", "entities": [{"start": 0, "end": 14, "label": "SINGER"}]}
+{"text": "יחזקאל שפיר מגיש 'מנוחה ושמחה'", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "מנדי טברסקי מגיש סינגל חדש תן שלום", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "אורון מאור מגיש סינגל שלישי 'למצוא חן'", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "שילה פרומוביץ באלבום חדש 'סקולען מיט עמי ענבר' - דוגמה", "entities": [{"start": 37, "end": 45, "label": "SINGER"}, {"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "שלמה בנימין אורצל באלבומו השני להודות לך", "entities": [{"start": 0, "end": 17, "label": "SINGER"}]}
+{"text": "מרק בנימין שר אמיר בושרי - אדון עולם", "entities": [{"start": 0, "end": 10, "label": "SINGER"}, {"start": 14, "end": 24, "label": "SINGER"}]}
+{"text": "ידיד שוסטר עם סינגל חדש לרגל בר המצווה לבנו חסד שבחסד", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "יניר שפירא שר מנדלוביץ על כל החסד", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "טמיר אמברבר וחוגגי סיום השס שרו את 'המלאך'", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "הזמר והיוצר רביד מנשה עם סינגל חדש – לכה דודי", "entities": [{"start": 12, "end": 21, "label": "SINGER"}]}
+{"text": "רולי דיקמן באלבום חדש - מיין נשמה זינגט", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "הרצל יפה במחרוזת חתונה מקפיצה", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "אליאסף חפץ בסינגל חדש ''כי לישועתך''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "ינון פרקש ור' עובד ווקנין בסינגל מיוחד תיקון חצות", "entities": [{"start": 14, "end": 25, "label": "SINGER"}, {"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "שימעון מרציאנו & יואלי רוט 'קל אדון' של רבי בנציון שנקר ז''ל", "entities": [{"start": 17, "end": 26, "label": "SINGER"}, {"start": 0, "end": 14, "label": "SINGER"}]}
+{"text": "הרשי פוזנר, שרלי בוכריס וצדוק גרינוואלד במחרוזת אנרגטית", "entities": [{"start": 12, "end": 23, "label": "SINGER"}]}
+{"text": "רן מנדלמן בשיר ד' בבות מתוך 'לחיים טיש חבד' 2", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "נפתלי שניצלער מחדש את הלהיט אתה קדוש", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "תבל חקימיאן במחרוזת ריקודים קצר & סוער!", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "כפיר דנין, שרולי זינגר ויעקב עופר במחרוזת אנרגטית חסידית", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "אורי זוהר בסינגל חדש אני מאמין", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "מיקי גלברט ואחיו 'מי אדיר", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "יענקל'ה הרשקוביץ כהנא מגיש לחיים טיש חב''ד 2", "entities": [{"start": 0, "end": 16, "label": "SINGER"}]}
+{"text": "שיר מושייב בסינגל שלישי הולך ונעלם", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "דין זעפרני - שמחה הלילה", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "אברימי אקשטיין מגיש עשור אליאסי - מחרוזת שאבס טיש", "entities": [{"start": 20, "end": 31, "label": "SINGER"}]}
+{"text": "איל טהר עם שליו דרוקר - אנא", "entities": [{"start": 11, "end": 21, "label": "SINGER"}, {"start": 0, "end": 7, "label": "SINGER"}]}
+{"text": "ארן מסורי הלחין על הקורונה - אדיר צבר מבצע", "entities": [{"start": 29, "end": 37, "label": "SINGER"}, {"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "תזמורתו של עזריאל קפון ואימרי בר - האפ קאזאק", "entities": [{"start": 11, "end": 22, "label": "SINGER"}]}
+{"text": "אביה סבאג מגיש סינגל חדש בדרך אל הגאולה", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "נאור שומר ומיטב אומני הצפון - קומזיץ תורה-זיץ", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "גבריאל שלה בסינגל שני וקצבי הג'ק דבשיל", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "בן-אל תבורי מגיש חוזרים לבתי הכנסת עם שיר חדש ומשפע", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "דודו ריכטר בשיר מקפיץ 'לרקוד עם רשבי'", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "משה בוט, מוישי פרוינד, מעיין קרניאל וצבי טוקצ'ינסקי - מענטשעלע", "entities": [{"start": 23, "end": 35, "label": "SINGER"}, {"start": 9, "end": 21, "label": "SINGER"}, {"start": 0, "end": 7, "label": "SINGER"}]}
+{"text": "גד לסרי שוורץ - מנן ומאן", "entities": [{"start": 0, "end": 7, "label": "SINGER"}]}
+{"text": "טל מימון, אלעד שולמן ושלומי דאקס 'במחרזות מתן תורה'", "entities": [{"start": 10, "end": 20, "label": "SINGER"}, {"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "אמנון טאובר משיק אלבום פיוטים חדש – יוצר יחידתי.", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "הערשי וויינבערגער בסינגל חדש 'טוב'", "entities": [{"start": 0, "end": 17, "label": "SINGER"}]}
+{"text": "''ארנון עוז משחרר סינגל נוסף ''חיבור חזק", "entities": [{"start": 2, "end": 11, "label": "SINGER"}]}
+{"text": "פרויקט רילקס זיו גורביץ - דוגמה", "entities": [{"start": 13, "end": 23, "label": "SINGER"}]}
+{"text": "הלל מאיר - אבא טוב", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "שי סרגייב, אמיתי דוד & לב שיינבוים - א חידוש", "entities": [{"start": 11, "end": 20, "label": "SINGER"}, {"start": 23, "end": 34, "label": "SINGER"}, {"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "איתם ברקו בסינגל חדש יאמר לצרותינו די", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "מרדכי קצב - התורה כוללת כל הטובות שבעולם", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "מאיר סטביסקי - אזהרות לחג השבועות", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "אריאל אוקרט - שקדתי (ווקאלי)", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "להקת 'קפל' במשאפ ווקאלי מיוחד ממ אחשווה ועד הוד שמאילוב", "entities": [{"start": 44, "end": 55, "label": "SINGER"}]}
+{"text": "אלימלך חנקין & אדריאן וניג - תן לאמונה יד - ווקאלי", "entities": [{"start": 0, "end": 12, "label": "SINGER"}, {"start": 15, "end": 26, "label": "SINGER"}]}
+{"text": "אבוא אליך שיר מרגש של המלחין הרב שרגא בוזו", "entities": [{"start": 33, "end": 42, "label": "SINGER"}]}
+{"text": "עיליי לוגסי מגיש את הגרסה הווקאלית שלו ל''כשהלב בוכה", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "עיליי פולק ואחיו במחרוזת שירים מרגשת - ווקאלי", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "זוהר אברהם בקאבר ווקאלי לשירו של אבינועם מימון שלח לי כח", "entities": [{"start": 33, "end": 46, "label": "SINGER"}, {"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "ישראל אדלער - הלב שלי (ווקאלי)", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "שלמה גליק בביצוע ווקאלי - מזמור לדוד", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "איתן כהנא ושמואל מוזס נאגבקר - 'סדר העבודה'", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "עתי אלבוים וגרשי שוורץ סופרים העומר בשירה", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "אדם רוסט בביצוע אקפלה אם אשכחך ירושלים", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "מצליח אטיאס ומנדי גולדברג מרגשים ממירון", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "לביא מרגלית בביצוע ווקאלי קה אכסוף", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "אמיר אורעד במופע אקפלה מלא", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "אליה שפירא בביצוע ווקאלי מנוחה ושמחה", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "אידינה מנזל - 'יבוא' בגירסה הווקאלית", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "מתתיהו פרלמן - מירון תש''פ", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "עמיאל קרמר עם גירסה ווקאלית לישתבח שמך", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "‏יואל זינגער בביצוע ווקאלי שבת היום להש", "entities": [{"start": 1, "end": 12, "label": "SINGER"}]}
+{"text": "יוסי נטיב - אלוקי אל תעזבני (ווקאלי)", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "נטע מונסונגו - דא וואוינט א איד (ווקאלי)", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "חגי סובל – לחישות הלב - דוגמה", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "דורון ברנשטיין בביצוע ווקאלי בזכות התורה", "entities": [{"start": 0, "end": 14, "label": "SINGER"}]}
+{"text": "יחזקאל הירשהורן - אהבת ישראל - ווקאלי", "entities": [{"start": 0, "end": 15, "label": "SINGER"}]}
+{"text": "לירוי ברגמן ואריאל כהן - מי האיש (ווקאלי)", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "מקהלת שירה - מחרוזת ישימך (ווקאלי)", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "משפחת 'מלכות' & יעל וולד - 'עוד ישבו'", "entities": [{"start": 16, "end": 24, "label": "SINGER"}]}
+{"text": "דותן שרף ועופר קמינר בסינגל רווי אמונה וביטחון בהשית 'והוא לבדו' (ווקאלי)", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "ארי שמאלוב - ומחה ה' דמעה - ווקאלי", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "אלירן פריברט & מיכאל לוי - כי טוב השם - ווקאלי", "entities": [{"start": 15, "end": 24, "label": "SINGER"}, {"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "אביהו ולנסי בגרסה ווקאלית ללהיט שלו מוכנים", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "אילן דמרי - אבא דואג להכל - ווקאלי", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "גל צ'בן ואורי חזקיה - ואהבת", "entities": [{"start": 0, "end": 7, "label": "SINGER"}]}
+{"text": "שיעור באידיש בנושא המדובר ה'קורנה' - א קאווע (5) מיט ר' כפיר נוה", "entities": [{"start": 56, "end": 64, "label": "SINGER"}]}
+{"text": "הערשי רוטנברג מרגש לרגל הילולת ר' ישעיל'ה  - ר' ישעי' בן ר' משה (ווקאלי)", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "אלן הוק - שבת שלום - ווקאלי", "entities": [{"start": 0, "end": 7, "label": "SINGER"}]}
+{"text": "שיעור באידיש בנושא המדובר ה'קורנה' - א קאווע (4) מיט ר' הדר קרייזל", "entities": [{"start": 56, "end": 66, "label": "SINGER"}]}
+{"text": "אבינועם גוטפרב & צבי זילבערשטיין - עננו (ווקאלי)", "entities": [{"start": 0, "end": 14, "label": "SINGER"}]}
+{"text": "אייל ואביו אליק עדני מגישים ביצוע ווקאלי לשיר לבחור נכון", "entities": [{"start": 11, "end": 20, "label": "SINGER"}]}
+{"text": "ראיון עם המשפיע ר' אהרון בסון שליטא על הקורות אתו בנגיף הקורונה", "entities": [{"start": 19, "end": 29, "label": "SINGER"}]}
+{"text": "אוריה שיף - שירת היונה - ווקאלי", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "מתתיהו הירשמן - נשמתי (אקפלה)", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "ילד הפלא שי מלכה שר רפאינו השם", "entities": [{"start": 9, "end": 16, "label": "SINGER"}]}
+{"text": "בנג'מין יוסף - לך עמי (ווקאלי)", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "שולם למר מגיש מנע מגיפה", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "אברהם שמעון מגיש 'שבתדיג' - בגירסה ווקאלית", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "דותן ליכטנפלד מגיש שעה מוסיקאלית של להיטים בגרסה ווקאלית", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "נגב עטרי עם גרסה ווקאלית לשירו עוד אבינו חי", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "גדי פוקס ויובל נחום - נחכה לך (ווקאלי)", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "אליהו טלקר והחזן שגיב ברוך בגרסה ווקאלית 'אמר רבי אלעזר'", "entities": [{"start": 17, "end": 26, "label": "SINGER"}, {"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "אלון אומדי - שברים (ווקאלי)", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "דור קוגן בביצוע נוסטלגי לנקדש את שמך", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "סטפן ונטורה - אתה קרוב  ווקאלי", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "אלעזר גבאי - נחכה לך וואקלי", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "יעקב אייזנבך (גרסה ווקאלית) רפאנו ה'", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "ערן יוסף בדואט מפתיע עם חנוך ליבוביץ מבצעים את ושמרו", "entities": [{"start": 0, "end": 8, "label": "SINGER"}, {"start": 24, "end": 36, "label": "SINGER"}]}
+{"text": "יפי ויסמן בביצוע מחזק - מי האיש", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "דוראל קמינסקי אברומי גלזר - בביצוע מרטיט באולפן לשיר עד אנה ה'", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "יוני חבין - רציתי לשיר", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "משה ברנס בביצוע אקוסטי - קלי", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "לאה גולדברג - דרכו של העולם", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "ילדי 'אגם שהם' וליאב אזולאי בביצוע לייב אורות", "entities": [{"start": 6, "end": 13, "label": "SINGER"}]}
+{"text": "שמחת חג מרכזית - בראשות הבעלי מנגנים ר' שימי יאמין ור' יגל נאמן", "entities": [{"start": 40, "end": 50, "label": "SINGER"}, {"start": 55, "end": 63, "label": "SINGER"}]}
+{"text": "מאור דסלר בסינגל חדש - קול תפילה", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "שרוליק מילר ובניו מברכים אתכם בברכת כהנים (נוסח חב''ד)", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "שרון ישר שר בגעגועים לירושלים", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "לירון קרני - תעיתי כשה אובד בקש עבדך", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "דורון אייל ובנו קדש ורחץ", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "אבירם ברודצקי - עם אחד", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "יוסי מצרי - כתר", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "הרצל סמירנוב & משה עזריאל - ושמחת בחגך", "entities": [{"start": 0, "end": 12, "label": "SINGER"}, {"start": 15, "end": 25, "label": "SINGER"}]}
+{"text": "מיילך בורנשטיין - כתר מלוכה - רמיקס (אליאב)", "entities": [{"start": 0, "end": 15, "label": "SINGER"}]}
+{"text": "שליו פרץ - שבת היא", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "ריאן ענבל & ירום רהט - מחרוזת מה אהבתי, הצמח צדק, ליבי, הטוב, צמאה", "entities": [{"start": 0, "end": 9, "label": "SINGER"}, {"start": 12, "end": 20, "label": "SINGER"}]}
+{"text": "ר' דולב גופר בסינגל נוסף - עין בעין", "entities": [{"start": 3, "end": 12, "label": "SINGER"}]}
+{"text": "אביגדור גביש - שמע ישראל", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "יונה קריאף מגיש - שברי מילים", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "דרור יילאו - ברוך המקום", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "מרדכי סמט ומיכאל מרסה - 'רק התורה'", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "אורן סולטן הלחין, עיבד ושר  שבח יקר וגדולה", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "עירן קדוש, פאר בורשטין ויוסי אמר איך זיץ", "entities": [{"start": 11, "end": 22, "label": "SINGER"}, {"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "נתנאל לוי ותזמורתו - נגינת המרפסות", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "ישועה אברהמוב - ברוגז רחם תזכור", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "ארי בן-ים - נשמת כל חי", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "עודד ויגדורצ'יק - רבונו של עולם", "entities": [{"start": 0, "end": 15, "label": "SINGER"}]}
+{"text": "טל יעסיס - קומזיץ", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "אריאל צור - ויהי נועם", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "יהונתן טל מגיש ונגינותי", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "ברק שלום - ניצוצות", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "מפגש מוזיקלי ומרגש בין אליהו דויטש לגדעון בויגנמן  והעלה ארוכה ומרפא", "entities": [{"start": 23, "end": 34, "label": "SINGER"}]}
+{"text": "רוי לב מגיש סינגל חדש - בורא עולם", "entities": [{"start": 0, "end": 6, "label": "SINGER"}]}
+{"text": "אגם עמאר מחדש - הלב שלי", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "מתנאל פרלמן ופנחס שוסיוב - הרבי היקר (My Dear Rebbe)", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "יואל פאלקוויטש - אעופה אשכונה", "entities": [{"start": 0, "end": 14, "label": "SINGER"}]}
+{"text": "ר' אייל דוד פיני קראוס ורביב ניר ושמחת בחגך", "entities": [{"start": 12, "end": 22, "label": "SINGER"}, {"start": 3, "end": 11, "label": "SINGER"}]}
+{"text": "אלקנה מוסרי, עדן ליבוביץ, שרולי וויליגר, אברומי גרמייזא ואברומי שוובל - כל המרחם", "entities": [{"start": 0, "end": 11, "label": "SINGER"}, {"start": 13, "end": 24, "label": "SINGER"}, {"start": 41, "end": 55, "label": "SINGER"}]}
+{"text": "8 שנים אחרי פטירתו של נער הפלא דותן עזרא ז''ל האזינו לשירו 'ונפשי'", "entities": [{"start": 31, "end": 40, "label": "SINGER"}]}
+{"text": "ר' יוסי פרל מגיש את לחנו של חולה הקורונה לכו נרננה", "entities": [{"start": 3, "end": 11, "label": "SINGER"}]}
+{"text": "בן ציון בורובסקי והילד אמנון יעקובי שרים מכניסי רחמים", "entities": [{"start": 0, "end": 16, "label": "SINGER"}, {"start": 23, "end": 35, "label": "SINGER"}]}
+{"text": "צח אריאל בביצוע רשמי למנע מגיפה", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "מאיר קלצקו במופע לייב של לרומם את המעריצים", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "לב סלוק בביצוע לבידוד 'חארשו'", "entities": [{"start": 0, "end": 7, "label": "SINGER"}]}
+{"text": "אלחנן חכימי - ימי קורונה", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "אריה נאמן בסינגל חדש – ''ממעמקים''", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "אלעד גפרי מחדש ומרענן את 'צמאה'", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "יונס אביב - ער האט א פלאן", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "עלי דובינסקי מארח חמישה פייטנים ''אנא תשבי''", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "אלנתן מורי ואביאל שלום מבקשים גאולה", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "דוד לייפר בשיר תפילה חדש הייל אונז אויס", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "אלעד עמדי ונדיר גרידי בדואט מרגש באידיש אבא איתי", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "שרון סורוצקין בסינגל בכורה חוסה", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "שלום - ילדי גדעון זכאי, קורן סקא ואורן סיגטי", "entities": [{"start": 24, "end": 32, "label": "SINGER"}, {"start": 12, "end": 22, "label": "SINGER"}]}
+{"text": "נעמה ביגדרוביץ בספיישל עם אמרי איטח, אבשלום גרינבלט וארי ברמן", "entities": [{"start": 26, "end": 35, "label": "SINGER"}, {"start": 0, "end": 14, "label": "SINGER"}, {"start": 37, "end": 51, "label": "SINGER"}]}
+{"text": "אדם קופמן מתפלל - תפילת אבינו מלכנו (קורונה)", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "29 שעת רחמים - סהר רוימי ורני שריקי", "entities": [{"start": 15, "end": 24, "label": "SINGER"}]}
+{"text": "06 גראמען - מור בניון", "entities": [{"start": 12, "end": 21, "label": "SINGER"}]}
+{"text": "05 גראמען - אלי ביר", "entities": [{"start": 12, "end": 19, "label": "SINGER"}]}
+{"text": "04 גראמען - אביגדור מסיכה", "entities": [{"start": 12, "end": 25, "label": "SINGER"}]}
+{"text": "שיעור באידיש על פרשת צו-שבת הגדול שנת תש''פ - בנושא המדובר ה'קורנה' - א קאווע (צווייטע) מיט ר' שאול נחום", "entities": [{"start": 95, "end": 104, "label": "SINGER"}]}
+{"text": "תזמורת זאלץ הלחין ושר סינגל חדש ''השם אחד''", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "עמנואל שמש בשיר חדש לרגל המצב 'כתר מלוכה", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "החזן דין שרון שר 'אני מאמין'", "entities": [{"start": 5, "end": 13, "label": "SINGER"}]}
+{"text": "מירי אלוני בסינגל חדש אני מאמין", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "דוד פראנק, מקהלות מלכות וחסידימלעך, ומונה 'אמר רבי אלעזר'", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "ליבל'ה ולדמן & רובי רוברטסון - אין עוד מלבדו", "entities": [{"start": 15, "end": 28, "label": "SINGER"}, {"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "אבישי יוסופוב בסינגל חדש ''אל תשליכני''", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "דוד האניג בסינגל חדש 'דווקא עכשיו'", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "אלישיב רוח, אריק ישראל ואבי הס שתהא תורתך", "entities": [{"start": 0, "end": 10, "label": "SINGER"}, {"start": 12, "end": 22, "label": "SINGER"}]}
+{"text": "יגל סטולרו ויעקב כהן מרגשים ''עמו אנוכי בצרה''", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "'שיר הלל' ו'פרחי הרא''ם' ב''אנא בכח'' של צבר אייזנר", "entities": [{"start": 41, "end": 51, "label": "SINGER"}]}
+{"text": "ראובן כהן בסינגל בכורה אחכה", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "דרור אייכנר מרגש עם 'מי שברך לחולה", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "גל גולדפלאם - רפא נא", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "איתן שמה של''ע חלה בקורונה בסינגל חדש ''לכו''", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "אברמי שטרויס מגיש את ''רפאנו'' בדואט עם בנו", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "רותם צברי בשיר חדש על המצב -געגועים לבני אדם", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "רוני דלומי & דביר כהן והלהקה קאבר - רפואה", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "המשפיע רבי אלכסנדר נמני בלהיט מעודד ומחזק זה לא הקורונה", "entities": [{"start": 11, "end": 23, "label": "SINGER"}]}
+{"text": "אבי נקש ונחמיה מימון מתחננים טאטע עננו", "entities": [{"start": 0, "end": 7, "label": "SINGER"}]}
+{"text": "שדה נתן בתפילת הלל מוזיקלית (במשך למעלה משעה)", "entities": [{"start": 0, "end": 7, "label": "SINGER"}]}
+{"text": "אריאל יורה יוצא עם שיר חדש אזכרה", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "בית ספר למוסיקה בסינגל חדש אתה עמדי", "entities": [{"start": 0, "end": 15, "label": "SINGER"}]}
+{"text": "אלכס מורנו בסינגל חדש - גאולה", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "ילד הפלא שליו גרינברג בקאבר ללהיט של שרולי ליפשיטץ עלה קטן", "entities": [{"start": 37, "end": 50, "label": "SINGER"}, {"start": 9, "end": 21, "label": "SINGER"}]}
+{"text": "58 - והיא שעמדה - נפתלי מנחם", "entities": [{"start": 18, "end": 28, "label": "SINGER"}]}
+{"text": "60 - שופכים לב כמים - נתן פוגל", "entities": [{"start": 22, "end": 30, "label": "SINGER"}]}
+{"text": "51 - ויהי נועם - ינאית בן-צבי", "entities": [{"start": 17, "end": 29, "label": "SINGER"}]}
+{"text": "41 - בנה ביתך - ריין זימן", "entities": [{"start": 16, "end": 25, "label": "SINGER"}]}
+{"text": "32 שיר ושבחה - סער זגדון", "entities": [{"start": 15, "end": 24, "label": "SINGER"}]}
+{"text": "28 שיר ושבחה - ירדן מנדלסון", "entities": [{"start": 15, "end": 27, "label": "SINGER"}]}
+{"text": "30 שיר ושבחה - מאיר קיי", "entities": [{"start": 15, "end": 23, "label": "SINGER"}]}
+{"text": "29 שיר ושבחה - אפק גרשון", "entities": [{"start": 15, "end": 24, "label": "SINGER"}]}
+{"text": "31 שיר ושבחה - משה בראל", "entities": [{"start": 15, "end": 23, "label": "SINGER"}]}
+{"text": "06 - רבי הוד סלושני שושן", "entities": [{"start": 9, "end": 19, "label": "SINGER"}]}
+{"text": "05 - רבי נוה רוטנברג שושן", "entities": [{"start": 9, "end": 20, "label": "SINGER"}]}
+{"text": "07 - רבי אליעד קופילוב שושן", "entities": [{"start": 9, "end": 22, "label": "SINGER"}]}
+{"text": "רוברט חן שר טובים מאורות", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "שיעור באידיש על פרשת ויקרא שנת תש''פ - בנושא המדובר ה'קורנה' - א קאווע מיט ר' אלישי קוקס", "entities": [{"start": 78, "end": 88, "label": "SINGER"}]}
+{"text": "יגל טולדנו ותזמורתו של דני אבידני בשעה וחצי של הופעה משובחת", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "אביעד שטיין שר אבינו מלכנו במופע צמאה", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "פנחס רובין שר לזכרו של צביקי ולדר ז''ל - רוץ כצבי", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "חיים באנעט התארח שוב לקומזיץ אצל פיצ'ה בן שמעון", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "גרשון לוין מבקש וקבץ נדחינו (מילים מהסליחות)", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "אילי ליטיצ'בסקי מחזק אין מה לפחד'", "entities": [{"start": 0, "end": 15, "label": "SINGER"}]}
+{"text": "אליאם ברומברג מ. גנטשוף ואיתן ארבוב - ''דא וואוינט א איד''", "entities": [{"start": 0, "end": 13, "label": "SINGER"}, {"start": 14, "end": 23, "label": "SINGER"}]}
+{"text": "אורין חמדי שר ומחזק באידיש למצב שמתפללים בבית", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "יונתן פוירשטיין - נשמת", "entities": [{"start": 0, "end": 15, "label": "SINGER"}]}
+{"text": "שגיב לביא בפיוט התפילה התימני בעקבות המצב", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "נתיב איטח ותזמורת המנגנים בשירה מרגשת בליל פורים", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "ברל חגי ברסון מבצע יחד עם יונה ליפשיץ את להיט החתונות שלו כולנו נזמר", "entities": [{"start": 0, "end": 7, "label": "SINGER"}, {"start": 26, "end": 37, "label": "SINGER"}]}
+{"text": "בן-אל בהם מארח את ילד הפלא דוד חכם הרסון - שעת רחמים", "entities": [{"start": 0, "end": 9, "label": "SINGER"}, {"start": 27, "end": 40, "label": "SINGER"}]}
+{"text": "בר הראל במיוחד לימים אלה- -הו קורונה", "entities": [{"start": 0, "end": 7, "label": "SINGER"}]}
+{"text": "לני סולומון מחזק את החתנים והכלות במצווה טאנץ", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "רמי קורדובה וניסים ברוך בקומזיץ של שעתיים מלאות", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "מרדכי שטילרמן מפתיע בסינגל חדש – באהבה תקבל", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "ר' מאיר ברוק הי''ו בדיבורי התחזקות מלווי נגינה על התבודדות ואמונה במצב הקורונה", "entities": [{"start": 3, "end": 12, "label": "SINGER"}]}
+{"text": "18 רבי צביקי לוקר", "entities": [{"start": 7, "end": 17, "label": "SINGER"}]}
+{"text": "16 רבי אבירם ברוך שושן 3", "entities": [{"start": 13, "end": 22, "label": "SINGER"}]}
+{"text": "09 יציאת מצרים - ר' עובד מוניס 5", "entities": [{"start": 20, "end": 30, "label": "SINGER"}]}
+{"text": "08 יציאת מצרים - ר' אלון גמזו 4", "entities": [{"start": 20, "end": 29, "label": "SINGER"}]}
+{"text": "07 יציאת מצרים - ר' רוג'רס פארק 3", "entities": [{"start": 20, "end": 31, "label": "SINGER"}]}
+{"text": "06 יציאת מצרים - ר' איתן חכים 2", "entities": [{"start": 20, "end": 29, "label": "SINGER"}]}
+{"text": "05 יציאת מצרים - ר' אבשלום אייצ'או", "entities": [{"start": 20, "end": 34, "label": "SINGER"}]}
+{"text": "ניסים שעשע בסינגל חדש ליום ההילולא רבי ר' אלימלך", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "רז יעקב שר מחר", "entities": [{"start": 0, "end": 7, "label": "SINGER"}]}
+{"text": "מאיר גרינימן בשיר הרגעה מול בהלת הקורונה טוב ה' לכל", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "רבי אלקנה רפפורט שר עם תלמידיו העצה לקורונה - רק אמונה", "entities": [{"start": 4, "end": 16, "label": "SINGER"}]}
+{"text": "ניל פלט, נריה שורצולד, רן ארדיטי ואלי דאקס  - כי המצווה", "entities": [{"start": 0, "end": 7, "label": "SINGER"}, {"start": 9, "end": 21, "label": "SINGER"}, {"start": 23, "end": 32, "label": "SINGER"}]}
+{"text": "שלמה טויסיג בסינגל שלישי חדש תתחיל לחייך", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "עמית אלקלעי עם שיר חדש השם ישמרך", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "יעקב שטארק בסינגל בכורה מה טובו", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "נדב ביטון והסימפונית במחרוזת שירי רגש", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "שלום ביטון' ואלעד עמיר במחרוזת חופה מרגשת", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "איל גולן - מתוך תמימות", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "ציון גרימברג ויגל אלנקרי - מקודשת", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "אשכול רובינשטיין בתוכנית עם אבינועם וורקו לרגל צאת אלבומו החדש גיוואלדיג", "entities": [{"start": 28, "end": 41, "label": "SINGER"}, {"start": 0, "end": 16, "label": "SINGER"}]}
+{"text": "גלית מלכא מארח את משה אילוביץ בשיר", "entities": [{"start": 18, "end": 29, "label": "SINGER"}, {"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "עמוס שביט בשיר חדש תודה לאבא", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "עומר טמנו במשלוח מנות מוזיקלי הולך ללמוד", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "עמוס ביטון - מחרוזת להיטים אנרגטית", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "איליי חן משחרר סינגל חדש גשם", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "ענר ששון וצבקי נוילנדר בסינגל מרגש תפילות", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "עזר נישואין ישיבת נחלת ישי ליבה", "entities": [{"start": 23, "end": 31, "label": "SINGER"}]}
+{"text": "שערי תורה די סענטר - אלון לוין", "entities": [{"start": 21, "end": 30, "label": "SINGER"}]}
+{"text": "מאקווא  ריף אשכנזי & סענדי שטיינער", "entities": [{"start": 8, "end": 18, "label": "SINGER"}]}
+{"text": "14.שיר השמאטע-הראל סעדה", "entities": [{"start": 14, "end": 23, "label": "SINGER"}]}
+{"text": "09.הטוב-ששון שגיא", "entities": [{"start": 8, "end": 17, "label": "SINGER"}]}
+{"text": "12.אך לאלוקים-חבד-עם מאור הרשטיין", "entities": [{"start": 21, "end": 33, "label": "SINGER"}]}
+{"text": "05.שושנת יעקב-רפי בסוב", "entities": [{"start": 14, "end": 22, "label": "SINGER"}]}
+{"text": "יהודי גלילי, נהוראי מליחי ובראל אבירם ריגשו בחופה", "entities": [{"start": 13, "end": 25, "label": "SINGER"}]}
+{"text": "שני רחמנוב בסינגל חדש ברכה והצלחה'", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "ילד הפלא אושר שורץ הרטיט עם הלהיט כאיל תערוג", "entities": [{"start": 9, "end": 18, "label": "SINGER"}]}
+{"text": "אברהם זאב בסינגל חדש וקרבתנו", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "פנחס מוניס בסינגל שמיני רק אחד קובע", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "הרב עמאר - אוירא דארץ ישראל - דוגמה", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "יהודה לבנון מגיש א פרישע טאנץ 4 דוגמה", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "הזמר רן גולדברג מגיש מחרוזת חתונה", "entities": [{"start": 5, "end": 15, "label": "SINGER"}]}
+{"text": "#עמיר פרץ חזר עם שמחות החיים 8 - דוגמה", "entities": [{"start": 1, "end": 9, "label": "SINGER"}]}
+{"text": "יוסף ג'ואי ניוקמב וילד הפלא שמעון סיבוני בסינגל חדש - טוב להודות", "entities": [{"start": 28, "end": 40, "label": "SINGER"}, {"start": 0, "end": 17, "label": "SINGER"}]}
+{"text": "שמואל חתוכה בפיוט נעימה לי מתוך אלבומו החדש 'קראתי בכל לב'", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "החדש של ירון מרדכייב 'לנצח'", "entities": [{"start": 8, "end": 20, "label": "SINGER"}]}
+{"text": "מור שומרוני ריגש בציון של רבי ישעיל'ה בקערעסטיר", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "תם רייזמן ועירן אסייג על במה אחת", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "לי זוהר וראובן סמון מגישים חי השם", "entities": [{"start": 0, "end": 7, "label": "SINGER"}]}
+{"text": "יהודה סעדו בסינגל חדש קוה", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "משנכנס אדר, משה קוסביצקי מקפיץ את ירושלים", "entities": [{"start": 12, "end": 24, "label": "SINGER"}]}
+{"text": "צדוק גולן מגיש את אלבום ה-11 געוואלדיג - דוגמה", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "מאחורי השירים של האלבום החדש של מוריס מוגרבי  - אנא אלך", "entities": [{"start": 32, "end": 44, "label": "SINGER"}]}
+{"text": "אור קלי מארח את צחי ווקר ילדי", "entities": [{"start": 0, "end": 7, "label": "SINGER"}, {"start": 16, "end": 24, "label": "SINGER"}]}
+{"text": "הרצל רוניס - כל המלמד", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "אלכסנדר אורן מגיש סינגל בכורה סוחף שירת היונה", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "שמילי שטיינמעץ אומר 'מזמור לתודה'", "entities": [{"start": 0, "end": 14, "label": "SINGER"}]}
+{"text": "שון נלסון מגיש לחן חדש 'ושכנתי'", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "הדר לב & גיל עקיביוב - יש חתונה פה", "entities": [{"start": 9, "end": 20, "label": "SINGER"}, {"start": 0, "end": 6, "label": "SINGER"}]}
+{"text": "ילד הפלא יהלי מוסקוביץ וערן ציגלר בלהיט החדש 'לעשות רצונך", "entities": [{"start": 9, "end": 22, "label": "SINGER"}]}
+{"text": "אלישע בנאי אנטון שיפר ואברהם אוחנה במחרוזת חסידית אותנטית", "entities": [{"start": 0, "end": 10, "label": "SINGER"}, {"start": 11, "end": 21, "label": "SINGER"}]}
+{"text": "שרה אהרונסון עם הגרסה האלקטרונית לשומר עלינו", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "מייקל פרי בסינגל קצבי חדש ואמר ביום ההוא", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "יואל נוף בסינגל חדש ומקפיץ ברוך הוא", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "משה שטעקעל מגיש סינגל חדש אלפי זהב", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "הזמר והיוצר אלישמע צ'ולפייב בסינגל חדש שעה אחת", "entities": [{"start": 12, "end": 27, "label": "SINGER"}]}
+{"text": "סהר שמילוביץ עם להקת רוג'רס פארק", "entities": [{"start": 0, "end": 12, "label": "SINGER"}, {"start": 21, "end": 32, "label": "SINGER"}]}
+{"text": "רונאל קאפח ופנחס הלוי ניגון לשבת ויוט", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "אלון סיסאי חוזר עם שיר מקסים בטעם של פעם - עין טוב", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "אליהו רפאל כאין ומשפחתו (פרידמן) משמחים ושרים בסיום הש''ס", "entities": [{"start": 0, "end": 15, "label": "SINGER"}]}
+{"text": "חורחה דרקסלר מארח את אביאור היימן – וחסד ה׳", "entities": [{"start": 21, "end": 33, "label": "SINGER"}, {"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "אברומי כהן ושגב דרויש - אש 3 - תקציר האלבום", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "החזן ראם ששון ביצירה של פאר מרקל ז''ל", "entities": [{"start": 5, "end": 13, "label": "SINGER"}, {"start": 24, "end": 32, "label": "SINGER"}]}
+{"text": "אסף שושן מארח את אלי שנידמן קלי", "entities": [{"start": 17, "end": 27, "label": "SINGER"}, {"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "יצחק בלוי מבצע את 'יענקל'ה הכונס' - באידיש", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "פלטיאל בומבך בסינגל חדש וקצבי - צועקים", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "איליי אלחדיף מחדש את אני מאמין של ניל מנדלבאום", "entities": [{"start": 0, "end": 12, "label": "SINGER"}, {"start": 34, "end": 46, "label": "SINGER"}]}
+{"text": "אהרל'ה ויינטרוב וילד הפלא יונתן שיינפלד מגישים לחן חדש 'אשר ברא'", "entities": [{"start": 26, "end": 39, "label": "SINGER"}, {"start": 0, "end": 15, "label": "SINGER"}]}
+{"text": "מקהלת רפאל מלול יוצאים באלבום מספר 2 - דוגמה", "entities": [{"start": 6, "end": 15, "label": "SINGER"}]}
+{"text": "יוחנן הסנדלר ובניה מכלוביץ לולו בגרסת רמיקס ל-'אתה מרים אותי תמיד' (אשר הלחמי)", "entities": [{"start": 0, "end": 12, "label": "SINGER"}, {"start": 68, "end": 77, "label": "SINGER"}]}
+{"text": "אחדות הנוער ויוסף קרדונר בקאבר נוסטלגי לאלי שפריי", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "רן מימון ותזמורתו & שגב אלנקוה - נחכה לך", "entities": [{"start": 0, "end": 8, "label": "SINGER"}, {"start": 20, "end": 30, "label": "SINGER"}]}
+{"text": "פיני אינהורן והקאפעליע - ניגון קדיש (דרי מעלה)", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "חנוך דנחי בשירו הנשמה רוצה יותר", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "יואל פישר מגיש סינגל ביכורים - עד אליך", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "אפי לייבוביץ', אופק אייד, דודו מוטאדה - במחרוזת רמיקס ישראלי", "entities": [{"start": 15, "end": 24, "label": "SINGER"}, {"start": 26, "end": 37, "label": "SINGER"}]}
+{"text": "שירה חכמון משיק אלבום שני אנה אלך", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "גבע סובולבסקי בשיר חדש להאמין בעצמך", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "תמר כדורי & אביאל שני - ניגון התוועדות שמח מתוך חב''ד 4", "entities": [{"start": 0, "end": 9, "label": "SINGER"}, {"start": 12, "end": 21, "label": "SINGER"}]}
+{"text": "הזמר והיוצר גבי שבו משיק סינגל חדש קרבת אלוקים לי טוב", "entities": [{"start": 12, "end": 19, "label": "SINGER"}]}
+{"text": "שלמה יהודה רכניץ ובנימין דרוק ואיליי קנטור מגישים קאבר משובח לשבת שירה", "entities": [{"start": 0, "end": 16, "label": "SINGER"}]}
+{"text": "ליאל עמיחי ניגון הבינוני מתוך התקליטור סדר ניגונים", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "מנדי ווייס בסינגל חדש לקראת חתונת בתו מסיני בא", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "רוני גרונר בסינגל חדש נכספתי", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "אלון אור (מלונדון) מארח הזמר האחים רוטשילד – תורה פארשטאנד", "entities": [{"start": 29, "end": 42, "label": "SINGER"}, {"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "עופרי חדד בסינגל חדש 'מכוון גבוה'", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "לכבוד שבת שירה מגישים אוהד מושקוביץ, מקהלת הילדים חסידימלע'ך מחרוזת שכולה 'שירה", "entities": [{"start": 22, "end": 35, "label": "SINGER"}]}
+{"text": "דין תירוש משיק סינגל חדש עוד יבוא היום", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "ציון חיים יהונתן מלכה ויצחק קרית - חב''ד 4 - תקציר האלבום", "entities": [{"start": 10, "end": 21, "label": "SINGER"}, {"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "בניה אדוני & אנרגיה במחרוזת ריקודים", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "תמיר לוי מרגש במחרוזת חופה", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "נערי הפלא עקיבא וואזנר וכתריאל לוי בין קודש לחול קאבר להקת אידיש וסתיו מרגלית", "entities": [{"start": 10, "end": 22, "label": "SINGER"}, {"start": 54, "end": 64, "label": "SINGER"}]}
+{"text": "אברהם שלומי בסינגל 'באתי לגני'", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "להקת רבותי משחרר סינגל המוקדש לדונאלד טראמפ נגד ההדחתו טראמפ'לה", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "ביצוע מרגש של אהרון מילר לילד החולה – הנני", "entities": [{"start": 14, "end": 24, "label": "SINGER"}]}
+{"text": "אהרלה סאמ'ט, יעקב דאסקל, אסף לוי וויקטור חזן עם להיט השנה ניגון לעלוב", "entities": [{"start": 25, "end": 32, "label": "SINGER"}]}
+{"text": "אביאל עדי התארח אצל פיצ'ה בן שמעון", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "משה בן גוזי באלבום חדש – שירת רבים", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "משה ירדן - אתה קרוב", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "בן-ציון שלמה ומקהלת 'זמרה' בחופה", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "נריה רוזינר ר' אלון הלל וילד הפלא מגישים אז ביום השביעי", "entities": [{"start": 15, "end": 23, "label": "SINGER"}, {"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "ר' שלום סבג בשיר חדש ומרגש שלוימל'ה בעט און בעט", "entities": [{"start": 3, "end": 11, "label": "SINGER"}]}
+{"text": "מעיין רכטר, מנדי בריל ודובי בר חורין - א צובראכן הארץ", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "פנחס שיינברג וארז מושקוביץ- סדר העבודה", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "מעיין קורמן ואסי נסים בדואט מרגש – לב שבור", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "די ג'י צחי אזולאי מארח את אלי יפה יפה ותמה בגרסת רמיקס", "entities": [{"start": 26, "end": 33, "label": "SINGER"}, {"start": 7, "end": 17, "label": "SINGER"}]}
+{"text": "לירז ארליך שוורץ, יונתן גרובייס והקלידן יידל כהנא - מסיבת הודיה בג'רזי סיטי", "entities": [{"start": 0, "end": 10, "label": "SINGER"}, {"start": 18, "end": 31, "label": "SINGER"}]}
+{"text": "חי בלגזל חשף שיר חדש וריגש עם שיר ישן ב'סיום השס", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "דב אינדיג ברמיקס תדליק את האש", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "אליה טוך הרטיט את פריז עם לב טהור", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "אלבום בכורה לזמר חווה צימבליסט אין עוד מלבדו", "entities": [{"start": 17, "end": 30, "label": "SINGER"}]}
+{"text": "דניאל שפירא מארח באלבום חדש והיה לארז אדיר", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "אפרים פיליפ מארח את נועם יששכר – אחת ולתמיד", "entities": [{"start": 20, "end": 30, "label": "SINGER"}, {"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "גרשון אלברטס בגרסת רמיקס לשיר שני קולות", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "אמיר זיידמן בהפקה מרגשת לשירו 'בריוואלע", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "יעקב בן חמו הלחין, צלי שטרן שר – כל מעייני", "entities": [{"start": 19, "end": 27, "label": "SINGER"}, {"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "ראיון מרגש!!! (באידיש) עם הרב עידו קורין ור' אהרן שם טוב", "entities": [{"start": 45, "end": 56, "label": "SINGER"}, {"start": 30, "end": 40, "label": "SINGER"}]}
+{"text": "חיה שור יואב ברסלויער ומאיר גרין אלו הם הצדיקים", "entities": [{"start": 0, "end": 7, "label": "SINGER"}, {"start": 8, "end": 21, "label": "SINGER"}]}
+{"text": "הערשי רוטנבערג משיק סינגל חדש השבעתי", "entities": [{"start": 0, "end": 14, "label": "SINGER"}]}
+{"text": "אייל מגנזי מגיש מחרוזת חפלה", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "ארי הלוי התארחו בקומזיץ מלווה מלכה", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "אהוד גולדברג ואהרון שטייניץ, מגישים את שומר עלינו בגרסת הרמיקס", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "סיני אלפסי ויקותיאל פרטוש מרגשים במחרוזת נוסטלגית", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "אליקים גרמן שר על המסע של איש פשוט", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "נדב פולצ'ק לכבוד סיום הש''ס באלעד אשרינו", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "נבו אליהו, נחמן זלטא, גפן מגידש, וכ15,000 איש שרים 'המלאך'", "entities": [{"start": 0, "end": 9, "label": "SINGER"}, {"start": 11, "end": 20, "label": "SINGER"}, {"start": 22, "end": 31, "label": "SINGER"}]}
+{"text": "עירן עמיר בסינגל חדש עוד אבינו חי", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "רועי אדרי מארח את יוסף חוריש  - יונתי", "entities": [{"start": 18, "end": 28, "label": "SINGER"}, {"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "הסינגל החדש של לני אלימי שמחה שלימה", "entities": [{"start": 15, "end": 24, "label": "SINGER"}]}
+{"text": "אלעד גינצברג וצוף עטרי בלחן של האדמור מפיטסבורג - כד יתבין", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "רפאל וויס בסינגל חדש הכל ממך", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "גרשון אלמלך מבצע את הלחן של לידור גייר הנה קל ישועתי", "entities": [{"start": 28, "end": 38, "label": "SINGER"}, {"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "על מה צמים בעשרה בטבת הרב מוטי קשרי מסביר", "entities": [{"start": 26, "end": 35, "label": "SINGER"}]}
+{"text": "איציק ווייס בשיר נוקב ממה אתה בורח", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "נועם טל מקפץ ומבצע את 'אהיים'", "entities": [{"start": 0, "end": 7, "label": "SINGER"}]}
+{"text": "בן ניסן מגיש כבר לא פוחד", "entities": [{"start": 0, "end": 7, "label": "SINGER"}]}
+{"text": "אביעד גוזלן בסינגל ביכורים – שמח תשמח", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "רן לוקש ויוסי לאובר מגישים שיר חדש לכבוד סיום השס גוט יום טוב רבנן", "entities": [{"start": 0, "end": 7, "label": "SINGER"}]}
+{"text": "יוסי הולצמן אח של ארי בסינגל בכורה לכבוד חתונת ידידו אפרים שכטר", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "זאב ברנשטיין ו״נרננה״ בסיום הש״ס בסיפורו המרטיט של 'יענקלה הכונס'", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "נמואל הרוש ו'אידישע נחת' בשיר 'הדרן' לכבוד סיום השס", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "צמד ה Djs מארח את אפיק רם והריקותי", "entities": [{"start": 18, "end": 25, "label": "SINGER"}]}
+{"text": "הגראמער דילן שנער מרגש וסוחט דמעות לחתן יתום בלונדון", "entities": [{"start": 8, "end": 17, "label": "SINGER"}]}
+{"text": "לכבוד סיום השס מני גאולה - לולי תורתך", "entities": [{"start": 15, "end": 24, "label": "SINGER"}]}
+{"text": "ישמעאל קדישזון בסינגל חדש ומקפיץ – 'הדרן'", "entities": [{"start": 0, "end": 14, "label": "SINGER"}]}
+{"text": "בועז רומנו עם סינגל חדש 'שברים", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "הזמר יותם זילברמן מגיש סינגל שני 'זה הבית שלי'", "entities": [{"start": 5, "end": 17, "label": "SINGER"}]}
+{"text": "בן-אל היימן & איתם פורן & ישי בן צבי - הכל הבו גודל", "entities": [{"start": 0, "end": 11, "label": "SINGER"}, {"start": 26, "end": 36, "label": "SINGER"}, {"start": 14, "end": 23, "label": "SINGER"}]}
+{"text": "עזרא אייזנשטיין מגיש סינגל שני הסיפור שלך", "entities": [{"start": 0, "end": 15, "label": "SINGER"}]}
+{"text": "עמיר מלאכי ותזמורתו - מארחים את אוהד אסרף, מרום סלע ועומר לוזון ומשלב מזרח ומערב", "entities": [{"start": 32, "end": 41, "label": "SINGER"}, {"start": 43, "end": 51, "label": "SINGER"}, {"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "שחף נחום וינאי אביטן מגישים לחן חדש - תורה חיים היא", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "יהושע מרום עם קאבר משובח בכורה מיינע תפילין", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "אלחנן הלפגוט וניצן פרויס בליווי חנניה קרישבסקי חננו ועננו", "entities": [{"start": 32, "end": 46, "label": "SINGER"}]}
+{"text": "החזן איצי אקרמן מבצע את הלחן של צביקה פישר רחם נא", "entities": [{"start": 32, "end": 42, "label": "SINGER"}, {"start": 5, "end": 15, "label": "SINGER"}]}
+{"text": "לישי גלזר ואברומי גענוד בביצוע הלב שלי של פנחס פינטו", "entities": [{"start": 0, "end": 9, "label": "SINGER"}, {"start": 42, "end": 52, "label": "SINGER"}]}
+{"text": "ירין פייגין ועינב הררי והריקותי לכם ברכה", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "בהרוז אהרוני ומקהלת ''ידידים'' במחרוזת מקפיצה", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "יענקי לעממר שר את היצירה של החזן איליי מורדוב לחנוכה", "entities": [{"start": 33, "end": 45, "label": "SINGER"}]}
+{"text": "גדעון אנוש ויהב טקה בדואט חדש 'שומר עלינו'", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "החזן נוי גזיאל וציון טייב של יוסל'ה קלצקין מגישים אנו עמלים", "entities": [{"start": 5, "end": 14, "label": "SINGER"}]}
+{"text": "רביד פריזנד בסינגל חופה מרגש – בואי בשלום", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "‏אביחי פז ויהלי שנור במחרוזת הלל - וואקלי", "entities": [{"start": 1, "end": 9, "label": "SINGER"}]}
+{"text": "אייל דובמן ובנו ושילה אתיאס במחרוזת להיטים", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "יוסי אשכנזי מרגש עם היצירה תנא דבי אליהו של דודי אייזנשטיין", "entities": [{"start": 0, "end": 11, "label": "SINGER"}, {"start": 44, "end": 59, "label": "SINGER"}]}
+{"text": "הגראמער נפתלי ארנפלד עם ילד הפלא גד אסולין - לב נשבר", "entities": [{"start": 8, "end": 20, "label": "SINGER"}, {"start": 33, "end": 42, "label": "SINGER"}]}
+{"text": "שמשי ניימן מגיש ה'תזמורת פייער' באלבום חדש עם מיטב הלהיטים", "entities": [{"start": 0, "end": 10, "label": "SINGER"}, {"start": 18, "end": 30, "label": "SINGER"}]}
+{"text": "דניאל חן והסימפונית - שלום עליכם", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "ר׳ עוז שיבי עם מחרוזת שירים באידיש", "entities": [{"start": 3, "end": 11, "label": "SINGER"}]}
+{"text": "ירמיהו פיחה שר בשבילי נברא העולם", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "דובי מיזלעס, נח איגר ואודי רוזנטל מגישים שבת שלום", "entities": [{"start": 13, "end": 20, "label": "SINGER"}]}
+{"text": "יצהר כלילי & רונלד כהן - השם אלוקינו", "entities": [{"start": 13, "end": 22, "label": "SINGER"}, {"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "54 רבי אביב גפן פוזן", "entities": [{"start": 7, "end": 15, "label": "SINGER"}]}
+{"text": "55 רבי גדליה שמאי פוזן", "entities": [{"start": 7, "end": 17, "label": "SINGER"}]}
+{"text": "05 ניב מלר - דף היומי", "entities": [{"start": 3, "end": 10, "label": "SINGER"}]}
+{"text": "06 רבי גרשון קפלן שושן¨", "entities": [{"start": 7, "end": 17, "label": "SINGER"}]}
+{"text": "אונטערן חופה מיט גיורא שבו", "entities": [{"start": 17, "end": 26, "label": "SINGER"}]}
+{"text": "אלקנה שפירא שר כל עצמותי תאמרנה מתוך צמאה 5", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "הזמר מנדי גפנר בביצוע מרגש לשיר יהיו לרצון", "entities": [{"start": 5, "end": 14, "label": "SINGER"}]}
+{"text": "עמיחי גרנות ורפאל נוראל בשיר חדש לך לבדך", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "מייק ניסימוב בביצוע ניגון א מאשינקע", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "אהרון אוסטרליץ לכבוד יט כסלו - חג הגאולה", "entities": [{"start": 0, "end": 14, "label": "SINGER"}]}
+{"text": "אוליבר קופמן ואיתי לחמני בפרויקט משותף יוצר מידו", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "הרב אליהו צור בדואט עם הרב מתן בנישתי אילנא דחיי", "entities": [{"start": 4, "end": 13, "label": "SINGER"}, {"start": 27, "end": 37, "label": "SINGER"}]}
+{"text": "טום דמפסי ונטע מגן - הגיע עת רקוד", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "עוז גדי שר למוישי הולצברג בבר מצווה את הלב שלי", "entities": [{"start": 0, "end": 7, "label": "SINGER"}]}
+{"text": "מרדכי זלצר & מתן שטרק - כד יתבון", "entities": [{"start": 13, "end": 21, "label": "SINGER"}]}
+{"text": "אמרי הנובר שר – 'אתה כאן' בדרך לאלבום שני", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "גד אוחיון שר כצלה לקל", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "עופר קדמי בסינגל מקפיץ וראשון 'שוש אשיש", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "טוביה ללזרי בסינגל חדש פסיעותיי", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "יוסי גרין מארח את היוצר והגיטריסט אריק גלוסקא – דגל לבן", "entities": [{"start": 34, "end": 45, "label": "SINGER"}, {"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "עמית כזום בסינגל חדש אבא תודה", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "אלבום חדש 'לרביד קריגרים' - מבית ר' יוסי בן דוד כהנא - דוגמא", "entities": [{"start": 36, "end": 47, "label": "SINGER"}]}
+{"text": "ארז שוטלנד ולהקת 'לב טהור' בדואט – כולי שלך", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "מירון וולף אומר תודה בסינגל חדש - לפיכך", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "איליה טלוי ויהל ולצר מרקידים עם ניגון באיאן", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "הביצוע המחודש של אבנר גומה 'לנגן ולנגן'", "entities": [{"start": 17, "end": 26, "label": "SINGER"}]}
+{"text": "דוד שווארץ בקאבר באנגלית ובעברית להלב שלי של יהודה קובלסקי", "entities": [{"start": 45, "end": 58, "label": "SINGER"}]}
+{"text": "מאור גורדין בראיון במוצש חי בהשקת אלבומו החדש דא וואוינט א איד", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "לוי פאלקאוויטש ונדב אלוני שרים 'הוי דן' של ג'קי מקייטן", "entities": [{"start": 43, "end": 54, "label": "SINGER"}]}
+{"text": "עומר רדעי בשיר הראשון מאלבומו החדש כל הכבוד - 'לך'", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "ישעיה תיבון ותזמורתו במחרוזת אנרגיה", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "אלישע פרידמן שר את שירו החדש ואני קרבת אלוקים לי טוב", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "נאור ראבד, גיא פליישר, שלוימי גוטליב - מחרוזת חסידית מזרחית", "entities": [{"start": 0, "end": 9, "label": "SINGER"}, {"start": 11, "end": 21, "label": "SINGER"}]}
+{"text": "אורעד חבה וזמירות בקאבר ללהיט של פריד – אבא", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "‫ אבי חן & שרגי גרסטנר - די גאולה טאנץ", "entities": [{"start": 2, "end": 8, "label": "SINGER"}, {"start": 11, "end": 22, "label": "SINGER"}]}
+{"text": "רותם אטדגי - אימתי קאתי מר מתוך 'צמאה 5'", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "דוד מרדכי בראונשטיין בסינגל חדש סוחף ומרגש בהתעטף עלי רוחי", "entities": [{"start": 0, "end": 20, "label": "SINGER"}]}
+{"text": "החזן בנימין לנדאו שר שהחיינו בחתונת בנו", "entities": [{"start": 5, "end": 17, "label": "SINGER"}]}
+{"text": "הזמר ליאו גרניט במחרוזת אנרגיה בחתונה", "entities": [{"start": 5, "end": 15, "label": "SINGER"}]}
+{"text": "אבי קונטנר ובנו בשיר מרגש אבא שלי", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "בועז גרובשטיין בשיר לכבוד מעמדי סיומי השס בזכות התורה", "entities": [{"start": 0, "end": 14, "label": "SINGER"}]}
+{"text": "דוד קליגר ו-3,000 איש, בביצוע המוני לשיר 'אבא'", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "עתי הייזלר שר חבד מתוך אלבומו השני בסדרת היו זמנים", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "שרולי וזיו וקניןאבר ללהיט נחכה לך של מקהלת חסידי מודז'יץ וג'וי גבריאל", "entities": [{"start": 37, "end": 56, "label": "SINGER"}]}
+{"text": "להקת ארמוניה ו'ידידים' עם מודים לקראת סיום השס", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "רחל זלצר בסינגל חדש – געזונט", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "פאל פהר בסינגל חדש ונוגע – שלהבת הנשמה", "entities": [{"start": 0, "end": 7, "label": "SINGER"}]}
+{"text": "רפאל דניאל כהן & יענקי אויש 'החופה הגדולה בארץ'", "entities": [{"start": 0, "end": 14, "label": "SINGER"}, {"start": 17, "end": 27, "label": "SINGER"}]}
+{"text": "בניה כוכב בסינגל חדש עדיין ילד", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "שחף מנדלאוי - כאפ א טענצעל (תפוס ריקוד)", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "להיט השמחה החסידי החדש של צור עומיסי אין אנחנו מספיקים", "entities": [{"start": 26, "end": 36, "label": "SINGER"}]}
+{"text": "יונתן סבה שרים לחתני בר המצווה - ברכני", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "ויקטור רבייב מגיש נודה לך", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "אריה ארליך בסינגל השני איני יכול לבדי", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "ציון צלאל במוצש חי לאלבומו החדש הרצליך 2", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "ג'קי אטיאס אלורו מארח את אבי עברי בניגון החתונה", "entities": [{"start": 0, "end": 10, "label": "SINGER"}, {"start": 25, "end": 33, "label": "SINGER"}]}
+{"text": "פינקי וועבר ויחזקאל יעקובזון בדואט מרגש ומיוחד נחכה לך", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "הסינגל החדש של שלמה זוועהיל לב נשבר", "entities": [{"start": 15, "end": 27, "label": "SINGER"}]}
+{"text": "עוזי חממי שר לקדושי הפיגוע בהר נוף אבינו עשה", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "צביקה צור מחדש את הניגון החבדי הותיק אין עוד מלבדו, מתוך צמאה 5", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "קול חי מיוזיק - מצעד שירי ר' דורי גרמה לכבוד 25 שנה", "entities": [{"start": 29, "end": 38, "label": "SINGER"}]}
+{"text": "גד ואביו עומרי בגימוב בשיר שמור ישראל", "entities": [{"start": 9, "end": 21, "label": "SINGER"}]}
+{"text": "אמיר לקנר יצר 'קאבר' ל'בין קודש לחול'", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "מיטב שיריו של ר' הערשי וייס בביצוע מיטב החזנים~1", "entities": [{"start": 17, "end": 27, "label": "SINGER"}]}
+{"text": "אראל גינזברג בסינגל חדש חלון ברקיע", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "ברוך עבוד בסינגל חדש אני מוסר נפשי", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "צוריאל ווקנין באלבומו החמישי דא וואוינט א איד - (כאן גר יהודי) - דוגמה", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "מרדכי חלמיש בסינגל חדש לא נשבר", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "נדיב אליה & אודי חסון - 'ווען משיח וועט קומען' לקראת ביקור האדמור מסאטמר בארהק", "entities": [{"start": 12, "end": 21, "label": "SINGER"}, {"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "אלעזר וולקן מארח אלון אלימלך - בשבילך נברא עולם", "entities": [{"start": 0, "end": 11, "label": "SINGER"}, {"start": 17, "end": 28, "label": "SINGER"}]}
+{"text": "הגראמער יהוידע הוכברג מפתיע בקטע מצוה טאנץ חדש ומרגש", "entities": [{"start": 8, "end": 21, "label": "SINGER"}]}
+{"text": "נוי גילאור בסינגל חדש אהבת עולם", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "הביצוע המרגש של להקת הילדים שאול יוסף הלב שלי", "entities": [{"start": 28, "end": 37, "label": "SINGER"}]}
+{"text": "המוזיקאי יניר בלום באלבום חדש, שירו של רבו הרב ישראל יצחק בזאנסון שליטא", "entities": [{"start": 9, "end": 18, "label": "SINGER"}]}
+{"text": "יחיאל אורינגר בשיר חדש נשמת מתוך הרצליך 2", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "אביאל וחיים ארד פייבל מחדשים את אחד משיריו הישנים של ר מושיק אלמקיס", "entities": [{"start": 12, "end": 21, "label": "SINGER"}, {"start": 55, "end": 67, "label": "SINGER"}]}
+{"text": "ענבר טוכנר בסינגל חדש רחל אמנו", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "מייק גרנוף מרטיט בלחן חדש ושבו בנים", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "אלון בידה - ניגון ויז'ניץ", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "הזמר החתן הטרי יונה פרץ בחתונה נשמת כל חי", "entities": [{"start": 15, "end": 23, "label": "SINGER"}]}
+{"text": "לידור מאירמן & קולין שחט - מוצאי ראש השנה תש''פ אומן", "entities": [{"start": 0, "end": 12, "label": "SINGER"}, {"start": 15, "end": 24, "label": "SINGER"}]}
+{"text": "בנצי שובל בהופעת בכורה בחתונה - אמר רבי יוסי של סימן כרמל", "entities": [{"start": 0, "end": 9, "label": "SINGER"}, {"start": 48, "end": 57, "label": "SINGER"}]}
+{"text": "מאיר גרשוני & משה טישלר - בין קודש לחול", "entities": [{"start": 14, "end": 23, "label": "SINGER"}, {"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "אהרון זרביב ועירא זלקה בדואט מרגש – חשוב בלבך", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "הזמר והפייטן סיני נאור בסינגל בכורה שני קולות", "entities": [{"start": 13, "end": 22, "label": "SINGER"}]}
+{"text": "שלום שבאזי וילדי 'מיכאל אבאייב' בביצוע מרגש לביצוע 'טאטי'", "entities": [{"start": 18, "end": 30, "label": "SINGER"}, {"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "רזיאל ברק בסינגל חדש מלך המשיח", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "אלירן גרוזמן ותזמורתו בזיץ סוחץ עם 1,000 בני ישיבה מביתר עילית", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "הזמר קרן סהר הבדיל עם עשר גיטרות בנוסח קרליבך", "entities": [{"start": 5, "end": 12, "label": "SINGER"}]}
+{"text": "היוצר גדעון אונה חוזר - חוס אלוקי ממעונך", "entities": [{"start": 6, "end": 16, "label": "SINGER"}]}
+{"text": "איתן פריילאך מארח את עופר קסוטו בדואט מרגש במיוחד", "entities": [{"start": 21, "end": 31, "label": "SINGER"}, {"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "יקיר דניאל שהשלום שלו מתוך פרויקט צמאה 5", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "יצחק משעניה חוזר באלבום חדש באנגלית -דוגמה", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "ציון דיין בביצוע ווקאלי מיוחד ללהיט החדש 'בין קודש לחול'", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "איליה טרום בסינגל חדש מן המיצר", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "יצחק ביטון בסינגל חדש הרים גבוהים", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "משה יודלוב בבלדה מרגשת – אבא דואג להכל", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "אליאור מרש ודובב רוחאן שרים ממקומך ונפשי", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "רפי פוזנר, ריף סידוף ומימון משעולי - א שטארקע חתונה", "entities": [{"start": 11, "end": 20, "label": "SINGER"}, {"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "הזמר שמעי מילר וינון טויטו עם מחרוזת מזרחית", "entities": [{"start": 5, "end": 14, "label": "SINGER"}]}
+{"text": "גיל רובין ורוני ויזל מגישים רודף אחרי הרוח", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "אלחי לגריסי עם אלבום שני משובח הרצליך 2 - דוגמה", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "הזמר מתניה חתוכה & הקלידן תמיר אברג'יל - בביצוע לשיר לא רעב ללחם של שמואלי אונגר", "entities": [{"start": 5, "end": 16, "label": "SINGER"}, {"start": 26, "end": 38, "label": "SINGER"}, {"start": 68, "end": 80, "label": "SINGER"}]}
+{"text": "יותם אשל - אחרי הבחירות", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "אבי בבאי בשיר כל הכבוד מתוך אלבומו רביעי", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "חננאל שוואב - ישעיהו ביבלאש - מיכה הראל - מחרוזת חתונה", "entities": [{"start": 30, "end": 39, "label": "SINGER"}, {"start": 0, "end": 11, "label": "SINGER"}, {"start": 14, "end": 27, "label": "SINGER"}]}
+{"text": "מקהלת בנימין חוזר בסינגל חדש מה אני בלעדיך", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "אביגדור מלכי ואייל טויטו בדואט לזכרו של הרב מרדכי אליהו זצוקל", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "‪יהודה צ'יק בביצוע מיוחד ל'ניגון ברדיטשוב'", "entities": [{"start": 1, "end": 11, "label": "SINGER"}]}
+{"text": "מייקל חורי - ויבשר", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "אלדד רואש מגיש סינגל חדש תפילת חתן", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "אבירן לנדאו בסינגל בכורה בואו", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "ליאם אמסלם בהופעה - שיר מטרה", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "מנחם דניאל - כל הכבוד - תקציר האלבום", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "חנוך חן בלהיט חדש – מלך", "entities": [{"start": 0, "end": 7, "label": "SINGER"}]}
+{"text": "אירוע השקת אלבומו החדש של בנימין שרף", "entities": [{"start": 26, "end": 36, "label": "SINGER"}]}
+{"text": "ראם פדידה בסינגל חדש לב אחד גדול", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "עברי צ'צ'יק והחזן ר' אברום הולנדר ז''ל – מחרוזת שירי ישמחו במלכותך", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "בוצר מארח את אלדד סיטון מאני – התבואי לגני", "entities": [{"start": 13, "end": 23, "label": "SINGER"}]}
+{"text": "דר אסולין בטעימות ראשון מתוך האלבום הטרי פיני", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "עוז נגש - זינג מיט מיר", "entities": [{"start": 0, "end": 7, "label": "SINGER"}]}
+{"text": "אברמי וינברג מארח את אלחנן מאיוסט ביד חרוצים - אלוקים", "entities": [{"start": 0, "end": 12, "label": "SINGER"}, {"start": 21, "end": 33, "label": "SINGER"}]}
+{"text": "הופעת הענק של זמר העשור גלית בורג בבנייני האומה", "entities": [{"start": 24, "end": 33, "label": "SINGER"}]}
+{"text": "דוד לואי ואוף שימחע'ס מגישים מאיר'ל מיין קינד", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "מוישי גלויבער בסינגל חדש – רבים", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "חוני איפרגן והחזן ר' און קישנר - בניגון ר' עמיחי אגוזי מברדיטשוב", "entities": [{"start": 43, "end": 54, "label": "SINGER"}, {"start": 21, "end": 30, "label": "SINGER"}, {"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "יחיאל בלומנקרנץ וירין הראל עם הלהיט השבעתי", "entities": [{"start": 0, "end": 15, "label": "SINGER"}]}
+{"text": "מקהלת 'יניב יעקובי' יהודה ברוך וארד טטרואשוילי קה ריבון", "entities": [{"start": 20, "end": 30, "label": "SINGER"}, {"start": 7, "end": 18, "label": "SINGER"}]}
+{"text": "יששכר ארז, דובי מייזלעס ובניהו זאבי - סוכל'ה", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "ירדן הררי - סוכות קומזיץ", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "ערד לביא, שבתאי אבני ויואלי גרינפעלד - שמחת בית השואבה מישקולץ סוכות תש-פ 2019", "entities": [{"start": 0, "end": 8, "label": "SINGER"}, {"start": 10, "end": 20, "label": "SINGER"}]}
+{"text": "דוד לייפער - שמחה פורצת גבולות 2", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "פרחי ישורון זה טוב", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "עדן קופרמן בסינגל חדש 'אשריכם", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "שילה כהן בסינגל חדש – ורוח קודשך", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "נתנאל אסתרין ומאור אליהו – כי ירבו ויוסיפו לך שנות חיים", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "ישוע ארנסטר מארח את אלעד חסידים ברכת הבנים", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "אמן הרגש חזקיה בועז מרטיט עם היצירה כל נדרי", "entities": [{"start": 9, "end": 19, "label": "SINGER"}]}
+{"text": "עידו ויינשטיין מציג מה היה ר אביה חורי אומר", "entities": [{"start": 29, "end": 38, "label": "SINGER"}, {"start": 0, "end": 14, "label": "SINGER"}]}
+{"text": "איתמר ברוך והלהקה - אנא בכח", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "שיר מנשרי - היום ילידיתך", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "יוסי סלע אל תשליכני", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "פרחי לונדון מארח את שלמה ראג'ה רגע לנשימה", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "יעקב אברהם ויהושע חליפה בדואט מיוחד בסיום הש''ס", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "אלכסנדר ועקנין - מצוה טאנץ מושלם", "entities": [{"start": 0, "end": 14, "label": "SINGER"}]}
+{"text": "בר קראוז ויגל רז מחדשים את נשמה של לב קישון", "entities": [{"start": 35, "end": 43, "label": "SINGER"}, {"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "ישראל באדאנסקי בסינגל חדש - אל האמת קראתי", "entities": [{"start": 0, "end": 14, "label": "SINGER"}]}
+{"text": "יוגב אליאס נשנק מהתרגשות בשיר אבא", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "גבי רוד בביצוע עוצמתי לאבינו מלכנו", "entities": [{"start": 0, "end": 7, "label": "SINGER"}]}
+{"text": "שוקי מילצקי בסינגל חדש א אידעלע", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "דינה פורת & אשר מזרחי - מתפייס בתחנונים טאטע", "entities": [{"start": 12, "end": 21, "label": "SINGER"}, {"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "החזן העולמי נועם סרוסי - מסלסל בסליחות", "entities": [{"start": 12, "end": 22, "label": "SINGER"}]}
+{"text": "רחמים ברק בסנונית ראשונה מתוך האלבום פתחי לי", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "גלעד ברקובסקי ושחר כפרי בקטע מרטיט נוסח ויז'ניץ", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "דואט השנה נוי נהוראי והלל נבנצל – הלב שלי", "entities": [{"start": 10, "end": 20, "label": "SINGER"}]}
+{"text": "בצלאל יהוד' בסינגל חדש ראש השנה כל השנה", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "עמיחי שורץ ואביחי עוזרי מבצעים את רבונו של שגב מרזן", "entities": [{"start": 43, "end": 51, "label": "SINGER"}, {"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "רזיאל לנג מגיש סינגל חדש ומרגש לימים נוראים - יעלה תחנוננו", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "פרופ' יעקב סוסנה & ניקולס חפץ - אזכרה נגינתי בלילה", "entities": [{"start": 19, "end": 29, "label": "SINGER"}]}
+{"text": "יוגב אברהמי וסתיו רלבג - כאייל תערוג", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "דב וייץ & אופיר חלץ - תקע בשופר", "entities": [{"start": 10, "end": 19, "label": "SINGER"}, {"start": 0, "end": 7, "label": "SINGER"}]}
+{"text": "מוריאל שייך ואדיר דוברובנסקי יש מי שמחכה", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "ריף גליק ובנימין קאופמן העולמית - שפכי כמים ליבך", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "שלום דוידוביץ' בסינגל חדש מרגש ומעורר לבבות - העולם ראוי שיתמהו", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "מילך קהאן בסינגל מקפיץ אומן ראש השנה", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "אורין דמארי משחרר את הסינגל לב טהור", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "הנוסח הויז'ניצאי העתיק בביצוע מרטיט של שמואלי אונגאר, נשמה וסנדר גלב - מלוך", "entities": [{"start": 39, "end": 52, "label": "SINGER"}]}
+{"text": "אשל קרשין - בין כסא לעשור", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "אבי דרור משיק סינגל חדש ומרגש – אדון הסליחות", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "יעקב מוצן בסינגל שני חדש ומרגש מכניסי רחמים", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "גליל שטרסמן מנדי בריל וישראל בורוכוב במחרוזת שירי הימים הנוראים", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "שבתאי לנדמן סוחף עם לא רעב ללחם", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "איציק שלם משחרר סינגל חדש תהא השעה הזאת", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "יהונתן עמיאל שר כל ישראל", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "סליחות ראשונות עם החזן עדיאל בראל בליווי כלי נגינה", "entities": [{"start": 23, "end": 33, "label": "SINGER"}]}
+{"text": "צוריאל חממי בסינגל חדש ומרגש שמחה בלבי", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "ר׳ ראם פרי והחברים בקאבר ללחנו של קרליבך ״ואני תפילתי״", "entities": [{"start": 3, "end": 10, "label": "SINGER"}]}
+{"text": "שאול לב בסינגל חדש כמו ילד", "entities": [{"start": 0, "end": 7, "label": "SINGER"}]}
+{"text": "הרב עודד אברמוב ובחורים מישיבה גבוהה מצפה יריחו - שמע קולנו", "entities": [{"start": 4, "end": 15, "label": "SINGER"}]}
+{"text": "שלומי יפרח מקפיץ במחרוזת ריקודים אנרגטית", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "ארז ישראלי ונפתלי ברכה ביצעו את מדוע", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "יעקב אדלשטיין בסינגל שני נשמתי", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "יוס'ל לייפער, מידן גליקסמן, יניב שגב - מסלסלים", "entities": [{"start": 14, "end": 26, "label": "SINGER"}, {"start": 28, "end": 36, "label": "SINGER"}]}
+{"text": "נתנאל בן דוד, עמיר צ'רניך, ערן בבאייבו - מחרוזת הרקדה", "entities": [{"start": 0, "end": 12, "label": "SINGER"}, {"start": 14, "end": 25, "label": "SINGER"}]}
+{"text": "הזמר מושי רוט בסינגל חדש מתנות מאלוקים", "entities": [{"start": 5, "end": 13, "label": "SINGER"}]}
+{"text": "ירדן שומונוב ויצחק קורן בדואט – 'אתה המלך'", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "החזן האגדי ירחמיאל בלק ובנו ישראל ריגשו בדינר היוקרתי - גייט א איד", "entities": [{"start": 11, "end": 22, "label": "SINGER"}]}
+{"text": "הזמר ריף שמע מוציא את אלבומו הרביעי החדש - אלול תשע''ט", "entities": [{"start": 5, "end": 12, "label": "SINGER"}]}
+{"text": "ישראל אבחצירא, אליה בעדש, שלח לעווי - מחרוזת ריקודים", "entities": [{"start": 26, "end": 35, "label": "SINGER"}, {"start": 0, "end": 13, "label": "SINGER"}, {"start": 15, "end": 24, "label": "SINGER"}]}
+{"text": "תום רוטקובסקי ועמרם בן דיוואן בשיר חדש ומרטיט - לחיים", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "אורן בוטבול במחרוזת חופה מרגשת", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "יוני סרוסי - ענני בהסתרה", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "אלישיב דורון - אדון הסליחות", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "ר' כפיר קורן - כלים שבורים", "entities": [{"start": 3, "end": 12, "label": "SINGER"}]}
+{"text": "לקראת היארצייט ספיר ברגר בסינגל חדש – שמע ישראל", "entities": [{"start": 15, "end": 24, "label": "SINGER"}]}
+{"text": "ציון וסילייב מרגש עם גראמען בחופה", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "אורון זרו וליאור קרויזר כאייל תערוג - מתוך מופע צמאה", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "אלירן פלוטניצקי - אמת", "entities": [{"start": 0, "end": 15, "label": "SINGER"}]}
+{"text": "שעיה קיי - רק תחייך", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "אמיר בורנשטיין וריף גבריאל - אם אשכחך", "entities": [{"start": 0, "end": 14, "label": "SINGER"}]}
+{"text": "ארז ליפץ בסינגל חדש ומרגש לאן.", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "רועי אמוראי אורן מועלם רוסלן וטורי ועוזי שלום - מאיר'ל", "entities": [{"start": 12, "end": 22, "label": "SINGER"}, {"start": 0, "end": 11, "label": "SINGER"}, {"start": 23, "end": 34, "label": "SINGER"}]}
+{"text": "מושי אייזענבערג בשיר מחזק למשפחות המתמודדות השם רופאך", "entities": [{"start": 0, "end": 15, "label": "SINGER"}]}
+{"text": "לאל אלדר ואיצלה איזנשטרק – 'בעבור אבותינו'", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "אורון שטורך וילדיו בסינגל חדש הריני מקבל עליי", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "סטפן גוטקוביץ - הים זעפרנייל", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "יהודה טקלה בסינגל חדש מעין עולם הבא", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "עדי אבקסיס בסינגל חדש צעדים", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "דוד ויינבך, שילה בולק ואופיר סנבטו במחרוזת סוחפת", "entities": [{"start": 12, "end": 21, "label": "SINGER"}, {"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "לקראת אלבום החדש של גולן גנון סינגל - סדר העבודה", "entities": [{"start": 20, "end": 29, "label": "SINGER"}]}
+{"text": "יפתח יוסיפוב ודן ארנון 'ברכת אהרון' - לא תחמוד", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "שימי לפשיץ - אתה יודע", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "שוקי קליין בסינגל בכורה אי-ה", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "משה אבוטבול פותח את 'זמן אלול' עם סינגל חדש – יצחק אלחנן", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "שמוליק בן-עמי – 'עוצו עצה' מתוך צמאה 5", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "שמעון גל חגג 20 שנות מוזיקה עם מיטב האמנים מוזיקה מכל הלב musicbamail@gmail", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "חיים משה רכניץ מגיש סינגל מרגש לב נשבר", "entities": [{"start": 0, "end": 14, "label": "SINGER"}]}
+{"text": "עדן קריב בלחן סליחות מקורי עזב נא בן אדם", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "יריב זקן ומנחם פייג ברכת הכהנים האחרונה - דאס לעצטע דוכענען", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "אהרן טוסיק ו-30 זמרים בשיר שבט אחים", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "דודי פרישמן, ובנו בכורו הילד הפלא אבירם צבי", "entities": [{"start": 0, "end": 11, "label": "SINGER"}, {"start": 34, "end": 43, "label": "SINGER"}]}
+{"text": "הזמר וויליאם ווקר והמעבד ציון דורסמן עם הלהיט של הקיץ לא מדבר אליי", "entities": [{"start": 25, "end": 36, "label": "SINGER"}, {"start": 5, "end": 17, "label": "SINGER"}]}
+{"text": "נחמן צרפתי ונחשון ז'ורבליוב באלבום שבתי גוט שבת - דוגמה", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "זאב פרבמן - שיבוא - רמיקס (די ג'יי חיים פלמן)", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "צוריאל בנימין בסינגל חדש עליות וירידות-", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "אביתר גיאן ואון טויק עם משאפ יהודי ישראלי", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "ילד הפלא מקהלת הילדים 'חסידימלעך' & רחמים טריקי יבנה המקדש", "entities": [{"start": 36, "end": 47, "label": "SINGER"}]}
+{"text": "דביר לב במחרוזת מקפיצה", "entities": [{"start": 0, "end": 7, "label": "SINGER"}]}
+{"text": "אביחי ליפשיץ  זכרתי לך", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "אבי מיירפלד ועדי קובלצ'וק - אבא", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "אליעד שלום - רפאנו", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "ילד הפלא מורן שפסה - מי אדיר", "entities": [{"start": 9, "end": 18, "label": "SINGER"}]}
+{"text": "הקאמבק של בריו חקשור עם איתמר קסוטו", "entities": [{"start": 24, "end": 35, "label": "SINGER"}, {"start": 10, "end": 20, "label": "SINGER"}]}
+{"text": "פנחס ליברמן בסינגל שלישי - מים רבים", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "זאנוויל מבצע את טובות ונחמות של גיורא דסטה", "entities": [{"start": 32, "end": 42, "label": "SINGER"}]}
+{"text": "תומר לוי בסינגל בכורה – חמישה קולות", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "מרדכי גוטליב ועברי הלוי - הבן יקיר לי של רזיאל זאהן", "entities": [{"start": 0, "end": 12, "label": "SINGER"}, {"start": 41, "end": 51, "label": "SINGER"}]}
+{"text": "שי גז וגו'אי פיינברג על נהרות בבל", "entities": [{"start": 0, "end": 5, "label": "SINGER"}]}
+{"text": "ששון בכר בסינגל חדש עוד יבוא יום", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "05 גראמען יוגב יצחק", "entities": [{"start": 10, "end": 19, "label": "SINGER"}]}
+{"text": "לוי פולקובי'ץ שר ביחד עם בנצי טאבאק ליבי ובשרי", "entities": [{"start": 25, "end": 35, "label": "SINGER"}]}
+{"text": "חנוך דהן עם שיר הנושא מתוך אלבומו החדש אלע אלע", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "הדר איפראימוב בסינגל חדש - הזמן של השמחה", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "שמעון ישעיה יניב דהן במחרוזת כגוונא", "entities": [{"start": 12, "end": 20, "label": "SINGER"}, {"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "הרב מנוחה קונצרט בסינגל חדש וקיצבי – נאך אביסל", "entities": [{"start": 4, "end": 16, "label": "SINGER"}]}
+{"text": "ליאור צאיג בבלדה מרגשת – חומות", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "נפתלי כלפה בסינגל חדש לא לפחד", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "פרחי שמיים מרטיט עם 'נחמו' לאחר האבל על אחיו", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "ישראל עובדיה במחרוזת מקפיצה של מיטב הלהיטים האחרונים", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "נתנאל פרץ באלבום חדש יהללו - דוגמה", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "ערן אברג'ל ורזיאל שטרנליכט בסינגל שני מרגש ומיוחד – צמח דוד", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "מורן יפרח בשיר חדש מישהו איתי כאן", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "הרב ר' נטע עודי מלאך שליטא שיעור באידיש על פרשת דברים - חזון שנת תשע''ט - בנושא תשעה באב עמי לא התבונן", "entities": [{"start": 7, "end": 15, "label": "SINGER"}]}
+{"text": "הרב אביחי דרף שושן- ליל תשעה באב", "entities": [{"start": 4, "end": 13, "label": "SINGER"}]}
+{"text": "הרב אלעזר וגשל, מסעי ימי בין המצרים, כו תמוז, תשעט", "entities": [{"start": 4, "end": 14, "label": "SINGER"}]}
+{"text": "ילד הפלא שי נסים ושניר גולדברג מחדשים את הקלאסיקה של גל וקנין 'רחם נא'", "entities": [{"start": 9, "end": 16, "label": "SINGER"}, {"start": 53, "end": 61, "label": "SINGER"}]}
+{"text": "משפחת גוטגולד בגרסה הוואקלית לשובה אליי", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "יוני נויבירט מגיש ביצוע ווקאלי לשיר 'ושלמו' של אהר'לה סאמעט", "entities": [{"start": 47, "end": 59, "label": "SINGER"}, {"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "נטע קייט מבצע את השיר לפרשת מסעי שנקרא 'זאת הארץ", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "אלירז אלמו, נוב טגניה ואהרון ביטון מגישים 'נחמה' לבין המצרים", "entities": [{"start": 0, "end": 10, "label": "SINGER"}, {"start": 12, "end": 21, "label": "SINGER"}]}
+{"text": "יוסף איזנשטרק - ואפיל תחינתי (ווקאלי)", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "עז לביא ומקהלת גשר – אם אשכחך", "entities": [{"start": 0, "end": 7, "label": "SINGER"}]}
+{"text": "יאיר & שולי רנד בביצוע ווקאלית לשיר אבא – אדם נוימן", "entities": [{"start": 7, "end": 15, "label": "SINGER"}, {"start": 42, "end": 51, "label": "SINGER"}]}
+{"text": "דולב לבנברג  ואלדר זורע - רק תהיה עצמך", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "הזמר עוזיאל שובי ביצוע ווקאלי ובהגייה חסידית לשיר על נהרות בבל", "entities": [{"start": 5, "end": 16, "label": "SINGER"}]}
+{"text": "רפאל ויספיש בסינגל מרגש על חומותייך - לימי בין המצרים", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "לירוי מזוז בשיר חדש לזכרו של אביו ז''ל", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "אושי פישר עם שלו קרוכמל בשמחה משפחתית מבצעים מחרוזת ניגוני חב''ד", "entities": [{"start": 13, "end": 23, "label": "SINGER"}]}
+{"text": "ה'אבגדהוזחטי' של דן כרמון", "entities": [{"start": 17, "end": 25, "label": "SINGER"}]}
+{"text": "גדעון סער ופיליפ ביבי בשירי חופה", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "רגב אלמלח & אמן הקלידים רוי מנחם במחרוזת מקפיצה", "entities": [{"start": 0, "end": 9, "label": "SINGER"}, {"start": 24, "end": 32, "label": "SINGER"}]}
+{"text": "מ. שטיבל - שנים אתה לא פה", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "אבינועם שטייר, סיני תור ועמנואל איציקסון 'ברכת הכהנים' של נריה דגני", "entities": [{"start": 58, "end": 67, "label": "SINGER"}, {"start": 15, "end": 23, "label": "SINGER"}, {"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "אהרון קופמן ברמיקס לשיר 'אבא' של עתי דראי & דקל בן-יוסף", "entities": [{"start": 44, "end": 55, "label": "SINGER"}, {"start": 33, "end": 41, "label": "SINGER"}]}
+{"text": "עמירם יונה שוואקי חוזר בסינגל חדש – חזור בך", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "רמי דנוך - קולתילי נסתנק", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "יעקב שטיינרמן – בסינגל נוסף למצוא חן", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "הזמר נוה פריץ מוציא שיר חדש המיותרת", "entities": [{"start": 5, "end": 13, "label": "SINGER"}]}
+{"text": "הזמר יומי לואי מגיש לחן חדש על לכה דודי", "entities": [{"start": 5, "end": 14, "label": "SINGER"}]}
+{"text": "ראם ברדה שר כי יעקב מתוך האלבום החדש טביעת אצבע", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "שלומי גרנטר שר הרחמן, מונה ניצח ו'אלי מנשה' השלימה את ההרמוניה", "entities": [{"start": 34, "end": 42, "label": "SINGER"}]}
+{"text": "הביצוע של אדמונד ספוז'ניקוב & ומוישי וינדיש ל'באתי לגני'", "entities": [{"start": 10, "end": 27, "label": "SINGER"}]}
+{"text": "שקד סמואל מרגש בקומזיץ עם מיטב לחניו", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "עמיעד סוטו (& ניסן אוחנה) - בונה ירושלים", "entities": [{"start": 14, "end": 24, "label": "SINGER"}, {"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "עידן בנעים - אינשאללה", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "בוריס ויזמן, שבתי מרדכי טייכמן ופריילך - רגע", "entities": [{"start": 13, "end": 30, "label": "SINGER"}, {"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "משה פורת מארח את יששכר אדלר למחרוזת להיטים", "entities": [{"start": 17, "end": 27, "label": "SINGER"}, {"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "ילדי הפלא אמיר פישר & שמילי מרמלשטיין בדואט ראשון", "entities": [{"start": 10, "end": 19, "label": "SINGER"}]}
+{"text": "שלמה זלמן הורביץ - הבית הישן", "entities": [{"start": 0, "end": 16, "label": "SINGER"}]}
+{"text": "יאיר בצלאל בסינגל חדש האירה פניך", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "תזמורת בלו מלודי ואביה מליק - כי הנה כחומר", "entities": [{"start": 0, "end": 16, "label": "SINGER"}]}
+{"text": "עובדיה מימוני - הלב שלי (רמיקס - אהרון קופמן)", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "רום אמור בשיר געגועים לבחור שנקטף בדמי ימיו – שרוליק׳ל", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "להקת הילדים חביב קדוש - יום השישי", "entities": [{"start": 12, "end": 21, "label": "SINGER"}]}
+{"text": "אופיר חיים - מרים אותי תמיד", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "פייבל גרינברג בסינגל חדש רק תשמח", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "עומרי טוטמן & אורי אנסבכר במחרוזת חופה", "entities": [{"start": 14, "end": 25, "label": "SINGER"}, {"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "הסינגל החדש של הזמר והיוצר שמילי שטיינמץ מזמור לתודה", "entities": [{"start": 27, "end": 40, "label": "SINGER"}]}
+{"text": "מאור אשואל משחרר להיט בכורה – רגע של חתן וכלה", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "יריב אוחיון בסינגל חדש צמאה נפשי", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "האחים שטרן עם מיכאל אשכנזי ונדב בראל וביום השבת", "entities": [{"start": 0, "end": 10, "label": "SINGER"}, {"start": 14, "end": 26, "label": "SINGER"}]}
+{"text": "הזמר והיוצר קורן נמיר ממילותיו של רבי נחמן מברסלב ה'יום הולדת", "entities": [{"start": 12, "end": 21, "label": "SINGER"}]}
+{"text": "רמי קפילוטו - אבאלה", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "שגיב רותם בגראמען מרגש לזכרו של מוישי ווינר ז''ל", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "חיים דבאבוב ותזמורת קרהומה במחרוזת שוואקי", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "פטריק טאובמן יניב ליכטנשטין וחי דברשוילי מרגש בחופה ומקפיץ בחתונה", "entities": [{"start": 0, "end": 12, "label": "SINGER"}, {"start": 13, "end": 27, "label": "SINGER"}]}
+{"text": "נהוראי קינד - כח (Yoni Z - Power)", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "צדוק מנדל & אהוד חמו - בכל מקום שאתה", "entities": [{"start": 12, "end": 20, "label": "SINGER"}, {"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "שלמה מילר בסינגל מרגש א שטיקעלע תוספות", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "טום חזן בסינגל בכורה – הטוב יישאר", "entities": [{"start": 0, "end": 7, "label": "SINGER"}]}
+{"text": "מאור ישראל - כי מלאכיו & מי אדיר מאלבומו החדש", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "הזמר יצחק הרץ עם סינגל חדש לרגל שמחת נישואיו", "entities": [{"start": 5, "end": 13, "label": "SINGER"}]}
+{"text": "הזמר רוברט נגר בלהיט חדש בשמחה נעבוד את הבורא", "entities": [{"start": 5, "end": 14, "label": "SINGER"}]}
+{"text": "שלמה זלמן מגיש אבנר שרביט במחרוזת שמחה מיוחדת", "entities": [{"start": 15, "end": 25, "label": "SINGER"}, {"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "ניסים הלברשטם במחרוזת מה תשתוחחי", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "המטפל הרגשי ליאם אברהם בסינגל חדש עולם הבא", "entities": [{"start": 12, "end": 22, "label": "SINGER"}]}
+{"text": "ליעד ווליצקי & עוזי יוסופוב & תמיר ריזמוביץ, מחרוזת ריקודים סוערים", "entities": [{"start": 30, "end": 43, "label": "SINGER"}, {"start": 0, "end": 12, "label": "SINGER"}, {"start": 15, "end": 27, "label": "SINGER"}]}
+{"text": "ב'ציון שנקר ודן בן אמוץ בדואט – בעזרת ה'", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "עמוס דוד בסינגל חדש אני חי", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "עודד אפשטין במחרוזת מלהיטיו הישנים", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "ישעיהו דניאלס מארח את ויטלי לרנר לדואט מרגש – בידך", "entities": [{"start": 22, "end": 32, "label": "SINGER"}, {"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "גילי זאודה - ישתבח", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "יהודה מור - ה' העלית", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "אסא קוליק & ברוך מגער - אל תירא", "entities": [{"start": 12, "end": 21, "label": "SINGER"}, {"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "הילל טייטלבאום בסינגל חדש כולנו", "entities": [{"start": 0, "end": 14, "label": "SINGER"}]}
+{"text": "ידידיה שניידר בביצוע מרגש לשירו שמרה נפשי", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "מלך העולם – סינגל חדש של הזמר והיוצר משה פיינשטיין", "entities": [{"start": 37, "end": 50, "label": "SINGER"}]}
+{"text": "דולב ריחני עמנואל אברהם ושובל פוזיילוב - צדיקים", "entities": [{"start": 11, "end": 23, "label": "SINGER"}, {"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "אורון אדטו - הכל משמים", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "אלדר ביכמן - אבינו מלכנו", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "מקסים ברוש & י. רנד - אזמרה", "entities": [{"start": 13, "end": 19, "label": "SINGER"}, {"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "חיים מרדכי פיירוורגר מארח את הזמרים ריף וקנין ותומר תגרין", "entities": [{"start": 0, "end": 20, "label": "SINGER"}, {"start": 36, "end": 45, "label": "SINGER"}]}
+{"text": "ליאור שטרן 'תורה הקדושה'", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "לראות בנים - הלהיט החדש של גורל הולדהיים ושרול יליפשיץ", "entities": [{"start": 27, "end": 40, "label": "SINGER"}]}
+{"text": "ילד הפלא גלבוע שפירו מבצע את היצירה של ר' יום טוב זל 'קבלת התורה'", "entities": [{"start": 9, "end": 20, "label": "SINGER"}]}
+{"text": "אלרואי יעקובי (& טל הלברטל) - כולי", "entities": [{"start": 0, "end": 13, "label": "SINGER"}, {"start": 17, "end": 26, "label": "SINGER"}]}
+{"text": "רעם ששון בסינגל רביעי – נס", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "יוני זיגלבוים - שערי הרחמים", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "רון רחימי במחרוזת מקפיצה במיוחד", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "יוסי בנאי וכרמי מיכאל פותחים את עונת החתונות", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "פרחי משאלות עם הבדלה בנוסח גרין", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "שולי זנגי - פליאה", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "חביב אסא - בחר בנו", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "שגב בוקאי מגיש רבי נהוראי בגרסת רמיקס", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "נתן קמה בסינגל חדש זה מעשה שלו וזה מעשה שלי", "entities": [{"start": 0, "end": 7, "label": "SINGER"}]}
+{"text": "מנדל ליבראו בסינגל חדש משכני בדרך לאלבום שני-", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "ריי רובין עם מחרוזת מעורב ירושלמי", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "טום סטופניצקי ומרום ויץ בשיר חדש אבא", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "הזמר והיוצר יער שמואלי באלבום חדש מבוע", "entities": [{"start": 12, "end": 22, "label": "SINGER"}]}
+{"text": "זבולון מימון - יהא רעווא", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "אביגדור בן-יהודה בסינגל שני – ישתבח שמך", "entities": [{"start": 0, "end": 16, "label": "SINGER"}]}
+{"text": "כפיר מנדלסון הפך את מילות הרבי לשיר מרגש - בנפשי וברוחי ונשמתי", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "בארי איסקוב - ידידים - בערל פרודי", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "אליהו שטרן & יוסף מורדוך הבט נא", "entities": [{"start": 13, "end": 24, "label": "SINGER"}, {"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "ברוך לווין עם ילדי יואל ברוין", "entities": [{"start": 19, "end": 29, "label": "SINGER"}]}
+{"text": "בארי לרנר מגיש את קטונתי בביצוע ייחודי", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "ניר טפליצקי בלהיט אש ״כדאי הוא רבי שמעון", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "חביב דיין מרגש נשמת כל חי – קרעטשניף'ער פייער - מהדורה ווקאלית", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "אריאל שהם בביצוע אקאפלה רשמי לשיר הקומזיץ שויתי", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "נתנאל קרמר בסינגל וואקלי החדש מה טוב לי", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "יהלי בסר ומנשה ברון מגישים ריבונו של עולם בגירסה ווקאלית", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "אוריאל סעדי בביצוע ווקאלי לנפשי", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "שילה אליה, ממשיך להפתיע ומוציא סינגל ווקאלי דרבי מאיר עננו", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "אריה בן-ציון & ישראל טוויל - במחרוזת פרקי אבות (ווקאלי)", "entities": [{"start": 0, "end": 12, "label": "SINGER"}, {"start": 15, "end": 26, "label": "SINGER"}]}
+{"text": "ידידיה וקסלר במחרוזת שירי אמיר וקנין ווקאלית", "entities": [{"start": 26, "end": 36, "label": "SINGER"}, {"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "מרדכי ארבל מבצעת את שירו של מאיר וידרקר מודים", "entities": [{"start": 0, "end": 10, "label": "SINGER"}, {"start": 28, "end": 39, "label": "SINGER"}]}
+{"text": "החזן והזמר נחמיה צלקה בביצוע ווקאלי ליצירה 'מודים'", "entities": [{"start": 11, "end": 21, "label": "SINGER"}]}
+{"text": "עמית פוזננסקי מגיש לשון הרע לא מדבר אליי בווקאלית", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "עודד ברוכין מגיש גרסת אקאפלה להלב שלי של אלי לוי", "entities": [{"start": 0, "end": 11, "label": "SINGER"}, {"start": 41, "end": 48, "label": "SINGER"}]}
+{"text": "אלישע קלצקו עם כוח השמחה בגרסה הווקאלית", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "יונתן יהושע בביצוע ווקאלי לשיר אש", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "צדוק אנגלרד אודך בביצוע ווקאלי", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "החזן מעוז מנה בפרקי אבות נוסח המרוקאי", "entities": [{"start": 5, "end": 13, "label": "SINGER"}]}
+{"text": "עמיאל צויג – אקפלה לקום", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "ברוך צ'ייט באלבום ווקאלי חדש 'קולי'", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "יעקב רוזמרין - אליהו הנביא (ווקאלי)", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "רותי נבון בסינגל וואקלי – עולמו המושלם", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "אחיה סבג מספר על האדמור מקאליב זצוקל", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "האלבום 'שבת מיט אוהד אזריאל' בגירסה ווקאלית", "entities": [{"start": 16, "end": 27, "label": "SINGER"}]}
+{"text": "הגרסא הווקאלית לשיר מלאך של ישי מדר", "entities": [{"start": 28, "end": 35, "label": "SINGER"}]}
+{"text": "הגרסה הווקאלית לסינגל הבכורה של הראל לוי – אדיר במרום", "entities": [{"start": 32, "end": 40, "label": "SINGER"}]}
+{"text": "שמילי מורגנשטרן, תומר טרבלסי ואבי זקס - מחרוזת חתונה", "entities": [{"start": 0, "end": 15, "label": "SINGER"}, {"start": 17, "end": 28, "label": "SINGER"}]}
+{"text": "עצמתי ומרגש האירוע ההצדעה למלחין האגדי ר' בני אלטשולר", "entities": [{"start": 42, "end": 53, "label": "SINGER"}]}
+{"text": "יהונתן מנת בביצוע מרגש ללחן הטורקי ברכת כהנים", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "עמנואל אסרף ברסון בלהיט חדש מי לי", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "ניקולס בנימין בסינגל בכורה – ליבי שפכתי", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "שלום זריהן - יבנה", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "10 אליהו הנביא - יהל אתאל ויעקב טעלכאוונער", "entities": [{"start": 17, "end": 25, "label": "SINGER"}]}
+{"text": "08 באנו אליך - שמשון צוברי ונרננה", "entities": [{"start": 15, "end": 26, "label": "SINGER"}]}
+{"text": "06 הבט נא - מתיתיהו אמסילי", "entities": [{"start": 12, "end": 26, "label": "SINGER"}]}
+{"text": "03 מזמור לתודה - מורן גרוב ועומר פיגל", "entities": [{"start": 17, "end": 26, "label": "SINGER"}]}
+{"text": "01 פרק שירה - ערן גפן וידידים", "entities": [{"start": 14, "end": 21, "label": "SINGER"}]}
+{"text": "02 ברכת כהנים - יורם זפרני ונרננה", "entities": [{"start": 16, "end": 26, "label": "SINGER"}]}
+{"text": "04 תשפיע רוח קדשך - אלון כורם", "entities": [{"start": 20, "end": 29, "label": "SINGER"}]}
+{"text": "בצלאל וגשל - ואפיל תחינתי", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "עיליי מיכאלי ומרדכי חנוכייב במחרוזת מלהיטי שנות ה-90", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "שמשון דנה ומילאן שטרנברג מגישים איך בין איך", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "סענדר געלב, נועה קירל, וריי מנשה - נשמה", "entities": [{"start": 12, "end": 21, "label": "SINGER"}]}
+{"text": "יוסף מאיר נוסענצוייג, שקד בוגנים, יובל רון - במחרוזת שבע ברכות", "entities": [{"start": 22, "end": 32, "label": "SINGER"}, {"start": 0, "end": 20, "label": "SINGER"}, {"start": 34, "end": 42, "label": "SINGER"}]}
+{"text": "הזמר נדיר לשם בסינגל חדש מפרץ חרום", "entities": [{"start": 5, "end": 13, "label": "SINGER"}]}
+{"text": "חנוך והב - תוכו רצוף אהבה", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "אהרון סיטבון בסינגל חדש שאו עיניכם 'אל ההרים'", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "יואב עזרא בקומזיץ בין הזמנים בבני ברק", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "יהושע קליין - והשיב לב אבות", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "החזן לידור קצב בסינגל ל'ישמחו במלכותך'", "entities": [{"start": 5, "end": 14, "label": "SINGER"}]}
+{"text": "ר׳ ינון מרדכי וחברים, שרים בקומזיץ את המיטב של קרליבך", "entities": [{"start": 3, "end": 13, "label": "SINGER"}]}
+{"text": "מיילך ברוינשטיין וחברים בסינגל נוסף מתוך פרויקט המדרשיר", "entities": [{"start": 0, "end": 16, "label": "SINGER"}]}
+{"text": "אמיל פרייב ומקהלת יעקב סגל בביצוע מרגש רצה", "entities": [{"start": 18, "end": 26, "label": "SINGER"}, {"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "יחזקאל בראון - רוצה להבין", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "מאיר טספאי בסינגל חדש אחת שאלתי", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "מוטי שטיימניץ בשיר חדש לזכר בנו התינוק שנפטר", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "אופיר שבת ופנחס ברקוביץ בריוועלע", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "ילד הפלא דותן גולדפרב וסער רוזנברג מרגשים עם נחמה", "entities": [{"start": 9, "end": 21, "label": "SINGER"}]}
+{"text": "הזמר החסידי איתמר אלמוג תניא אמר ר' יוסי", "entities": [{"start": 12, "end": 23, "label": "SINGER"}]}
+{"text": "איתי גרינבוים שוורץ ויואב כחלון - א ערליכע ברכה", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "יוסף נוביק מספר את סיפור 'הגיבן הקדוש' של ר' שלמה", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "שולם דוידוביץ חוזר עם סינגל חדש 'באתי לגני'", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "ינאי ברקוביץ בסינגל חדש 'ותיהב לי בנין דיכרין'", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "אוראל בקשי, מוריאל שמילוביץ ורביב הראש - מחרוזת אנרגיה", "entities": [{"start": 12, "end": 27, "label": "SINGER"}, {"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "אביה מזוז בליווי שחף ארייב ולשם יצחקי - גם כי אלך", "entities": [{"start": 17, "end": 26, "label": "SINGER"}, {"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "אביאל פרי מגיש איך דאנק דיר השם", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "שמואל דהן שר ״לך על זה״", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "דוד נעים ונכדו שניאור אלבז - מודה אני לך", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "להיט הקומזיצים החדש 'פאר דיר' אושר חיו, לוי אלמגור, ילד הפלא שימי אנגל ואילן טיירו", "entities": [{"start": 30, "end": 38, "label": "SINGER"}, {"start": 40, "end": 50, "label": "SINGER"}, {"start": 61, "end": 70, "label": "SINGER"}]}
+{"text": "טום חזיזה כולם רוצים", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "חילו גנוט בסינגל חדש – השבת שלי", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "משה אוישר - עין טובה", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "אלכס רגב עם סטיבן שצמן בפורים שפיל בציריך", "entities": [{"start": 0, "end": 8, "label": "SINGER"}, {"start": 12, "end": 22, "label": "SINGER"}]}
+{"text": "ברק מנדלבאום - שיר הפרטיזנים", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "ניסים חלפון - לקום", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "נבו חמני מרגש בגראמען במיידאנק פולין", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "הזמר אוריאן גמליאלי מגיש סינגל חדש 'שמחתנו'", "entities": [{"start": 5, "end": 19, "label": "SINGER"}]}
+{"text": "'הניגון' של בנציון אבורמד שהולחן בין נטילת ידיים לברכת המוציא", "entities": [{"start": 12, "end": 25, "label": "SINGER"}]}
+{"text": "סינגל ביכורים לכוכב העולה יותם לברון - אדיר במרום", "entities": [{"start": 26, "end": 36, "label": "SINGER"}]}
+{"text": "תוכנית מיוחדת לפורים בערוץ 'הידברות' בהגשת נריה אנג׳ל", "entities": [{"start": 43, "end": 53, "label": "SINGER"}]}
+{"text": "שעתיים של משתה היין עם אלי ברגשטיין - קול ברמה", "entities": [{"start": 23, "end": 35, "label": "SINGER"}]}
+{"text": "חביב אטיאס & תזמורת נגינה מחרוזת ריקודים", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "הילל סלמן בסינגל אלקטרוני חדש ״מלמעלה ללמטה״", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "אחיקם שחר מזמר את ניב אקשטיין ביאליק ביידיש", "entities": [{"start": 18, "end": 29, "label": "SINGER"}, {"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "מטר גולמן בלהיט חדש אָה אַה", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "הזמר והיוצר רועי יצחק בסינגל חדש נסיעה טובה", "entities": [{"start": 12, "end": 21, "label": "SINGER"}]}
+{"text": "האמונה בוערת- יוסף (ג'ואי) ניוקם", "entities": [{"start": 14, "end": 32, "label": "SINGER"}]}
+{"text": "אברהם קלצקי - ג'ינגל ישיבת שכר שכיר - פורים ע''ט", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "התעוררות - גינג'ל יד אהרון - יאיר זיו - מיקס יניב בלאס", "entities": [{"start": 29, "end": 37, "label": "SINGER"}]}
+{"text": "עקיבא שכטר משחזר את השיר מגטו לודז׳", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "המנגנים & סנדרה ג'ונסון באלבום חתונת חדש על הבמה", "entities": [{"start": 10, "end": 23, "label": "SINGER"}]}
+{"text": "והשבוע פיצ'ה בן שמעון, עם יענקי עקשטיין", "entities": [{"start": 26, "end": 39, "label": "SINGER"}]}
+{"text": "הגראמער סענדי שטיינר & שלום שוקרון מרגשים בגראמען", "entities": [{"start": 23, "end": 34, "label": "SINGER"}]}
+{"text": "לוי סגל מגיש סינגל בכורה - פרק שירה", "entities": [{"start": 0, "end": 7, "label": "SINGER"}]}
+{"text": "אברהם משה ברדוגו ויהב בבאי 'אסרי לגפן'", "entities": [{"start": 0, "end": 16, "label": "SINGER"}]}
+{"text": "מתוך האלבום החדש של ר' סמואל יונה 'שַׁאבֶּע'ס בַּיי נַאכְט'", "entities": [{"start": 23, "end": 33, "label": "SINGER"}]}
+{"text": "אביתר חורי מרגש ברחם בדינר השנתי של ארגון ילדי במונטריאל", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "מימון גולדשטיין - העיירה המזמרת", "entities": [{"start": 0, "end": 15, "label": "SINGER"}]}
+{"text": "תום מרדכי משחרר סינגל חדש  ישמע האל", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "יומי & תום גרין - אידישע דורות", "entities": [{"start": 7, "end": 15, "label": "SINGER"}]}
+{"text": "אשר פלדמן מרגש את זעקת עמלי התורה להצלת רשת הכוללים 'יששכר באהליך'", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "יוגב סמט מקפיץ בחתונה", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "נחום סטארק - בננה", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "הזמר איתן בלום מבקש תעשו לו טובה בלי פוליטיקות", "entities": [{"start": 5, "end": 14, "label": "SINGER"}]}
+{"text": "ליעם אורפלי & עמית ליאני - איפה", "entities": [{"start": 14, "end": 24, "label": "SINGER"}, {"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "שרלי שטרסר וחנן גולדנברג הרקידו בהונגריה אצל ר׳ שיעל׳ה מקרעסטיר", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "אהרלה סאמט בסינגל חדש 'ולירושלים'", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "דין ירון - טרם היותי", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "שעתיים וחצי של קומזיץ עם יונה וולך", "entities": [{"start": 25, "end": 34, "label": "SINGER"}]}
+{"text": "דוד רוזנפעלד, מלווה בתזמורת בת 40 נגנים ובפרדי מאור ביצירת ה'הדרן'", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "ילד הפלא ישי בוך, עירן פאר, עירן צייזלר - ותשפיע רוח קדשך", "entities": [{"start": 18, "end": 26, "label": "SINGER"}, {"start": 9, "end": 16, "label": "SINGER"}, {"start": 28, "end": 39, "label": "SINGER"}]}
+{"text": "מרטין הלל בסינגל חדש – יום מיוחד", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "איזי רוטקובסקי - כל מה שהיה", "entities": [{"start": 0, "end": 14, "label": "SINGER"}]}
+{"text": "אראל משיח מוציא שוב - רקוד טאנץ 365 - חלק 2 - דוגמה", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "פיני לנדאו שר נפשי, ריבו הפתיע והצטרף", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "רני קלימוב ליפא והינדל שיינבוים בסעודת הודיה", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "יגל ברינר בשירו של משיח אביבי ז''ל להיות בשמחה", "entities": [{"start": 0, "end": 9, "label": "SINGER"}, {"start": 19, "end": 29, "label": "SINGER"}]}
+{"text": "שחר נח - אזמענטש", "entities": [{"start": 0, "end": 6, "label": "SINGER"}]}
+{"text": "נווה וולדפוגל מארח את אביגדור לוגסי מי שהיינו באידיש", "entities": [{"start": 22, "end": 35, "label": "SINGER"}, {"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "סטיבן שני בביצוע ליצירתו של מנור מדר – ״אהבת השם״", "entities": [{"start": 0, "end": 9, "label": "SINGER"}, {"start": 28, "end": 36, "label": "SINGER"}]}
+{"text": "אוריאן ביריוקוב בסינגל חדש ״לשה״ר לא מדבר אלי״", "entities": [{"start": 0, "end": 15, "label": "SINGER"}]}
+{"text": "הזמר כרמל ירס מרקיד בחתונה עם מיטב הלהיטים", "entities": [{"start": 5, "end": 13, "label": "SINGER"}]}
+{"text": "עוזי פלדמן בשירו החדש כל הנחלים הולכים לים", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "מב''ד עם שליו קורוטקין במחרוזת משותפת נדירה במשך ח''י רגעים", "entities": [{"start": 9, "end": 22, "label": "SINGER"}]}
+{"text": "שרגא ברודנו מגיש מה עלי לעשות", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "בצלאל אבקסיס בסינגל בכורה הטוב", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "אלרואי דוידוביץ & חיליק פרנק - מזמור לתודה", "entities": [{"start": 0, "end": 15, "label": "SINGER"}, {"start": 18, "end": 28, "label": "SINGER"}]}
+{"text": "דב הלפרין - היום שלכם", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "הגראמן המיוחד במוצש מהחזן דודי לינקר בכינוס כתר זהב למען המגבית של יזכור אהבתו", "entities": [{"start": 26, "end": 36, "label": "SINGER"}]}
+{"text": "הוד סוסונוב - הבדלה", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "יונתן מגרבי - הבריאה של השם", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "לקראת צאת אלבומו גלוי וידוע, התארח יקיר גודמן בתוכנית ב'קול חי'", "entities": [{"start": 35, "end": 45, "label": "SINGER"}]}
+{"text": "סאלי צ'רניאק בביצוע אקוסטי ללבחור נכון", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "עזי שלי וארי פרקש בקטע מרגש בקבלת פנים", "entities": [{"start": 0, "end": 7, "label": "SINGER"}]}
+{"text": "הרצל מעודד ויאיר יצחק - הלב והמעיין", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "שידור חוזר מקול חי של ההופעה אוריה וקסמן, צביקה שעיה ואימרי נחום בטבריה", "entities": [{"start": 29, "end": 40, "label": "SINGER"}, {"start": 42, "end": 52, "label": "SINGER"}]}
+{"text": "המטפל חננאל אוחנה בשיר חמישי ''לך מחכים''", "entities": [{"start": 6, "end": 17, "label": "SINGER"}]}
+{"text": "ר' שמשון ניימאן & סתיו זהבי - נחמה", "entities": [{"start": 18, "end": 27, "label": "SINGER"}]}
+{"text": "ר׳ מרום רולניק באלבום חדש ומיוחד- גלוי וידוע - דוגמה", "entities": [{"start": 3, "end": 14, "label": "SINGER"}]}
+{"text": "צביקה ציטרון ואייל פרנקל עם יהושע רוט אני מאמין", "entities": [{"start": 0, "end": 12, "label": "SINGER"}, {"start": 28, "end": 37, "label": "SINGER"}]}
+{"text": "גילי מיכאילוב שר על ״אלרואי פרוינד״ מנחלאות", "entities": [{"start": 0, "end": 13, "label": "SINGER"}, {"start": 21, "end": 34, "label": "SINGER"}]}
+{"text": "הרופא שמעון ניסנוב בסינגל בכורה כי הם חיינו", "entities": [{"start": 6, "end": 18, "label": "SINGER"}]}
+{"text": "שוהם וגמן מגיש מודה אני לפניך בלחן חדש", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "תומאס שר מגיש אתה לי אור", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "המלחין הרב עידו פורטל מוציא את ״שירי פנחס 4״", "entities": [{"start": 11, "end": 21, "label": "SINGER"}]}
+{"text": "סינגל חדש למוסיקאי יעקב רוזנבלום – אדון עולם", "entities": [{"start": 19, "end": 32, "label": "SINGER"}]}
+{"text": "יהלי סלם ושחם הולנדר 'הבט נא'", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "אבירן גפנר  בסינגל חתן - יעמוד", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "לוריא רייך מארח את אליעזר אליהו – בפי ישרים", "entities": [{"start": 19, "end": 31, "label": "SINGER"}, {"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "מורן מלמד תזמורת ה'מנגנים' ויהונתן שלמה וילסון בהופעה בטבריה", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "ניב פולק מגיש שיר הישועות של ראש הישיבה שבתי עם דוד קנובלך", "entities": [{"start": 0, "end": 8, "label": "SINGER"}, {"start": 48, "end": 58, "label": "SINGER"}]}
+{"text": "עילי אפרגן ברימיקס לשיר של כדורי אביטבול לשוב הביתה", "entities": [{"start": 0, "end": 10, "label": "SINGER"}, {"start": 27, "end": 40, "label": "SINGER"}]}
+{"text": "שמואל ברונר בסינגל חדש - צידרייט", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "ילד הפלא אמנון אבייב, גפן יעקב ואביב משה - 'גם כי אלך'", "entities": [{"start": 9, "end": 20, "label": "SINGER"}, {"start": 22, "end": 30, "label": "SINGER"}]}
+{"text": "אהוד אטיאס ויובל מנצורה לבחור נכון", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "הזמר יהלי אופן וארז שמש במחרוזת שירים לכבוד ראש חודש אדר", "entities": [{"start": 5, "end": 14, "label": "SINGER"}]}
+{"text": "ברק צוברי ומתתיהו אפטקר בדואט מדהים  – באמת", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "ירדן פפר ותזמורתו במחרוזת חבדי''ת למהדרין", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "עתי מועלם - נפלתי וקמתי", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "יוסי לעבאוויטש שר שירים של אביב מור", "entities": [{"start": 27, "end": 35, "label": "SINGER"}]}
+{"text": "החזן עוז גזבר בשיר חדש כבודו", "entities": [{"start": 5, "end": 13, "label": "SINGER"}]}
+{"text": "יצחק פנגר בסיגל מה בצע", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "אראל שטרן תפילת חתן", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "צוף ימין מרגשים בחופה", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "אראל הרצל, שלום משה פריינד ושביט יצחקוב באירוע בטבריה", "entities": [{"start": 11, "end": 26, "label": "SINGER"}, {"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "אלבום חדש שבת מיט אביתר מורגוליס", "entities": [{"start": 18, "end": 32, "label": "SINGER"}]}
+{"text": "ילד הפלא יהלי מלט בחופה ״אני מאמין״", "entities": [{"start": 9, "end": 17, "label": "SINGER"}]}
+{"text": "נחמן יעקובי עם מחרוזת יואלידאנס", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "סינגל חדש בסגנון אחר מאת הלל קנפו הלב שלי", "entities": [{"start": 25, "end": 33, "label": "SINGER"}]}
+{"text": "ארהל סקעת במחרוזת לכבוד חמדת לבבי", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "נאור יוליס, ספי שפירא בביצוע מחודש ליצירה מיין טאט'נס א קינד", "entities": [{"start": 0, "end": 10, "label": "SINGER"}, {"start": 12, "end": 21, "label": "SINGER"}]}
+{"text": "ליעם ונטורה - עובדיה דוידוב", "entities": [{"start": 14, "end": 27, "label": "SINGER"}, {"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "הלהקה המיתולוגית 'סימפלי צפת' לצד הזמר גוני בקר בשילוב מעניין ומקורי", "entities": [{"start": 39, "end": 47, "label": "SINGER"}]}
+{"text": "בן שמעון מארח את זאב קצנלבוגן", "entities": [{"start": 17, "end": 29, "label": "SINGER"}]}
+{"text": "ניו יורק בויס בביצוע יפהפה לשיר אל מסתתר", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "פאר ברוך בליווי דניאל אדמון במחרוזת חתונה מקפיצה", "entities": [{"start": 0, "end": 8, "label": "SINGER"}, {"start": 16, "end": 27, "label": "SINGER"}]}
+{"text": "דני פלגון - חלק שלי", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "כדורי שטיינר בסינגל שני אתה המלך", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "הרב אורי חמד וילד הפלא גלעד מזרחי מבקשים עננו", "entities": [{"start": 23, "end": 33, "label": "SINGER"}, {"start": 4, "end": 12, "label": "SINGER"}]}
+{"text": "הזמר שלומי לינדנר חשף שיר חדש שלו אין אדם נוקף אצבעו", "entities": [{"start": 5, "end": 17, "label": "SINGER"}]}
+{"text": "אביתר סאלם בביצוע מרגש לשיר למעלות", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "ניתאי ישראלי בסינגל חדש – אזמרה", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "בר המצווה לילד הפלא הבה''ח יחיאל בוזגלו", "entities": [{"start": 27, "end": 39, "label": "SINGER"}]}
+{"text": "שלמה & רביב דורון, יניר מלאייב בגירסה באידיש ל'אדמה ושמים' - אהיים", "entities": [{"start": 7, "end": 17, "label": "SINGER"}, {"start": 19, "end": 30, "label": "SINGER"}]}
+{"text": "עדן הרשקוביץ בחידוש מיוחד לקלאסיקה שירת העשבים", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "שיר חדש 'ומשפע מצוות תפילין' לכב' בר המצווה לילד הפלא שון גונן", "entities": [{"start": 54, "end": 62, "label": "SINGER"}]}
+{"text": "דיויד הירשהורן וילד הפלא עידו בן גל בשיר בחופה אם אשכחך", "entities": [{"start": 0, "end": 14, "label": "SINGER"}, {"start": 25, "end": 35, "label": "SINGER"}]}
+{"text": "ליפא חממי - זמן חופה", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "רפי מילר וישכר אברה - א אידישע מאמע", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "הזמר מנור קאפח בסינגל חדש – -מסע ארו", "entities": [{"start": 5, "end": 14, "label": "SINGER"}]}
+{"text": "מופיע אייל ישראל שטרנליב 32 - גרשון הרוש", "entities": [{"start": 6, "end": 24, "label": "SINGER"}, {"start": 30, "end": 40, "label": "SINGER"}]}
+{"text": "לומדי ׳דרשו׳ בוינה ערכו סיום, נתן אוחנה ריגש עם ״אזכרה״", "entities": [{"start": 30, "end": 39, "label": "SINGER"}]}
+{"text": "משכיל לדוד - מוימורן חומסקי, יזהר גויטה וליאון אזולאי", "entities": [{"start": 29, "end": 39, "label": "SINGER"}]}
+{"text": "רז רויזן הבוגר וחנה רותם הילד בדואט כוכבים", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "יוחאי נומה ויהושע העשיל ברים ביצוע מרגש להנני", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "יהודה זיתון ואלף בני נוער שרים 'אחדות'", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "ברי אורן - את השמחה לא נעצור", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "גיל הורסקי הקליט את שירו מחדש 'אין קדוש כהשם'", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "מופיע יידל ורדיגר 32 - זושא ופואהרן שובותא", "entities": [{"start": 6, "end": 17, "label": "SINGER"}]}
+{"text": "טובי אברהמי בסינגל בכורה 'מודים'", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "מופיע יהודה אריה דינר 32 - שימי סקלאר ומוט דאב", "entities": [{"start": 6, "end": 21, "label": "SINGER"}, {"start": 27, "end": 37, "label": "SINGER"}]}
+{"text": "והשבוע מענדי בריכטא בקומזיץ מיוחד עם יומי לאוי אצל בן שמעון", "entities": [{"start": 7, "end": 19, "label": "SINGER"}]}
+{"text": "אליעד מקס  - הבבא סאלי", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "רנן ארקה וחברים שרים וזוכר של קרליבך", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "הרב מירון מטלון במהלך קומזיץ שינה מעט את המילים לשירו לטב עביד", "entities": [{"start": 4, "end": 15, "label": "SINGER"}]}
+{"text": "טעימה מהפרוייקט החדש של 'נחמיה קולמן' מיטב שירי השבת", "entities": [{"start": 25, "end": 36, "label": "SINGER"}]}
+{"text": "מקהלת אלכסנדר ולייב קגן בדואט – אדמה ושמים", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "פורת פישר מגיש סינגל חדש לצפון", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "יגיל קסוטו & אליהו חייט ותזמורתו במחרוזת חתונה מקפיצה במיוחד", "entities": [{"start": 0, "end": 10, "label": "SINGER"}, {"start": 13, "end": 23, "label": "SINGER"}]}
+{"text": "רועי פלדמן שר 30 שירים בשבע דקות", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "יהדות כנישואין ביחד עם ליפא ״אל תסתר״", "entities": [{"start": 0, "end": 14, "label": "SINGER"}]}
+{"text": "תזמורת בלו מדולי - חוף מבטחים", "entities": [{"start": 0, "end": 16, "label": "SINGER"}]}
+{"text": "והשבוע בן שמעון מארח את החזן אריק שני לקומזיץ", "entities": [{"start": 29, "end": 37, "label": "SINGER"}]}
+{"text": "רביב שוייחט ומקהלת הילדים בביצוע באידיש", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "יורם צוברי, אלברט חגבי ואוריה ביילין שרים ומספרים על חבד", "entities": [{"start": 12, "end": 22, "label": "SINGER"}, {"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "יועד וידר ודיג'יי שלמה יענק'ל וועבר אדמה ושמיים", "entities": [{"start": 18, "end": 35, "label": "SINGER"}, {"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "יצחק יסעור ומקהלת הילדים ליעד זרוק על לבבך", "entities": [{"start": 25, "end": 34, "label": "SINGER"}, {"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "יחיאל נהרי שר 'אם אשכחך'' מאלבומו 'בשעה טובה'", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "ריף בק מארח את יהל לנדאו בחתונה", "entities": [{"start": 15, "end": 24, "label": "SINGER"}, {"start": 0, "end": 6, "label": "SINGER"}]}
+{"text": "ידידיה רחמנוב ולייבל'ה ליפסקר בניגון המרטיט ד' בבות", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "יובל סטופל שר נפשי בהופעה בבית שמש", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "יונתן טירהויז בציון הבעל התניא בהאדיטש שבאוקראינה", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "מאטי אילוויטש חוזר כ-יוסף - האזינו לסינגל החדש, -זה אתה", "entities": [{"start": 0, "end": 13, "label": "SINGER"}]}
+{"text": "נועם לוזון ובן-ציון לוזון בבר מצווה לפני עשור", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "יוגב גרינברג שר -  אין זמן כמו עכשיו", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "ניב סיומין בסינגל חדש – מזמן לזמן", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "חנינא דלל במחרוזת ריקודים עדכנית ומקפיצה", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "ברכת האורח - ילדי הפלא אמרי שני ומויאורין יפלח ואיתן-כץ", "entities": [{"start": 23, "end": 31, "label": "SINGER"}]}
+{"text": "אלקנה גודלי & המעגל - ליבי ובשרי", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "ילד הפלא סרגיי מצרי, מרדכי יחזקאל & אליהו שוקרון", "entities": [{"start": 21, "end": 33, "label": "SINGER"}, {"start": 9, "end": 19, "label": "SINGER"}, {"start": 36, "end": 48, "label": "SINGER"}]}
+{"text": "הזמר מרדכי קליין ברמיקס ל'בשבילי'", "entities": [{"start": 5, "end": 16, "label": "SINGER"}]}
+{"text": "אלחנן מעודד ואריה פאר במחרוזת מקפיצה", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "ים מארקוביץ & איל אביב - אבל מלך עליון", "entities": [{"start": 0, "end": 11, "label": "SINGER"}, {"start": 14, "end": 22, "label": "SINGER"}]}
+{"text": "עובדיה נסים, בגראמען על השיר עברי אנוכי", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "דן פולייף שר עם יעקב יצחק וינגרטן", "entities": [{"start": 0, "end": 9, "label": "SINGER"}, {"start": 16, "end": 33, "label": "SINGER"}]}
+{"text": "צדק איסרליס ב'מחרוזת מזרחית'", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "אבי דלמנטי בשירו עוד טיפה", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "לירון מונטג, חנניה אביעד, יעקב יודא דסקל, רבש“ע ותן חלקנו", "entities": [{"start": 13, "end": 24, "label": "SINGER"}, {"start": 0, "end": 11, "label": "SINGER"}, {"start": 26, "end": 40, "label": "SINGER"}]}
+{"text": "אמן הבוזוקי דביר גפנר & שנהב שלזינגר ותזמורתו, במחרוזת יוונית", "entities": [{"start": 24, "end": 36, "label": "SINGER"}, {"start": 12, "end": 21, "label": "SINGER"}]}
+{"text": "ברק אלמגור ודן עובד ריגשו עם הלהיט נפשי", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "רוני עוזרי - פסגת החיים", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "מחרוזת חופה עם אתי עומר ותזמרותו של אלישע קמינסקי", "entities": [{"start": 15, "end": 23, "label": "SINGER"}, {"start": 36, "end": 49, "label": "SINGER"}]}
+{"text": "הרב משה ולדמן וידידים במחרוזת מקפיצה", "entities": [{"start": 4, "end": 13, "label": "SINGER"}]}
+{"text": "דב שורין בסינגל חדש בטח בה׳", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "עופר שפר וילד הפלא אלחי קלר -נפשי", "entities": [{"start": 0, "end": 8, "label": "SINGER"}, {"start": 19, "end": 27, "label": "SINGER"}]}
+{"text": "משה יצחק רייכמאן - כפרה עליכם", "entities": [{"start": 0, "end": 16, "label": "SINGER"}]}
+{"text": "מנור צרובסקי באלבום התוועדות מקפיץ", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "החזן אופיר בכר מרגש בשיר חדש חנני השם", "entities": [{"start": 5, "end": 14, "label": "SINGER"}]}
+{"text": "הזמר צור ירושלמי מגיש את אמר רבי יוסי", "entities": [{"start": 5, "end": 16, "label": "SINGER"}]}
+{"text": "חיים י. היילפרן בסינגל חדש מבינים את החיים", "entities": [{"start": 0, "end": 15, "label": "SINGER"}]}
+{"text": "פלג נר בסינגל חדש ומרגש – בדמיך חיי", "entities": [{"start": 0, "end": 6, "label": "SINGER"}]}
+{"text": "גיא אזרד בסינגל מרגש על חומותייך", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "ראם מרדכי בסינגל חדש ברכת הילדים", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "גדעון שפרן ואבי גלסברג בחופה מרגשת", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "אדר משעלי בסינגל בכורה – קה קלי", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "מנחם מצנבר, בסינגל חדש וייחודי עם מילים שמקדישים", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "מנדי וורדיגר - הלב", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "יצחק קולסניק וצפריר רובין - הכל טוב", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "אלחנן קקון & עמוס רביב בוסקילה - שומר עלי", "entities": [{"start": 0, "end": 10, "label": "SINGER"}, {"start": 13, "end": 22, "label": "SINGER"}]}
+{"text": "שיר מהרב דנאל יהושע בנושא הסמרטפון", "entities": [{"start": 9, "end": 19, "label": "SINGER"}]}
+{"text": "מאיר-רפי סלמן - הכל עוד יסתדר", "entities": [{"start": 5, "end": 13, "label": "SINGER"}]}
+{"text": "מקסים חזן מגיש ביצוע מרגש משלו לשיר 'כשושנה' של פריד", "entities": [{"start": 0, "end": 9, "label": "SINGER"}]}
+{"text": "מסיבת חנוכה לילדי 'מקהלת אלירם גבור'", "entities": [{"start": 25, "end": 35, "label": "SINGER"}]}
+{"text": "עופרי זימרמן בסינגל חדש טוב ה' לכל", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "ערן רפאילוב ואברומי בערקו  - לטב עביד", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "גדי איסמקוב בסינגל חדש – כי אין מלה בלשוני", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "הרלי פליישמן ועמיחי שטרן - בטחו", "entities": [{"start": 0, "end": 12, "label": "SINGER"}]}
+{"text": "מלכות, אביחי מזרחי, יוסל'ה רוזנבלט, שלומי סלמן - מחרוזת הלל", "entities": [{"start": 36, "end": 46, "label": "SINGER"}, {"start": 20, "end": 34, "label": "SINGER"}, {"start": 7, "end": 18, "label": "SINGER"}]}
+{"text": "אורן ארנון ועילם קוסטנוביץ - מחרוזת שירי ישעיה גברא", "entities": [{"start": 41, "end": 51, "label": "SINGER"}, {"start": 0, "end": 10, "label": "SINGER"}]}
+{"text": "לאחר עשור הזמר והיוצר לירן שושני בסינגל חדש", "entities": [{"start": 22, "end": 32, "label": "SINGER"}]}
+{"text": "עוזי רוט מרגש בסינגל חדש אזכרה", "entities": [{"start": 0, "end": 8, "label": "SINGER"}]}
+{"text": "ליאל ברום - מרדכי מלייב - תזמורת פריילעך - מחרוזת דאנס", "entities": [{"start": 0, "end": 9, "label": "SINGER"}, {"start": 12, "end": 23, "label": "SINGER"}]}
+{"text": "עיליי אביטל - יש הכל", "entities": [{"start": 0, "end": 11, "label": "SINGER"}]}
+{"text": "אבי אליסון, משה פרייליך ומקהלת שיר יהודי - תפילת בעל המנגן", "entities": [{"start": 0, "end": 10, "label": "SINGER"}]}

--- a/src/tests/test_check_name_similarity.py
+++ b/src/tests/test_check_name_similarity.py
@@ -1,63 +1,30 @@
-import sys
-import unittest
 from pathlib import Path
+import sys
+
+import pytest
 
 sys.path.append(str(Path(__file__).resolve().parents[1] / "core"))
 
 from check_name import check_exact_name
 
 
-class TestCheckNameSimilarity(unittest.TestCase):
-    def test_exact_match_still_supported(self):
-        self.assertTrue(check_exact_name("מוטי שטיינמץ - שיר חדש", "מוטי שטיינמץ"))
-
-    def test_vav_prefix_still_supported(self):
-        self.assertTrue(check_exact_name("ועם ומוטי שטיינמץ", "מוטי שטיינמץ"))
-
-    def test_one_letter_difference_in_word_is_supported(self):
-        self.assertTrue(check_exact_name("שיר חדש של ויסמנדל", "וייסמנדל"))
-        self.assertTrue(check_exact_name("ביצוע של וייסמנדל", "ויסמנדל"))
-
-    def test_short_name_does_not_match_with_one_letter_change(self):
-        self.assertFalse(check_exact_name("אלה קליין - הופעה", "אלי קליין"))
-
-    def test_long_name_supports_two_differences(self):
-        self.assertTrue(
-            check_exact_name(
-                "דואט עם אברהם מרדכי שוורצ",  # חסרה אות אחת במילה האחרונה
-                "אברהם מרדכי שוורץ",
-            )
-        )
-        self.assertTrue(
-            check_exact_name(
-                "דואט עם אברהם מורדכי שוורז",  # 2 הבדלים מפוזרים בשם ארוך
-                "אברהם מרדכי שוורץ",
-            )
-        )
-
-    def test_long_name_rejects_when_difference_too_large(self):
-        self.assertFalse(
-            check_exact_name(
-                "דואט עם אברם מורדכע שוורזז",
-                "אברהם מרדכי שוורץ",
-            )
-        )
-
-    def test_prevent_false_positive_for_prefix_forms(self):
-        self.assertFalse(check_exact_name("שיר נוסף - למוטי שטיינמץ", "מוטי שטיינמץ"))
-
-    def test_prevent_false_positive_for_suffix_forms(self):
-        self.assertFalse(check_exact_name("שיר נוסף - מוטי שטיינמץל", "מוטי שטיינמץ"))
-
-    def test_prevent_false_positive_for_distinct_names(self):
-        self.assertFalse(check_exact_name("יואלי קליין - הופעה", "אלי קליין"))
-
-    def test_multi_word_window_matching(self):
-        self.assertTrue(check_exact_name("ביצוע חי - אלי קלינן", "אלי קליין"))
-
-    def test_window_requires_same_word_count(self):
-        self.assertFalse(check_exact_name("הופעה של מרדכי", "אברהם מרדכי שוורץ"))
-
-
-if __name__ == "__main__":
-    unittest.main()
+@pytest.mark.parametrize(
+    ("filename", "artist", "expected"),
+    [
+        ("מוטי שטיינמץ - שיר חדש", "מוטי שטיינמץ", True),
+        ("ועם ומוטי שטיינמץ", "מוטי שטיינמץ", True),
+        ("שיר חדש של ויסמנדל", "וייסמנדל", True),
+        ("ביצוע של וייסמנדל", "ויסמנדל", True),
+        ("אלה קליין - הופעה", "אלי קליין", False),
+        ("דואט עם אברהם מרדכי שוורצ", "אברהם מרדכי שוורץ", True),
+        ("דואט עם אברהם מורדכי שוורז", "אברהם מרדכי שוורץ", True),
+        ("דואט עם אברם מורדכע שוורזז", "אברהם מרדכי שוורץ", False),
+        ("שיר נוסף - למוטי שטיינמץ", "מוטי שטיינמץ", False),
+        ("שיר נוסף - מוטי שטיינמץל", "מוטי שטיינמץ", False),
+        ("יואלי קליין - הופעה", "אלי קליין", False),
+        ("ביצוע חי - אלי קלינן", "אלי קליין", True),
+        ("הופעה של מרדכי", "אברהם מרדכי שוורץ", False),
+    ],
+)
+def test_check_exact_name_similarity(filename: str, artist: str, expected: bool) -> None:
+    assert check_exact_name(filename, artist) is expected

--- a/src/tests/test_singner_dataset_matching.py
+++ b/src/tests/test_singner_dataset_matching.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / "core"))
+
+from check_name import check_exact_name
+
+
+DATASET_SAMPLE_PATH = Path(__file__).resolve().parent / "data" / "singner_sample_5000.jsonl"
+
+def _load_dataset_sample() -> list[dict]:
+    rows: list[dict] = []
+    with DATASET_SAMPLE_PATH.open("r", encoding="utf-8") as sample_file:
+        for line in sample_file:
+            rows.append(json.loads(line))
+    return rows
+
+
+@pytest.fixture(scope="module")
+def singner_rows() -> list[dict]:
+    rows = _load_dataset_sample()
+    assert len(rows) >= 5000, "Expected at least 5000 rows in sample"
+    return rows
+
+
+@pytest.fixture(scope="module")
+def singer_mentions(singner_rows: list[dict]) -> list[tuple[str, str]]:
+    mentions: list[tuple[str, str]] = []
+    for row in singner_rows:
+        text = row["text"]
+        for entity in row["entities"]:
+            if entity.get("label") != "SINGER":
+                continue
+            singer_name = text[entity["start"]:entity["end"]].strip()
+            if singer_name:
+                mentions.append((text, singer_name))
+
+    assert mentions, "No singer mentions extracted from dataset"
+    return mentions
+
+
+def _pick_unique_singers(mentions: list[tuple[str, str]], limit: int) -> list[str]:
+    seen: set[str] = set()
+    singers: list[str] = []
+
+    for _, singer in mentions:
+        if singer not in seen:
+            seen.add(singer)
+            singers.append(singer)
+        if len(singers) >= limit:
+            break
+
+    return singers
+
+
+def test_dataset_row_count_is_significant(singner_rows: list[dict]) -> None:
+    assert len(singner_rows) == 5000
+
+
+def test_singer_entities_match_in_original_text(singer_mentions: list[tuple[str, str]]) -> None:
+    sampled_mentions = singer_mentions[:1500]
+    matched = sum(1 for text, singer in sampled_mentions if check_exact_name(text, singer))
+    ratio = matched / len(sampled_mentions)
+
+    assert ratio >= 0.98, f"Unexpectedly low match ratio on dataset sample: {ratio:.3f}"
+
+
+def test_comprehensive_edge_cases_from_dataset(singer_mentions: list[tuple[str, str]]) -> None:
+    unique_singers = _pick_unique_singers(singer_mentions, limit=300)
+    assert len(unique_singers) >= 120
+
+    edge_cases: list[tuple[str, str, bool]] = []
+
+    # 1) Positive direct cases from dataset (40)
+    for text, singer in singer_mentions[:40]:
+        edge_cases.append((text, singer, True))
+
+    # 2) Positive with optional Hebrew vav-prefix (20)
+    vav_candidates = [s for s in unique_singers if not s.startswith("ו")]
+    for singer in vav_candidates[:20]:
+        edge_cases.append((f"שיר חי עם ו{singer}", singer, True))
+
+    # 3) Negative: prefix expansion should not match (20)
+    for singer in unique_singers[20:40]:
+        edge_cases.append((f"ל{singer} בהופעה", singer, False))
+
+    # 4) Negative: suffix expansion should not match (20)
+    for singer in unique_singers[40:60]:
+        edge_cases.append((f"{singer}ל בהופעה", singer, False))
+
+    # 5) Negative: text with no realistic artist mention (20)
+    for singer in unique_singers[60:80]:
+        edge_cases.append(("zzzzq xxyy 12345 ללא זמר מזוהה", singer, False))
+
+    assert len(edge_cases) >= 120
+
+    failed_cases = [
+        (filename, artist, expected)
+        for filename, artist, expected in edge_cases
+        if check_exact_name(filename, artist) is not expected
+    ]
+
+    assert not failed_cases, f"Found {len(failed_cases)} failing edge cases"
+
+
+def test_no_answer_when_artist_not_present(singer_mentions: list[tuple[str, str]]) -> None:
+    unique_singers = _pick_unique_singers(singer_mentions, limit=100)
+    text_without_singer = "גרסת בדיקה ללא התאמה כלל 987654321"
+
+    assert all(not check_exact_name(text_without_singer, singer) for singer in unique_singers)


### PR DESCRIPTION
### Motivation
- Improve confidence in the singer-name matching logic by validating it against a large, real-world labeled dataset.
- Make dataset-driven tests reproducible and runnable offline by saving a deterministic sample locally.
- Migrate existing `unittest`-style checks to a native `pytest` layout for easier parametrization and integration.

### Description
- Converted the legacy `unittest` test in `src/tests/test_check_name_similarity.py` to a parameterized `pytest` test using `@pytest.mark.parametrize` for clearer, pytest-native cases.
- Added a deterministic 5,000-row sample of `NHLOCAL/SingNER` at `src/tests/data/singner_sample_5000.jsonl` and a helper script `src/tests/data/download_singner_sample.py` to (re)download the same sample from the Hugging Face dataset.
- Introduced a new dataset-driven test module `src/tests/test_singner_dataset_matching.py` that loads the sample, extracts `SINGER` entities and runs comprehensive validations (direct matches, vav-prefix variants, prefix/suffix negatives, no-answer checks), assembling 120+ edge cases derived from the sample.
- Small hygiene edits to remove unused imports and random seed remnants so tests are deterministic and self-contained.

### Testing
- Confirmed the sample file contains exactly 5,000 rows with `wc -l src/tests/data/singner_sample_5000.jsonl`.
- Verified the Hugging Face dataset can be loaded and a sample written via `load_dataset('NHLOCAL/SingNER')` and the included `download_singner_sample.py` script.
- Ran the full test suite with `pytest -q` and observed all tests passing (17 passed).
- Installed `datasets` as part of validation and exercised the dataset loading flow used to generate the committed sample.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69913de54e58832d8e3de6a2e4a3e2e0)